### PR TITLE
Unify identity: rebuild profiles as users table

### DIFF
--- a/bot/analyzer.py
+++ b/bot/analyzer.py
@@ -81,6 +81,20 @@ _ANTHROPIC_TOOL = {
     "input_schema": _TOOL_SCHEMA,
 }
 
+# Fallback profile used when no real one is available: the anonymous /api/try
+# path, or a signed-in user who hasn't set their own profile yet. Mirrors the
+# landing-page positioning ("For everyone trying to keep up with AI") so the
+# LLM always has a real audience to be specific about.
+DEFAULT_PROFILE = (
+    "The reader is someone trying to keep up with AI — a developer, researcher, "
+    "founder, or technical practitioner who wants signal, not noise. They value: "
+    "practical relevance to AI/tech work, an honest time-to-value assessment, and "
+    "clear \"watch / skim / skip\" verdicts. They're skeptical of hype, allergic "
+    "to generic news takes, and engage best with concrete patterns, benchmarks, "
+    "and architecture."
+)
+
+
 _PROMPT = """You are my personal AI research analyst.
 {profile_block}
 Analyze the following content and produce a structured analysis covering the required fields. Be concrete and specific to this person.
@@ -97,9 +111,11 @@ _OPENAI_JSON_SUFFIX = (
 )
 
 
-def _load_profile(user_id: str) -> str:
-    from bot.db import get_profile
-    return get_profile(user_id)
+def _load_profile(user_id: int | None) -> str:
+    if user_id is None:
+        return DEFAULT_PROFILE
+    from bot.db import get_user_profile
+    return get_user_profile(user_id) or DEFAULT_PROFILE
 
 
 def _normalize(raw: dict) -> dict:
@@ -112,7 +128,7 @@ def _normalize(raw: dict) -> dict:
     return out
 
 
-def analyze(text: str, user_id: str) -> dict:
+def analyze(text: str, user_id: int | None = None) -> dict:
     """Returns a dict with keys: main_idea, why_it_matters, category, suggested_experiment, time_required, verdict."""
     profile = _load_profile(user_id)
     profile_block = f"\nAbout the person you are analysing for:\n{profile}\n" if profile else ""

--- a/bot/api.py
+++ b/bot/api.py
@@ -18,10 +18,10 @@ from bot.db import (
     delete_item,
     get_all_items,
     get_item,
-    get_profile,
+    get_user_profile,
     save_item,
     search_items,
-    set_profile,
+    set_user_profile,
 )
 from bot.fetcher import fetch_url
 from bot.storage import full_path, save_file
@@ -47,13 +47,13 @@ _VIDEO_SOURCE_TYPES = {"youtube", "video"}
 # ---------------------------------------------------------------------------
 
 @router.get("/items")
-async def list_items(q: str | None = None, user_id: str = Depends(require_token)):
+async def list_items(q: str | None = None, user_id: int = Depends(require_token)):
     rows = search_items(q, user_id) if q else get_all_items(user_id)
     return [dict(r) for r in rows]
 
 
 @router.get("/items/{item_id}")
-async def show_item(item_id: int, user_id: str = Depends(require_token)):
+async def show_item(item_id: int, user_id: int = Depends(require_token)):
     row = get_item(item_id, user_id)
     if not row:
         raise HTTPException(status_code=404, detail="Not found")
@@ -61,14 +61,14 @@ async def show_item(item_id: int, user_id: str = Depends(require_token)):
 
 
 @router.delete("/items/{item_id}", status_code=204)
-async def remove_item(item_id: int, user_id: str = Depends(require_token)):
+async def remove_item(item_id: int, user_id: int = Depends(require_token)):
     if not get_item(item_id, user_id):
         raise HTTPException(status_code=404, detail="Not found")
     delete_item(item_id, user_id)
 
 
 @router.get("/items/{item_id}/file")
-async def download_file(item_id: int, user_id: str = Depends(require_token)):
+async def download_file(item_id: int, user_id: int = Depends(require_token)):
     row = get_item(item_id, user_id)
     if not row or not row["file_path"]:
         raise HTTPException(status_code=404, detail="No file stored for this item")
@@ -86,7 +86,7 @@ async def download_file(item_id: int, user_id: str = Depends(require_token)):
 async def submit_text(
     text: str = Form(...),
     user_note: str = Form(""),
-    user_id: str = Depends(require_token),
+    user_id: int = Depends(require_token),
 ):
     analysis = analyze(text, user_id)
     save_item(user_id, "note", "", text, to_json_str(analysis), user_note)
@@ -97,7 +97,7 @@ async def submit_text(
 async def submit_url(
     url: str = Form(...),
     user_note: str = Form(""),
-    user_id: str = Depends(require_token),
+    user_id: int = Depends(require_token),
 ):
     fetched = await fetch_url(url)
     if not fetched["text"].strip():
@@ -111,7 +111,7 @@ async def submit_url(
 async def submit_file(
     file: UploadFile = File(...),
     user_note: str = Form(""),
-    user_id: str = Depends(require_token),
+    user_id: int = Depends(require_token),
 ):
     mime = file.content_type or ""
     name = file.filename or "file"
@@ -160,16 +160,16 @@ async def submit_file(
 # ---------------------------------------------------------------------------
 
 @router.get("/profile")
-async def get_profile_endpoint(user_id: str = Depends(require_token)):
-    return {"content": get_profile(user_id)}
+async def get_profile_endpoint(user_id: int = Depends(require_token)):
+    return {"content": get_user_profile(user_id)}
 
 
 @router.put("/profile", status_code=200)
 async def set_profile_endpoint(
     content: str = Form(...),
-    user_id: str = Depends(require_token),
+    user_id: int = Depends(require_token),
 ):
-    set_profile(user_id, content)
+    set_user_profile(user_id, content)
     return {"ok": True}
 
 
@@ -227,7 +227,7 @@ async def try_url(req: TryRequest, _: None = Depends(_require_try_secret)):
         raise HTTPException(status_code=422, detail={"error": "extraction-failed"})
 
     try:
-        analysis = analyze(text, user_id="")
+        analysis = analyze(text, user_id=None)
     except Exception as e:
         logger.exception("analyze crashed for %s: %s", url, e)
         raise HTTPException(status_code=502, detail={"error": "analyze-failed"})

--- a/bot/auth.py
+++ b/bot/auth.py
@@ -2,25 +2,25 @@ import secrets
 
 from fastapi import Header, HTTPException, status
 
-from bot.db import get_profile_by_token
+from bot.db import get_user_by_token
 
 
 def generate_token() -> str:
     return secrets.token_urlsafe(32)
 
 
-async def require_token(authorization: str = Header(...)) -> str:
-    """FastAPI dependency — validates Bearer token, returns user_id."""
+async def require_token(authorization: str = Header(...)) -> int:
+    """FastAPI dependency — validates Bearer token, returns canonical users.id."""
     scheme, _, token = authorization.partition(" ")
     if scheme.lower() != "bearer" or not token:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Missing or malformed Authorization header",
         )
-    row = get_profile_by_token(token)
+    row = get_user_by_token(token)
     if not row:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid token",
         )
-    return row["user_id"]
+    return row["id"]

--- a/bot/commands.py
+++ b/bot/commands.py
@@ -4,7 +4,16 @@ import logging
 from telegram import Update
 from telegram.ext import ContextTypes
 
-from bot.db import get_all_items, get_item, search_items, delete_item, get_profile, set_profile, set_profile_field
+from bot.db import (
+    delete_item,
+    get_all_items,
+    get_item,
+    get_or_create_user_by_telegram,
+    get_user_profile,
+    search_items,
+    set_user_field,
+    set_user_profile,
+)
 from bot.formatting import format_analysis
 
 logger = logging.getLogger(__name__)
@@ -34,7 +43,7 @@ async def cmd_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 
 async def cmd_list(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """/list — show the most recent knowledge base entries."""
-    user_id = str(update.effective_user.id)
+    user_id = get_or_create_user_by_telegram(update.effective_user.id)
     rows = get_all_items(user_id)
     if not rows:
         await update.message.reply_text("Knowledge base is empty.")
@@ -53,7 +62,7 @@ async def cmd_list(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 
 async def cmd_show(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """/show <id> — show full analysis and source for an entry."""
-    user_id = str(update.effective_user.id)
+    user_id = get_or_create_user_by_telegram(update.effective_user.id)
     args = context.args
     if not args or not args[0].isdigit():
         await update.message.reply_text("Usage: /show &lt;id&gt;", parse_mode="HTML")
@@ -86,7 +95,7 @@ async def cmd_show(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 
 async def cmd_search(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """/search <query> — search source, content, and analysis."""
-    user_id = str(update.effective_user.id)
+    user_id = get_or_create_user_by_telegram(update.effective_user.id)
     if not context.args:
         await update.message.reply_text("Usage: /search &lt;query&gt;", parse_mode="HTML")
         return
@@ -122,18 +131,18 @@ async def cmd_search(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None
 
 async def cmd_profile(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """/profile [text] — show or update your personal profile."""
-    user_id = str(update.effective_user.id)
+    user_id = get_or_create_user_by_telegram(update.effective_user.id)
     message = update.effective_message
     if not message:
         return
 
     if context.args:
         text = " ".join(context.args)
-        set_profile(user_id, text)
+        set_user_profile(user_id, text)
         await message.reply_text("Profile updated.")
         return
 
-    content = get_profile(user_id)
+    content = get_user_profile(user_id)
     if not content:
         await message.reply_text(
             "No profile set yet. Use /profile <your background> to set one.\n\n"
@@ -146,10 +155,10 @@ async def cmd_profile(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
 
 async def cmd_token(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """/token — (re)generate your web UI API token."""
-    user_id = str(update.effective_user.id)
+    user_id = get_or_create_user_by_telegram(update.effective_user.id)
     from bot.auth import generate_token
     token = generate_token()
-    set_profile_field(user_id, api_token=token)
+    set_user_field(user_id, api_token=token)
     await update.message.reply_text(
         "Your API token (keep this secret — generating a new one invalidates the old one):\n\n"
         f"<code>{token}</code>\n\n"
@@ -160,7 +169,7 @@ async def cmd_token(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 
 async def cmd_delete(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """/delete <id> — remove an entry from the knowledge base."""
-    user_id = str(update.effective_user.id)
+    user_id = get_or_create_user_by_telegram(update.effective_user.id)
     args = context.args
     if not args or not args[0].isdigit():
         await update.message.reply_text("Usage: /delete &lt;id&gt;", parse_mode="HTML")

--- a/bot/daily_report.py
+++ b/bot/daily_report.py
@@ -2,7 +2,7 @@ from bot.analyzer import parse_stored, to_plain_text
 from bot.db import get_all_items
 
 
-def generate_brief(user_id: str | None = None) -> str:
+def generate_brief(user_id: int | None = None) -> str:
     items = get_all_items(user_id)
     report = "Daily Research Brief\n\n"
     for item in items[-5:]:

--- a/bot/db.py
+++ b/bot/db.py
@@ -8,26 +8,39 @@ _DATA_DIR = Path(os.getenv("DATA_DIR") or (Path(__file__).parent.parent))
 _DATA_DIR.mkdir(parents=True, exist_ok=True)
 DB_PATH = _DATA_DIR / "research.db"
 
+
+# Canonical identity. One row per person; both web (email) and Telegram
+# (telegram_chat_id) faces hang off the same `id`. `profile` is the
+# perspective text fed to the analyzer ("about this person"). When a user
+# eventually has multiple profiles, this column moves to a separate
+# `profiles` table (id, user_id, name, content) with one row per profile.
+_CREATE_USERS_SQL = """\
+CREATE TABLE IF NOT EXISTS users (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    telegram_chat_id INTEGER UNIQUE,
+    email            TEXT UNIQUE,
+    api_token        TEXT UNIQUE,
+    profile          TEXT NOT NULL DEFAULT '',
+    created_at       TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%S', 'now'))
+)"""
+
 _CREATE_ITEMS_SQL = """\
 CREATE TABLE IF NOT EXISTS items (
     id          INTEGER PRIMARY KEY AUTOINCREMENT,
-    user_id     TEXT NOT NULL DEFAULT '',
+    user_id     INTEGER NOT NULL,
     source_type TEXT NOT NULL DEFAULT 'unknown',
     source      TEXT NOT NULL DEFAULT '',
     content     TEXT NOT NULL DEFAULT '',
     analysis    TEXT NOT NULL DEFAULT '',
     user_note   TEXT NOT NULL DEFAULT '',
     file_path   TEXT NOT NULL DEFAULT '',
-    created_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%S', 'now'))
+    created_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%S', 'now')),
+    FOREIGN KEY (user_id) REFERENCES users(id)
 )"""
 
-_CREATE_PROFILES_SQL = """\
-CREATE TABLE IF NOT EXISTS profiles (
-    user_id   TEXT PRIMARY KEY,
-    content   TEXT NOT NULL DEFAULT '',
-    email     TEXT UNIQUE,
-    api_token TEXT UNIQUE
-)"""
+_CREATE_INDEXES_SQL = [
+    "CREATE INDEX IF NOT EXISTS idx_items_user ON items(user_id, created_at DESC)",
+]
 
 
 def _get_conn() -> sqlite3.Connection:
@@ -36,62 +49,161 @@ def _get_conn() -> sqlite3.Connection:
     return conn
 
 
-def _init():
+def _has_table(conn: sqlite3.Connection, name: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (name,)
+    ).fetchone()
+    return row is not None
+
+
+def _migrate_from_profiles(conn: sqlite3.Connection) -> None:
+    """One-time migration: profiles + items(user_id TEXT) -> users + items(user_id INT).
+
+    - Telegram users (numeric profiles.user_id) move to users.telegram_chat_id.
+    - `web:<email>` rows are dropped — that codepath was never reached in prod.
+    - Items whose user_id can't be mapped are dropped — they predate multi-user
+      (NOT NULL DEFAULT '' rows) and have no owner in the new model.
+    """
+    conn.execute(_CREATE_USERS_SQL)
+
+    id_map: dict[str, int] = {}
+    old_profiles = conn.execute(
+        "SELECT user_id, content, email, api_token FROM profiles"
+    ).fetchall()
+    for r in old_profiles:
+        old_id = (r["user_id"] or "").strip()
+        if not old_id.isdigit():
+            continue  # skip web:<email> + any other non-Telegram rows
+        cur = conn.execute(
+            "INSERT INTO users (telegram_chat_id, email, api_token, profile) "
+            "VALUES (?, ?, ?, ?)",
+            (int(old_id), r["email"], r["api_token"], r["content"] or ""),
+        )
+        id_map[old_id] = cur.lastrowid
+
+    conn.execute("ALTER TABLE items RENAME TO _items_old")
+    conn.execute(_CREATE_ITEMS_SQL)
+
+    old_items = conn.execute(
+        "SELECT id, user_id, source_type, source, content, analysis, "
+        "user_note, file_path, created_at FROM _items_old"
+    ).fetchall()
+    for r in old_items:
+        new_uid = id_map.get((r["user_id"] or "").strip())
+        if new_uid is None:
+            continue
+        conn.execute(
+            "INSERT INTO items (id, user_id, source_type, source, content, "
+            "analysis, user_note, file_path, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                r["id"], new_uid, r["source_type"], r["source"], r["content"],
+                r["analysis"], r["user_note"], r["file_path"], r["created_at"],
+            ),
+        )
+
+    conn.execute("DROP TABLE _items_old")
+    conn.execute("DROP TABLE profiles")
+
+
+def _init() -> None:
     with _get_conn() as conn:
-        info = conn.execute("PRAGMA table_info(items)").fetchall()
-        cols = {row["name"] for row in info}
-
-        if not cols:
+        if _has_table(conn, "users"):
+            # Already on the new schema; ensure tables/indexes exist (idempotent).
+            conn.execute(_CREATE_USERS_SQL)
             conn.execute(_CREATE_ITEMS_SQL)
-            conn.execute(_CREATE_PROFILES_SQL)
-            return
-
-        if "source_type" not in cols:
-            # Migrate from very old schema (id, url, analysis, maybe created_at)
-            has_created_at = "created_at" in cols
-            conn.execute("ALTER TABLE items RENAME TO _items_old")
+        elif _has_table(conn, "profiles"):
+            _migrate_from_profiles(conn)
+        else:
+            conn.execute(_CREATE_USERS_SQL)
             conn.execute(_CREATE_ITEMS_SQL)
-            ts_col = (
-                "COALESCE(created_at, strftime('%Y-%m-%dT%H:%M:%S', 'now'))"
-                if has_created_at
-                else "strftime('%Y-%m-%dT%H:%M:%S', 'now')"
-            )
-            conn.execute(
-                f"INSERT INTO items (id, source, analysis, created_at) "
-                f"SELECT id, COALESCE(url, ''), COALESCE(analysis, ''), {ts_col} "
-                f"FROM _items_old"
-            )
-            conn.execute("DROP TABLE _items_old")
-            # Re-fetch cols after migration
-            info = conn.execute("PRAGMA table_info(items)").fetchall()
-            cols = {row["name"] for row in info}
-
-        # Add user_id column if missing (migration from single-user schema)
-        if "user_id" not in cols:
-            conn.execute("ALTER TABLE items ADD COLUMN user_id TEXT NOT NULL DEFAULT ''")
-
-        # Add file_path column if missing
-        if "file_path" not in cols:
-            conn.execute("ALTER TABLE items ADD COLUMN file_path TEXT NOT NULL DEFAULT ''")
-
-        conn.execute(_CREATE_PROFILES_SQL)
-
-        # Migrate profiles table: add email + api_token if missing
-        profile_info = conn.execute("PRAGMA table_info(profiles)").fetchall()
-        profile_cols = {row["name"] for row in profile_info}
-        if "email" not in profile_cols:
-            conn.execute("ALTER TABLE profiles ADD COLUMN email TEXT")
-            conn.execute("CREATE UNIQUE INDEX IF NOT EXISTS idx_profiles_email ON profiles(email)")
-        if "api_token" not in profile_cols:
-            conn.execute("ALTER TABLE profiles ADD COLUMN api_token TEXT")
-            conn.execute("CREATE UNIQUE INDEX IF NOT EXISTS idx_profiles_api_token ON profiles(api_token)")
+        for stmt in _CREATE_INDEXES_SQL:
+            conn.execute(stmt)
 
 
 _init()
 
 
+# ---------------------------------------------------------------------------
+# Users
+# ---------------------------------------------------------------------------
+
+def get_or_create_user_by_telegram(telegram_chat_id: int) -> int:
+    """Return the canonical users.id for a Telegram chat. Creates a row if missing."""
+    with _get_conn() as conn:
+        row = conn.execute(
+            "SELECT id FROM users WHERE telegram_chat_id = ?", (telegram_chat_id,)
+        ).fetchone()
+        if row:
+            return row["id"]
+        cur = conn.execute(
+            "INSERT INTO users (telegram_chat_id) VALUES (?)", (telegram_chat_id,)
+        )
+        return cur.lastrowid
+
+
+def upsert_user_by_email(email: str) -> int:
+    """Get or create a user keyed by email (used by the magic-link flow)."""
+    email = email.lower().strip()
+    with _get_conn() as conn:
+        row = conn.execute(
+            "SELECT id FROM users WHERE email = ?", (email,)
+        ).fetchone()
+        if row:
+            return row["id"]
+        cur = conn.execute("INSERT INTO users (email) VALUES (?)", (email,))
+        return cur.lastrowid
+
+
+def get_user(user_id: int) -> sqlite3.Row | None:
+    with _get_conn() as conn:
+        return conn.execute(
+            "SELECT id, telegram_chat_id, email, api_token, profile, created_at "
+            "FROM users WHERE id = ?",
+            (user_id,),
+        ).fetchone()
+
+
+def get_user_by_token(token: str) -> sqlite3.Row | None:
+    with _get_conn() as conn:
+        return conn.execute(
+            "SELECT id, telegram_chat_id, email, api_token, profile, created_at "
+            "FROM users WHERE api_token = ?",
+            (token,),
+        ).fetchone()
+
+
+def get_user_profile(user_id: int) -> str:
+    """The user's profile text — perspective fed to the analyzer."""
+    row = get_user(user_id)
+    return row["profile"] if row else ""
+
+
+def set_user_profile(user_id: int, profile: str) -> None:
+    with _get_conn() as conn:
+        conn.execute(
+            "UPDATE users SET profile = ? WHERE id = ?", (profile, user_id)
+        )
+
+
+def set_user_field(user_id: int, **fields) -> None:
+    """Update arbitrary user columns (email, api_token, profile)."""
+    if not fields:
+        return
+    set_clause = ", ".join(f"{k} = ?" for k in fields)
+    with _get_conn() as conn:
+        conn.execute(
+            f"UPDATE users SET {set_clause} WHERE id = ?",
+            list(fields.values()) + [user_id],
+        )
+
+
+# ---------------------------------------------------------------------------
+# Items
+# ---------------------------------------------------------------------------
+
 def save_item(
-    user_id: str,
+    user_id: int,
     source_type: str,
     source: str,
     content: str,
@@ -102,138 +214,65 @@ def save_item(
 ) -> None:
     with _get_conn() as conn:
         conn.execute(
-            "INSERT INTO items (user_id, source_type, source, content, analysis, user_note, file_path) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            "INSERT INTO items (user_id, source_type, source, content, "
+            "analysis, user_note, file_path) VALUES (?, ?, ?, ?, ?, ?, ?)",
             (user_id, source_type, source, content, analysis, user_note, file_path),
         )
 
 
-def get_all_items(user_id: str | None = None) -> list[sqlite3.Row]:
+_ITEM_COLS = (
+    "id, user_id, source_type, source, content, analysis, user_note, file_path, created_at"
+)
+
+
+def get_all_items(user_id: int | None = None) -> list[sqlite3.Row]:
     with _get_conn() as conn:
         if user_id is not None:
             return conn.execute(
-                "SELECT id, user_id, source_type, source, content, analysis, user_note, file_path, created_at "
-                "FROM items WHERE user_id = ? ORDER BY id DESC",
+                f"SELECT {_ITEM_COLS} FROM items WHERE user_id = ? ORDER BY id DESC",
                 (user_id,),
             ).fetchall()
         return conn.execute(
-            "SELECT id, user_id, source_type, source, content, analysis, user_note, file_path, created_at "
-            "FROM items ORDER BY id DESC"
+            f"SELECT {_ITEM_COLS} FROM items ORDER BY id DESC"
         ).fetchall()
 
 
-def get_item(item_id: int, user_id: str | None = None) -> sqlite3.Row | None:
+def get_item(item_id: int, user_id: int | None = None) -> sqlite3.Row | None:
     with _get_conn() as conn:
         if user_id is not None:
             return conn.execute(
-                "SELECT id, user_id, source_type, source, content, analysis, user_note, file_path, created_at "
-                "FROM items WHERE id = ? AND user_id = ?",
+                f"SELECT {_ITEM_COLS} FROM items WHERE id = ? AND user_id = ?",
                 (item_id, user_id),
             ).fetchone()
         return conn.execute(
-            "SELECT id, user_id, source_type, source, content, analysis, user_note, file_path, created_at "
-            "FROM items WHERE id = ?",
-            (item_id,),
+            f"SELECT {_ITEM_COLS} FROM items WHERE id = ?", (item_id,)
         ).fetchone()
 
 
-def search_items(query: str, user_id: str | None = None) -> list[sqlite3.Row]:
+def search_items(query: str, user_id: int | None = None) -> list[sqlite3.Row]:
     pattern = f"%{query}%"
     with _get_conn() as conn:
         if user_id is not None:
             return conn.execute(
-                "SELECT id, user_id, source_type, source, content, analysis, user_note, file_path, created_at "
-                "FROM items "
-                "WHERE user_id = ? AND (source LIKE ? OR content LIKE ? OR analysis LIKE ? OR user_note LIKE ?) "
-                "ORDER BY id DESC",
+                f"SELECT {_ITEM_COLS} FROM items "
+                "WHERE user_id = ? AND (source LIKE ? OR content LIKE ? "
+                "OR analysis LIKE ? OR user_note LIKE ?) ORDER BY id DESC",
                 (user_id, pattern, pattern, pattern, pattern),
             ).fetchall()
         return conn.execute(
-            "SELECT id, user_id, source_type, source, content, analysis, user_note, file_path, created_at "
-            "FROM items "
-            "WHERE source LIKE ? OR content LIKE ? OR analysis LIKE ? OR user_note LIKE ? "
-            "ORDER BY id DESC",
+            f"SELECT {_ITEM_COLS} FROM items "
+            "WHERE source LIKE ? OR content LIKE ? OR analysis LIKE ? "
+            "OR user_note LIKE ? ORDER BY id DESC",
             (pattern, pattern, pattern, pattern),
         ).fetchall()
 
 
-def delete_item(item_id: int, user_id: str | None = None) -> None:
+def delete_item(item_id: int, user_id: int | None = None) -> None:
     with _get_conn() as conn:
         if user_id is not None:
-            conn.execute("DELETE FROM items WHERE id = ? AND user_id = ?", (item_id, user_id))
+            conn.execute(
+                "DELETE FROM items WHERE id = ? AND user_id = ?",
+                (item_id, user_id),
+            )
         else:
             conn.execute("DELETE FROM items WHERE id = ?", (item_id,))
-
-
-def get_profile(user_id: str) -> str:
-    with _get_conn() as conn:
-        row = conn.execute(
-            "SELECT content FROM profiles WHERE user_id = ?", (user_id,)
-        ).fetchone()
-        return row["content"] if row else ""
-
-
-def set_profile(user_id: str, content: str) -> None:
-    with _get_conn() as conn:
-        conn.execute(
-            "INSERT INTO profiles (user_id, content) VALUES (?, ?) "
-            "ON CONFLICT(user_id) DO UPDATE SET content = excluded.content",
-            (user_id, content),
-        )
-
-
-def set_profile_field(user_id: str, **fields) -> None:
-    """Upsert arbitrary profile columns (e.g. email, api_token)."""
-    if not fields:
-        return
-    set_clause = ", ".join(f"{k} = excluded.{k}" for k in fields)
-    col_names = ", ".join(fields.keys())
-    placeholders = ", ".join("?" for _ in fields)
-    values = list(fields.values())
-    with _get_conn() as conn:
-        conn.execute(
-            f"INSERT INTO profiles (user_id, {col_names}) VALUES (?, {placeholders}) "
-            f"ON CONFLICT(user_id) DO UPDATE SET {set_clause}",
-            [user_id] + values,
-        )
-
-
-def get_profile_row(user_id: str) -> sqlite3.Row | None:
-    with _get_conn() as conn:
-        return conn.execute(
-            "SELECT user_id, content, email, api_token FROM profiles WHERE user_id = ?",
-            (user_id,),
-        ).fetchone()
-
-
-def get_profile_by_token(token: str) -> sqlite3.Row | None:
-    with _get_conn() as conn:
-        return conn.execute(
-            "SELECT user_id, content, email, api_token FROM profiles WHERE api_token = ?",
-            (token,),
-        ).fetchone()
-
-
-def get_profile_by_email(email: str) -> sqlite3.Row | None:
-    with _get_conn() as conn:
-        return conn.execute(
-            "SELECT user_id, content, email, api_token FROM profiles WHERE email = ?",
-            (email.lower().strip(),),
-        ).fetchone()
-
-
-def create_web_user(email: str, api_token: str) -> str:
-    """Create a web-only user. Returns user_id. Raises ValueError if email exists."""
-    email = email.lower().strip()
-    user_id = f"web:{email}"
-    with _get_conn() as conn:
-        existing = conn.execute(
-            "SELECT user_id FROM profiles WHERE email = ?", (email,)
-        ).fetchone()
-        if existing:
-            raise ValueError(f"Email {email} is already registered (user_id={existing['user_id']})")
-        conn.execute(
-            "INSERT INTO profiles (user_id, email, api_token) VALUES (?, ?, ?)",
-            (user_id, email, api_token),
-        )
-    return user_id

--- a/bot/handlers.py
+++ b/bot/handlers.py
@@ -9,7 +9,7 @@ from telegram.ext import ContextTypes
 
 from bot.analyzer import analyze, analyze_image, to_json_str
 from bot.config import MAX_CONTENT_CHARS
-from bot.db import save_item
+from bot.db import get_or_create_user_by_telegram, save_item
 from bot.fetcher import fetch_url
 from bot.formatting import format_analysis
 from bot.storage import save_file_from_path
@@ -39,7 +39,7 @@ async def _describe_images(image_urls: list[str]) -> str:
 
 async def _analyze_and_reply(
     update: Update,
-    user_id: str,
+    user_id: int,
     text: str,
     source_type: str = "note",
     source: str = "",
@@ -73,7 +73,7 @@ async def handle_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
     if not text:
         return
 
-    user_id = str(update.effective_user.id)
+    user_id = get_or_create_user_by_telegram(update.effective_user.id)
     entities = message.entities or []
     urls = [
         text[e.offset: e.offset + e.length] if e.type == "url" else e.url
@@ -112,7 +112,7 @@ async def handle_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
 # --- Voice messages ---
 
 async def handle_voice(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    user_id = str(update.effective_user.id)
+    user_id = get_or_create_user_by_telegram(update.effective_user.id)
     await update.message.reply_text("Transcribing voice message...")
     with tempfile.NamedTemporaryFile(suffix=".ogg", delete=False) as f:
         path = f.name
@@ -134,7 +134,7 @@ async def handle_voice(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
 # --- Audio files ---
 
 async def handle_audio(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    user_id = str(update.effective_user.id)
+    user_id = get_or_create_user_by_telegram(update.effective_user.id)
     audio = update.message.audio
     suffix = f".{audio.mime_type.split('/')[-1]}" if audio.mime_type else ".mp3"
     await update.message.reply_text(f"Transcribing audio: {audio.file_name or 'file'}...")
@@ -161,7 +161,7 @@ async def handle_audio(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
 # --- Video & video notes ---
 
 async def handle_video(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    user_id = str(update.effective_user.id)
+    user_id = get_or_create_user_by_telegram(update.effective_user.id)
     video = update.message.video or update.message.video_note
     await update.message.reply_text("Extracting and transcribing video audio...")
     with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as f:
@@ -183,7 +183,7 @@ async def handle_video(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
 # --- Photos (vision) ---
 
 async def handle_photo(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    user_id = str(update.effective_user.id)
+    user_id = get_or_create_user_by_telegram(update.effective_user.id)
     await update.message.reply_text("Analyzing image...")
     photo = update.message.photo[-1]  # largest available size
     with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as f:
@@ -214,7 +214,7 @@ async def handle_photo(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
 # --- Documents (PDF, text files, audio attachments) ---
 
 async def handle_document(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    user_id = str(update.effective_user.id)
+    user_id = get_or_create_user_by_telegram(update.effective_user.id)
     doc = update.message.document
     mime = doc.mime_type or ""
     name = doc.file_name or "document"

--- a/kb.py
+++ b/kb.py
@@ -25,18 +25,22 @@ _TYPE_ICONS = {
 }
 
 
-def _parse_user_flag(args: list[str]) -> tuple[str | None, list[str]]:
+def _parse_user_flag(args: list[str]) -> tuple[int | None, list[str]]:
     """Extract --user <id> from args, return (user_id, remaining_args)."""
     if "--user" in args:
         idx = args.index("--user")
         if idx + 1 < len(args):
-            user_id = args[idx + 1]
+            raw = args[idx + 1]
             remaining = args[:idx] + args[idx + 2:]
-            return user_id, remaining
+            try:
+                return int(raw), remaining
+            except ValueError:
+                print(f"--user expects an integer id, got {raw!r}")
+                sys.exit(2)
     return None, args
 
 
-def cmd_list(user_id: str | None = None):
+def cmd_list(user_id: int | None = None):
     rows = get_all_items(user_id)
     if not rows:
         print("No items in knowledge base yet.")
@@ -82,7 +86,7 @@ def cmd_show(item_id: int):
     print()
 
 
-def cmd_search(query: str, user_id: str | None = None):
+def cmd_search(query: str, user_id: int | None = None):
     rows = search_items(query, user_id)
     if not rows:
         print(f"No results for '{query}'.")
@@ -111,15 +115,12 @@ def cmd_delete(item_id: int):
 
 
 def cmd_adduser(email: str):
-    """Create a new web-only user and print their API token."""
+    """Create a new web-only user (or attach an api_token to an existing one) and print the token."""
     from bot.auth import generate_token
-    from bot.db import create_web_user
+    from bot.db import upsert_user_by_email, set_user_field
     token = generate_token()
-    try:
-        user_id = create_web_user(email=email, api_token=token)
-    except ValueError as e:
-        print(f"Error: {e}")
-        return
+    user_id = upsert_user_by_email(email)
+    set_user_field(user_id, api_token=token)
     print(f"Created user : {user_id}")
     print(f"Email        : {email}")
     print(f"API token    : {token}")


### PR DESCRIPTION
## Summary
- Replace `profiles` (TEXT PK) with canonical `users` (INTEGER PK) — Telegram and web sign-in will hang off the same identity going forward.
- `items.user_id` flips from TEXT to INTEGER FK; one-shot migration on `_init()` remaps existing Telegram rows and **preserves item IDs**.
- Drop the unused `web:<email>` codepath (`create_web_user`).
- Rename helpers across `bot/`, `kb.py`: `get_profile`/`set_profile` → `get_user_profile`/`set_user_profile`; add `get_or_create_user_by_telegram` + `upsert_user_by_email`. `require_token` now returns the canonical INTEGER user id.
- Anonymous `/api/try` callers **and** fresh signed-in users without their own profile fall back to `analyzer.DEFAULT_PROFILE`, which mirrors the landing-page positioning ("For everyone trying to keep up with AI") so the LLM always has an audience.

This is **step 1** of the unified-identity refactor agreed on 2026-05-18. Frontend rewires (sessions → backend user id, signed-in `/api/try` → backend, anon-claim cross-DB move, /me proxy) are separate PRs.

## Migration behaviour
Idempotent — runs once when `_init()` sees an old `profiles` table and no `users` table:
- Numeric `profiles.user_id` rows → new `users` row with `telegram_chat_id` set.
- `web:<email>` rows are dropped (codepath was unused in prod).
- `items` rows whose `user_id` doesn't map (empty / `web:`) are dropped — they predate multi-user.
- Item IDs preserved so `/show <id>` keeps resolving.

## Test plan

### Pre-merge (no deploy needed)

- [x] Snapshot prod `research.db` on Fly: `flyctl ssh console -C 'cp /data/research.db /data/research.db.pre-users-migration'`
- [x] Pull a copy of prod DB locally and dry-run the migration. **Important:** `bot/db.py` hardcodes the filename as `research.db`, so put the copy into its own directory with that exact name and point `DATA_DIR` at the directory (not the file):
  ```bash
  flyctl ssh sftp get /data/research.db ./prod-copy.db
  mkdir -p /tmp/migrate-test
  cp prod-copy.db /tmp/migrate-test/research.db
  DATA_DIR=/tmp/migrate-test python3 -c 'from bot import db; print("migrated ok")'

  sqlite3 /tmp/migrate-test/research.db <<'SQL'
  .mode table
  .headers on
  SELECT name FROM sqlite_master WHERE type='table' ORDER BY name;
  SELECT id, telegram_chat_id, email, api_token,
         substr(profile, 1, 60) AS profile_preview, created_at
  FROM users;
  SELECT id, user_id, source_type,
         substr(source, 1, 60) AS source, created_at
  FROM items ORDER BY id;
  SQL
  ```
  Expect: tables list = `items`, `sqlite_sequence`, `users` (no more `profiles`); one `users` row per Telegram user; item count = old items minus any orphan / `web:<email>` rows.

### Post-deploy (after merge triggers the Fly action)

- [x] Bot restarts cleanly on Fly (no migration errors in `flyctl logs`)
- [x] Telegram: `/list` — shows existing items under the new `user_id`
- [x] Telegram: `/show <id>` — same item ids resolve as before
- [ ] Telegram: `/search <query>` — finds existing rows
- [x] Telegram: `/profile` — shows the migrated perspective text (was `profiles.content`)
- [ ] Telegram: `/profile <new text>` — updates and re-reads correctly
- [x] Telegram: `/token` — regenerates and stores against the new `users.api_token`
- [x] Telegram: send a new note/URL — analyses and saves under the new schema
- [x] Web: `/api/try` (anon) via the Worker — verdict reads as if written for the AI-keeping-up audience (`DEFAULT_PROFILE` in effect)
- [ ] Web: `/api/items`, `/api/profile` GET/PUT with the regenerated Bearer token

🤖 Generated with [Claude Code](https://claude.com/claude-code)