### PR TITLE
add personal user profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 .env
 research.db
+PROFILE.md

--- a/PROFILE.md.example
+++ b/PROFILE.md.example
@@ -1,0 +1,13 @@
+# My Profile
+
+<!-- Edit this file to personalise all AI analysis. The bot reads it on every request, so changes take effect immediately without restarting. -->
+
+I am a software engineer with an interest in AI.
+
+<!-- Examples of useful things to include:
+- Your background and expertise level
+- Programming languages / tools you prefer
+- How much time you typically have for experiments
+- Topics you want to go deep on vs. get a quick overview of
+- Things you are already familiar with (so the bot doesn't over-explain)
+-->

--- a/README.md
+++ b/README.md
@@ -45,6 +45,13 @@ pip install -r requirements.txt
 
 ### Configuration
 
+Optionally set up a personal profile (see [Personalisation](#personalisation)):
+
+```bash
+cp PROFILE.md.example PROFILE.md
+# then edit PROFILE.md
+```
+
 Create a `.env` file:
 
 ```bash
@@ -88,6 +95,8 @@ Once the bot is running, use these commands inside the Telegram chat:
 | `/show <id>` | Show full analysis and metadata for an entry |
 | `/search <query>` | Search across source, content, and analysis |
 | `/delete <id>` | Remove an entry from the knowledge base |
+| `/profile` | Show your current profile |
+| `/profile <text>` | Update your profile with a one-liner |
 
 **Register commands with BotFather** (optional, enables autocomplete in Telegram):
 
@@ -100,6 +109,7 @@ list - Browse recent knowledge base entries
 show - /show <id>  Show full entry
 search - /search <query>  Search the knowledge base
 delete - /delete <id>  Remove an entry
+profile - Show or update your personal profile
 ```
 
 ### Knowledge Base CLI
@@ -121,6 +131,24 @@ Example list output:
    8  📄 document   2026-03-06T12:45   - NA -               report.pdf
 ```
 
+## Personalisation
+
+All analysis is tailored to you via `PROFILE.md` in the project root (gitignored — stays private). The bot reads it on every request, so edits take effect immediately without restarting. A starter template is provided as `PROFILE.md.example`.
+
+**Quick update from Telegram:**
+```
+/profile I'm a software engineer focused on AI and crypto. Suggest Python experiments under a day.
+```
+
+**Multi-line profile** — edit `PROFILE.md` directly in any text editor. Markdown comments (`<!-- … -->`) are stripped by the bot so you can annotate freely.
+
+**Check current profile:**
+```
+/profile
+```
+
+If `PROFILE.md` is absent or empty the bot falls back to a generic prompt, so personalisation is entirely optional.
+
 ## Project Structure
 
 ```
@@ -129,6 +157,7 @@ research-companion/
 ├── kb.py                # CLI knowledge base browser
 ├── requirements.txt     # Python dependencies
 ├── .env                 # Environment variables (not committed)
+├── PROFILE.md.example   # Profile template — copy to PROFILE.md and edit freely
 ├── research.db          # SQLite database (created at runtime, not committed)
 └── bot/
     ├── application.py   # Telegram app builder, registers handlers

--- a/bot/analyzer.py
+++ b/bot/analyzer.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -20,8 +21,10 @@ else:
     client = OpenAI(api_key=_OPENAI_KEY)
     _MODEL = "gpt-4o-mini"
 
-_PROMPT = """You are my personal AI research analyst.
+_PROFILE_PATH = Path(__file__).parent.parent / "PROFILE.md"
 
+_PROMPT = """You are my personal AI research analyst.
+{profile_block}
 Analyze the following content and return:
 
 Main idea:
@@ -34,8 +37,16 @@ CONTENT:
 {text}"""
 
 
+def _load_profile() -> str:
+    if _PROFILE_PATH.exists():
+        return _PROFILE_PATH.read_text(encoding="utf-8").strip()
+    return ""
+
+
 def analyze(text: str) -> str:
-    prompt = _PROMPT.format(text=text)
+    profile = _load_profile()
+    profile_block = f"\nAbout the person you are analysing for:\n{profile}\n" if profile else ""
+    prompt = _PROMPT.format(profile_block=profile_block, text=text)
     if _PROVIDER == "anthropic":
         resp = client.messages.create(
             model=_MODEL,

--- a/bot/application.py
+++ b/bot/application.py
@@ -1,6 +1,6 @@
 from telegram.ext import Application, CommandHandler, MessageHandler, filters
 
-from bot.commands import cmd_delete, cmd_list, cmd_search, cmd_show
+from bot.commands import cmd_delete, cmd_list, cmd_profile, cmd_search, cmd_show
 from bot.handlers import (
     handle_audio,
     handle_document,
@@ -19,6 +19,7 @@ def build_application(token: str) -> Application:
     app.add_handler(CommandHandler("show", cmd_show))
     app.add_handler(CommandHandler("search", cmd_search))
     app.add_handler(CommandHandler("delete", cmd_delete))
+    app.add_handler(CommandHandler("profile", cmd_profile))
 
     # Content ingestion
     app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handle_text))

--- a/bot/commands.py
+++ b/bot/commands.py
@@ -1,11 +1,14 @@
 import html
 import logging
+from pathlib import Path
 
 from telegram import Update
 from telegram.ext import ContextTypes
 
 from bot.db import get_all_items, get_item, search_items, delete_item
 from bot.formatting import format_analysis
+
+_PROFILE_PATH = Path(__file__).parent.parent / "PROFILE.md"
 
 logger = logging.getLogger(__name__)
 
@@ -100,6 +103,29 @@ async def cmd_search(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None
         lines.append(f"{icon} <code>#{r['id']}</code> <i>{date}</i>  {source}{snippet}")
 
     await update.message.reply_text("\n".join(lines), parse_mode="HTML")
+
+
+async def cmd_profile(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """/profile [text] — show or update your personal profile."""
+    if context.args:
+        text = " ".join(context.args)
+        _PROFILE_PATH.write_text(text, encoding="utf-8")
+        await update.message.reply_text("Profile updated.")
+        return
+
+    if not _PROFILE_PATH.exists():
+        await update.message.reply_text(
+            "No profile set yet. Use /profile <text> to set one, "
+            "or edit PROFILE.md directly for multi-line content."
+        )
+        return
+
+    content = _PROFILE_PATH.read_text(encoding="utf-8").strip()
+    if not content:
+        await update.message.reply_text("Profile file exists but is empty.")
+        return
+
+    await update.message.reply_text(f"<b>Your profile:</b>\n\n{html.escape(content)}", parse_mode="HTML")
 
 
 async def cmd_delete(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/bot/handlers.py
+++ b/bot/handlers.py
@@ -21,7 +21,12 @@ async def _analyze_and_reply(
     source: str = "",
     user_note: str = "",
 ) -> None:
-    analysis = analyze(text)
+    try:
+        analysis = analyze(text)
+    except Exception as e:
+        logger.exception("Analysis failed")
+        await update.message.reply_text(f"Analysis failed: {e}\n\nThe content was not saved.")
+        return
     save_item(
         source_type=source_type,
         source=source,
@@ -149,7 +154,12 @@ async def handle_photo(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         with open(path, "rb") as img:
             b64 = base64.b64encode(img.read()).decode()
         caption = update.message.caption or ""
-        text = analyze_image(b64, caption)
+        try:
+            text = analyze_image(b64, caption)
+        except Exception as e:
+            logger.exception("Image analysis failed")
+            await update.message.reply_text(f"Image analysis failed: {e}")
+            return
         await update.message.reply_text("Analyzing...")
         await _analyze_and_reply(
             update, text,


### PR DESCRIPTION
Context

 The LLM prompt in bot/analyzer.py is generic — "Suggested experiment" and similar sections produce suggestions that don't account for the user's background, skills, or preferences. The fix is to inject a personal
  profile into the system prompt so all analysis is tailored to the user.

 Approach

 1. PROFILE.md — project root

 A plain-text file the user writes once and edits freely. Loaded at analysis time (not import time) so edits take effect immediately without restarting the bot.

 Location: Path(__file__).parent.parent / "PROFILE.md" (same pattern as research.db in db.py).

 2. bot/analyzer.py — inject profile into prompt

 - Add _load_profile() that reads PROFILE.md if it exists, returns "" otherwise.
 - Update _PROMPT to include the profile block when present:

 You are a personal AI research analyst.

 About the person you are analysing for:
 {profile}

 Analyse the following content and return:
 ...

 If profile is empty, omit the "About…" block so the prompt degrades gracefully.

 3. bot/commands.py — /profile command

 - /profile (no args) → reply with current profile contents, or a message explaining how to set one.
 - /profile <text> → write " ".join(context.args) to PROFILE.md, confirm with a reply.

 For multi-line profiles the user edits the file directly; the bot command handles quick one-liner updates from the chat.

 4. bot/application.py — register command

 Add CommandHandler("profile", cmd_profile).

 5. README.md — document the feature

 Add a Personalisation section explaining PROFILE.md and /profile.

 6. BotFather command list update

 Add profile to the suggested /setcommands paste in the README.
