### PR TITLE
Align backend SPA with filter.fyi brand (CSS + font + green-dot mark)

### DIFF
--- a/bot/static/index.html
+++ b/bot/static/index.html
@@ -3,115 +3,139 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex">
 <title>filter.fyi</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
 <style>
   *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
   :root {
-    --bg:      #141414;
-    --surface: #1e1e1e;
-    --border:  #2e2e2e;
-    --text:    #d4d4d4;
-    --muted:   #6b6b6b;
-    --accent:  #7c6af7;
-    --accent2: #5b4fd6;
-    --danger:  #c0392b;
-    --green:   #27ae60;
-    --radius:  6px;
-    --font:    'Menlo', 'Consolas', 'Monaco', monospace;
+    --bg:         #efece4;
+    --bg-2:       #f7f4ec;
+    --ink:        #1c1c1a;
+    --ink-2:      #5e5e58;
+    --ink-3:      #9b9b91;
+    --green:      #1f7a3a;
+    --green-soft: #dfe8d6;
+    --amber:      #b8780a;
+    --red:        #a83a2a;
+    --red-soft:   #efd6d0;
+    --mono:       'JetBrains Mono','IBM Plex Mono',ui-monospace,SFMono-Regular,Menlo,monospace;
   }
 
-  body { background: var(--bg); color: var(--text); font-family: var(--font); font-size: 13px; line-height: 1.6; }
+  html, body { background: var(--bg); }
+  body {
+    color: var(--ink); font-family: var(--mono);
+    font-size: 14px; line-height: 1.6;
+    font-variant-numeric: tabular-nums;
+    -webkit-font-smoothing: antialiased;
+  }
+  ::selection { background: var(--ink); color: var(--bg-2); }
 
+  .dot { color: var(--green); }
+  .fyi { color: var(--ink-3); }
+
+  /* Login */
   #login {
     display: flex; align-items: center; justify-content: center;
-    min-height: 100vh; flex-direction: column; gap: 12px;
+    min-height: 100vh; flex-direction: column; gap: 14px;
   }
-  #login h1 { font-size: 18px; color: var(--accent); letter-spacing: 1px; }
-  #login p { color: var(--muted); font-size: 12px; }
+  #login h1 { font-size: 22px; font-weight: 700; letter-spacing: -0.02em; }
+  #login p { color: var(--ink-2); font-size: 12px; }
   #login input {
-    width: 320px; padding: 10px 14px; background: var(--surface);
-    border: 1px solid var(--border); color: var(--text); border-radius: var(--radius);
-    font-family: var(--font); font-size: 13px; outline: none;
+    width: 320px; padding: 12px 14px; background: var(--bg-2);
+    border: 1px solid var(--ink); color: var(--ink);
+    font-family: var(--mono); font-size: 13px; outline: none;
   }
-  #login input:focus { border-color: var(--accent); }
+  #login input:focus { background: var(--bg); }
 
+  /* Header */
   header {
     display: flex; align-items: center; gap: 20px;
-    padding: 12px 20px; border-bottom: 1px solid var(--border);
-    background: var(--surface); position: sticky; top: 0; z-index: 10;
+    padding: 14px 24px; border-bottom: 1px solid var(--ink);
+    background: var(--bg); position: sticky; top: 0; z-index: 10;
   }
-  header h1 { font-size: 14px; color: var(--accent); white-space: nowrap; }
+  header h1 { font-size: 15px; font-weight: 700; letter-spacing: -0.02em; white-space: nowrap; }
   nav { display: flex; gap: 4px; flex: 1; }
   nav button {
-    padding: 5px 14px; border: 1px solid transparent; border-radius: var(--radius);
-    background: none; color: var(--muted); font-family: var(--font); font-size: 12px;
+    padding: 6px 14px; border: 1px solid transparent;
+    background: none; color: var(--ink-2); font-family: var(--mono); font-size: 12px;
     cursor: pointer; transition: all 0.15s;
   }
-  nav button:hover { color: var(--text); }
-  nav button.active { background: var(--bg); border-color: var(--border); color: var(--accent); }
+  nav button:hover { color: var(--ink); }
+  nav button.active { background: var(--bg-2); border-color: var(--ink); color: var(--ink); font-weight: 600; }
   #logout-btn {
-    margin-left: auto; padding: 5px 12px; border: 1px solid var(--border);
-    border-radius: var(--radius); background: none; color: var(--muted);
-    font-family: var(--font); font-size: 11px; cursor: pointer;
+    margin-left: auto; padding: 6px 12px; border: 1px solid var(--ink-3);
+    background: none; color: var(--ink-2);
+    font-family: var(--mono); font-size: 11px; cursor: pointer;
   }
-  #logout-btn:hover { color: var(--danger); border-color: var(--danger); }
+  #logout-btn:hover { color: var(--red); border-color: var(--red); }
 
-  main { max-width: 780px; margin: 0 auto; padding: 28px 20px; }
+  main { max-width: 780px; margin: 0 auto; padding: 28px 24px 96px; }
 
   section { display: none; }
   section.active { display: block; }
 
-  h2 { font-size: 13px; color: var(--muted); text-transform: uppercase;
-       letter-spacing: 1px; margin-bottom: 16px; }
+  h2 {
+    font-size: 11px; color: var(--ink-2);
+    text-transform: uppercase; letter-spacing: 0.16em;
+    margin-bottom: 18px;
+  }
+  h2::before { content: '— '; color: var(--green); }
 
   /* Submit tab */
   .mode-tabs { display: flex; gap: 8px; margin-bottom: 16px; }
   .mode-tab {
-    padding: 4px 12px; border: 1px solid var(--border); border-radius: var(--radius);
-    background: none; color: var(--muted); font-family: var(--font); font-size: 12px;
-    cursor: pointer;
+    padding: 5px 12px; border: 1px solid var(--ink-3);
+    background: none; color: var(--ink-2); font-family: var(--mono); font-size: 12px;
+    cursor: pointer; transition: all 0.15s;
   }
-  .mode-tab.active { border-color: var(--accent); color: var(--accent); }
+  .mode-tab:hover { color: var(--ink); border-color: var(--ink); }
+  .mode-tab.active { background: var(--bg-2); border-color: var(--ink); color: var(--ink); font-weight: 600; }
 
   .submit-form { display: none; flex-direction: column; gap: 10px; }
   .submit-form.active { display: flex; }
 
   textarea, input[type=text], input[type=url] {
-    width: 100%; padding: 10px 14px; background: var(--surface);
-    border: 1px solid var(--border); color: var(--text); border-radius: var(--radius);
-    font-family: var(--font); font-size: 13px; resize: vertical; outline: none;
+    width: 100%; padding: 12px 14px; background: var(--bg-2);
+    border: 1px solid var(--ink); color: var(--ink);
+    font-family: var(--mono); font-size: 13px; resize: vertical; outline: none;
+    transition: background 0.15s;
   }
-  textarea:focus, input[type=text]:focus, input[type=url]:focus { border-color: var(--accent); }
+  textarea:focus, input[type=text]:focus, input[type=url]:focus { background: var(--bg); }
   textarea { min-height: 120px; }
 
   label.file-label {
-    display: flex; align-items: center; gap: 10px; padding: 10px 14px;
-    background: var(--surface); border: 1px dashed var(--border);
-    border-radius: var(--radius); cursor: pointer; color: var(--muted);
-    transition: border-color 0.15s;
+    display: flex; align-items: center; gap: 10px; padding: 14px;
+    background: var(--bg-2); border: 1px dashed var(--ink);
+    cursor: pointer; color: var(--ink-2);
+    transition: color 0.15s, background 0.15s;
   }
-  label.file-label:hover { border-color: var(--accent); color: var(--text); }
+  label.file-label:hover { color: var(--ink); background: var(--bg); }
   input[type=file] { display: none; }
-  .file-name { font-size: 12px; color: var(--text); }
+  .file-name { font-size: 12px; color: var(--ink); }
 
   .row { display: flex; gap: 10px; align-items: flex-start; }
   .row textarea, .row input { flex: 1; }
 
   .btn {
-    padding: 8px 20px; border: none; border-radius: var(--radius);
-    background: var(--accent); color: #fff; font-family: var(--font);
-    font-size: 13px; cursor: pointer; transition: background 0.15s; white-space: nowrap;
+    padding: 10px 20px; border: none;
+    background: var(--ink); color: var(--bg-2);
+    font-family: var(--mono); font-size: 12px; font-weight: 700; letter-spacing: 0.02em;
+    cursor: pointer; transition: background 0.15s; white-space: nowrap;
   }
-  .btn:hover { background: var(--accent2); }
+  .btn:hover { background: var(--green); }
+  .btn:active { transform: translateY(1px); }
   .btn:disabled { opacity: 0.5; cursor: not-allowed; }
-  .btn-danger { background: var(--danger); }
-  .btn-danger:hover { background: #a93226; }
-  .btn-sm { padding: 4px 10px; font-size: 11px; }
+  .btn-danger { background: var(--red); }
+  .btn-danger:hover { background: #7a2a1f; }
+  .btn-sm { padding: 5px 10px; font-size: 11px; }
 
   #result {
-    margin-top: 20px; padding: 16px; background: var(--surface);
-    border: 1px solid var(--border); border-radius: var(--radius);
+    margin-top: 20px; padding: 16px;
+    background: var(--bg-2); border: 1px solid var(--ink);
     white-space: pre-wrap; font-size: 12px; display: none;
   }
   #result.visible { display: block; }
@@ -123,24 +147,24 @@
   #items-list { display: flex; flex-direction: column; gap: 8px; }
 
   .item-card {
-    padding: 12px 14px; background: var(--surface);
-    border: 1px solid var(--border); border-radius: var(--radius); cursor: pointer;
-    transition: border-color 0.15s;
+    padding: 12px 14px;
+    background: var(--bg-2); border: 1px solid var(--ink);
+    cursor: pointer; transition: background 0.15s;
   }
-  .item-card:hover { border-color: var(--accent); }
-  .item-card.expanded { border-color: var(--accent); }
+  .item-card:hover { background: var(--bg); }
+  .item-card.expanded { background: var(--bg); }
   .item-header { display: flex; gap: 10px; align-items: baseline; }
-  .item-id { color: var(--muted); font-size: 11px; min-width: 36px; }
-  .item-type { color: var(--accent); font-size: 11px; min-width: 70px; }
-  .item-date { color: var(--muted); font-size: 11px; min-width: 80px; }
-  .item-source { color: var(--text); font-size: 12px; flex: 1;
+  .item-id { color: var(--ink-3); font-size: 11px; min-width: 36px; }
+  .item-type { color: var(--green); font-size: 11px; min-width: 70px; font-weight: 600; }
+  .item-date { color: var(--ink-3); font-size: 11px; min-width: 80px; }
+  .item-source { color: var(--ink); font-size: 12px; flex: 1;
                   overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   .item-body { display: none; margin-top: 12px; padding-top: 12px;
-               border-top: 1px solid var(--border); font-size: 12px; }
+               border-top: 1px dotted var(--ink); font-size: 12px; }
   .item-card.expanded .item-body { display: block; }
-  .item-analysis { white-space: pre-wrap; color: var(--text); }
+  .item-analysis { white-space: pre-wrap; color: var(--ink); }
   .item-actions { margin-top: 10px; display: flex; gap: 8px; }
-  #items-empty { color: var(--muted); font-size: 12px; padding: 20px 0; }
+  #items-empty { color: var(--ink-2); font-size: 12px; padding: 20px 0; }
 
   /* Profile tab */
   #profile-form { display: flex; flex-direction: column; gap: 10px; }
@@ -148,24 +172,24 @@
   #profile-status { font-size: 12px; color: var(--green); display: none; }
 
   /* Status / spinner */
-  .status { font-size: 12px; color: var(--muted); margin-top: 8px; }
-  .error { color: #e74c3c; }
+  .status { font-size: 12px; color: var(--ink-2); margin-top: 8px; }
+  .error { color: var(--red); }
 
   .spinner {
     display: inline-block; width: 12px; height: 12px; margin-right: 6px;
-    border: 2px solid var(--border); border-top-color: var(--accent);
+    border: 2px solid var(--ink-3); border-top-color: var(--green);
     border-radius: 50%; animation: spin 0.7s linear infinite; vertical-align: middle;
   }
   @keyframes spin { to { transform: rotate(360deg); } }
 
-  .note-hint { font-size: 11px; color: var(--muted); }
+  .note-hint { font-size: 11px; color: var(--ink-3); }
 </style>
 </head>
 <body>
 
 <!-- ── Login ─────────────────────────────────────────────────── -->
 <div id="login">
-  <h1>⬡ filter.fyi</h1>
+  <h1><span class="dot">●</span> filter<span class="fyi">.fyi</span></h1>
   <p>Enter your API token to continue</p>
   <input id="token-input" type="password" placeholder="paste your token here" autocomplete="off">
   <button class="btn" onclick="doLogin()">Sign in</button>
@@ -175,7 +199,7 @@
 <!-- ── App ───────────────────────────────────────────────────── -->
 <div id="app" style="display:none">
   <header>
-    <h1>⬡ filter.fyi</h1>
+    <h1><span class="dot">●</span> filter<span class="fyi">.fyi</span></h1>
     <nav>
       <button class="active" data-tab="submit">Submit</button>
       <button data-tab="browse">Browse</button>


### PR DESCRIPTION
## Summary

Brings the token-auth admin SPA at `/` into line with the marketing site's visual brand. The DOM and JS are unchanged — every class name and id matches the previous version, so login / submit / browse / profile flows behave identically. The diff is essentially the `<style>` block plus the two `⬡ filter.fyi` → `● filter.fyi` h1s, plus a `noindex` meta and the JetBrains Mono font link.

## What changes visually

| Before | After |
|---|---|
| `#141414` dark background | `#efece4` cream background (matches filter.fyi/) |
| Menlo / Consolas / Monaco | JetBrains Mono via Google Fonts |
| `#7c6af7` purple accent | `#1f7a3a` brand green |
| `⬡` hex symbol | `●` green dot before "filter.fyi" |
| Rounded 6px corners everywhere | Flat square edges (matches landing card style) |
| Purple buttons | Ink-on-cream buttons, hover-green (matches landing CTA) |
| h2 like a Slack channel title | Eyebrow style — uppercase, letter-spaced, em-dash prefix |

## Why not a deeper redesign

The DOM was kept verbatim so this PR stays small and review-able. If you want to revisit the SPA's interaction model (e.g. richer cards on browse, an inline result panel instead of `<pre>`-formatted output, etc.), that's a separate piece of work. This is just the colour/font/mark unification.

## How to preview

The Fly auto-deploy only fires on push to `main`, so there's no per-branch preview URL. Two options:

```bash
git checkout design-align-spa
make dev
open http://localhost:8080/
```

…or just merge and watch the new look go live alongside the auto-deploy.

## Test plan

- [ ] Login screen renders cleanly; pasting a valid token logs you in
- [ ] Header `● filter.fyi` displays with green dot, ink text, ink-3 `.fyi`
- [ ] Submit tab — text / URL / file modes switch + submit successfully
- [ ] Browse tab — items render with green-bold type label, expand on click
- [ ] Profile tab — saves and shows the green "Saved ✓" message
- [ ] Logout returns to login screen
- [ ] No console errors, no broken layouts at narrow widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)