### PR TITLE
Backend: Worker-facing endpoints (users/upsert, library, claim, link) + pytest setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,14 @@ PORT    ?= 8080
 
 .DEFAULT_GOAL := help
 
-.PHONY: help install dev run kb adduser
+.PHONY: help install dev run test kb adduser
 
 help:
 	@echo ""
 	@echo "  make install          create .venv and install dependencies"
 	@echo "  make dev              start with auto-reload (local dev)"
 	@echo "  make run              start without auto-reload (production)"
+	@echo "  make test             run the pytest suite"
 	@echo "  make kb               open the admin CLI (python kb.py)"
 	@echo "  make adduser          create a web-only user  (EMAIL=foo@bar.com)"
 	@echo ""
@@ -37,6 +38,9 @@ dev: install
 
 run: install
 	$(UVICORN) main:app --host 0.0.0.0 --port $(PORT)
+
+test: install
+	$(PYTHON) -m pytest tests/ -v
 
 kb: install
 	$(PYTHON) kb.py $(ARGS)

--- a/bot/api.py
+++ b/bot/api.py
@@ -258,12 +258,12 @@ async def try_url(req: TryRequest, _: None = Depends(_require_try_secret)):
 # only legitimate caller.
 # ---------------------------------------------------------------------------
 
-class _ProfileUpsertRequest(BaseModel):
+class _UserUpsertRequest(BaseModel):
     email: str
 
 
-@router.post("/profile/upsert")
-async def profile_upsert(req: _ProfileUpsertRequest, _: None = Depends(_require_try_secret)):
+@router.post("/users/upsert")
+async def user_upsert(req: _UserUpsertRequest, _: None = Depends(_require_try_secret)):
     """Get-or-create a users row by email. Returns the canonical INTEGER id."""
     email = (req.email or "").strip()
     if not email or "@" not in email:

--- a/bot/api.py
+++ b/bot/api.py
@@ -1,5 +1,6 @@
 import base64
 import io
+import json
 import logging
 import os
 import secrets
@@ -15,6 +16,8 @@ from bot.analyzer import analyze, analyze_image, to_json_str, to_plain_text
 from bot.auth import require_token
 from bot.config import MAX_CONTENT_CHARS
 from bot.db import (
+    LINK_CODE_TTL_SECONDS,
+    create_link_code,
     delete_item,
     get_all_items,
     get_item,
@@ -22,6 +25,7 @@ from bot.db import (
     save_item,
     search_items,
     set_user_profile,
+    upsert_user_by_email,
 )
 from bot.fetcher import fetch_url
 from bot.storage import full_path, save_file
@@ -245,3 +249,178 @@ async def try_url(req: TryRequest, _: None = Depends(_require_try_secret)):
         "verdict": verdict,
         "analysis": analysis,
     }
+
+
+# ---------------------------------------------------------------------------
+# Worker-only endpoints (shared FILTER_FYI_TRY_SECRET, same trust model as /try)
+# The Cloudflare Worker calls these after it has resolved a session/cookie to a
+# canonical users.id; it then passes that id in the request. The Worker is the
+# only legitimate caller.
+# ---------------------------------------------------------------------------
+
+class _ProfileUpsertRequest(BaseModel):
+    email: str
+
+
+@router.post("/profile/upsert")
+async def profile_upsert(req: _ProfileUpsertRequest, _: None = Depends(_require_try_secret)):
+    """Get-or-create a users row by email. Returns the canonical INTEGER id."""
+    email = (req.email or "").strip()
+    if not email or "@" not in email:
+        raise HTTPException(status_code=400, detail={"error": "invalid-email"})
+    return {"user_id": upsert_user_by_email(email)}
+
+
+class _LibraryAddRequest(BaseModel):
+    user_id: int
+    url: str
+    user_note: str = ""
+
+
+@router.post("/library/add", status_code=201)
+async def library_add(req: _LibraryAddRequest, _: None = Depends(_require_try_secret)):
+    """Signed-in `/api/try`: analyse a URL for the given user AND save to items.
+
+    Mirrors `/api/try`'s response shape (so the Worker can use the same renderer)
+    but adds `id`: the newly created items row id, so the Worker can deep-link
+    to the entry afterwards.
+    """
+    url = (req.url or "").strip()
+    if not _is_http_url(url):
+        raise HTTPException(status_code=400, detail={"error": "invalid-url"})
+
+    try:
+        fetched = await fetch_url(url)
+    except Exception as e:
+        logger.exception("fetch_url crashed for %s: %s", url, e)
+        raise HTTPException(status_code=502, detail={"error": "fetch-failed"})
+
+    text = (fetched.get("text") or "").strip()
+    source_type = fetched.get("source_type") or "article"
+
+    if not text:
+        if source_type in _VIDEO_SOURCE_TYPES:
+            raise HTTPException(status_code=422, detail={"error": "no-transcript"})
+        raise HTTPException(status_code=422, detail={"error": "extraction-failed"})
+
+    try:
+        analysis = analyze(text, user_id=req.user_id)
+    except Exception as e:
+        logger.exception("analyze crashed for %s: %s", url, e)
+        raise HTTPException(status_code=502, detail={"error": "analyze-failed"})
+
+    # Persist full analysis (incl. verdict) to items.analysis as JSON.
+    save_item(
+        user_id=req.user_id,
+        source_type=source_type,
+        source=url,
+        content=text,
+        analysis=to_json_str(analysis),
+        user_note=req.user_note,
+    )
+
+    # Fetch the row we just inserted so the Worker gets the canonical id.
+    rows = get_all_items(req.user_id)
+    new_id = rows[0]["id"] if rows else None
+
+    verdict = analysis.pop("verdict", "skim")
+    return {
+        "id": new_id,
+        "url": url,
+        "title": fetched.get("title") or url,
+        "source_type": source_type,
+        "image_urls": fetched.get("image_urls") or [],
+        "content_preview": text[:TRY_PREVIEW_CHARS],
+        "verdict": verdict,
+        "analysis": analysis,
+    }
+
+
+def _extract_verdict_and_title(analysis_json: str) -> tuple[str, str]:
+    """Pull verdict + a short title-ish from a stored analysis JSON, defensively."""
+    if not analysis_json:
+        return "", ""
+    try:
+        data = json.loads(analysis_json)
+    except json.JSONDecodeError:
+        return "", ""
+    if not isinstance(data, dict):
+        return "", ""
+    verdict = str(data.get("verdict") or "").strip().lower()
+    title = str(data.get("main_idea") or "").strip()
+    return verdict, title[:120]
+
+
+@router.get("/library")
+async def library_list(user_id: int, _: None = Depends(_require_try_secret)):
+    """Lean library list for a user — enough to render `/me` without per-row fetches."""
+    rows = get_all_items(user_id)
+    out = []
+    for r in rows:
+        verdict, title = _extract_verdict_and_title(r["analysis"])
+        out.append({
+            "id": r["id"],
+            "source_type": r["source_type"],
+            "source": r["source"],
+            "verdict": verdict,
+            "title": title,
+            "created_at": r["created_at"],
+        })
+    return out
+
+
+@router.get("/library/{item_id}")
+async def library_show(item_id: int, user_id: int, _: None = Depends(_require_try_secret)):
+    """Full item — for the `/me` show page."""
+    row = get_item(item_id, user_id)
+    if not row:
+        raise HTTPException(status_code=404, detail={"error": "not-found"})
+    return dict(row)
+
+
+class _ClaimRow(BaseModel):
+    url: str
+    title: str | None = None
+    source_type: str = "article"
+    content_preview: str | None = None
+    verdict: str = "skim"
+    analysis: dict | None = None
+
+
+class _ClaimRequest(BaseModel):
+    user_id: int
+    rows: list[_ClaimRow]
+
+
+@router.post("/claim", status_code=201)
+async def claim(req: _ClaimRequest, _: None = Depends(_require_try_secret)):
+    """Worker pushes a batch of anon rows here right after magic-link verify.
+
+    The Worker reads its D1 `summaries` rows by `anon_id`, posts them here, then
+    deletes them from D1. We can only store what the anon row had — full source
+    text was never persisted, so `content_preview` is the best we get.
+    """
+    saved = 0
+    for r in req.rows:
+        analysis_obj = dict(r.analysis or {})
+        analysis_obj["verdict"] = r.verdict or analysis_obj.get("verdict") or "skim"
+        save_item(
+            user_id=req.user_id,
+            source_type=r.source_type,
+            source=r.url,
+            content=r.content_preview or "",
+            analysis=to_json_str(analysis_obj),
+        )
+        saved += 1
+    return {"count": saved}
+
+
+class _LinkStartRequest(BaseModel):
+    user_id: int
+
+
+@router.post("/link/start", status_code=201)
+async def link_start(req: _LinkStartRequest, _: None = Depends(_require_try_secret)):
+    """Issue a 6-digit code the user types into the Telegram bot as `/link <code>`."""
+    code = create_link_code(req.user_id)
+    return {"code": code, "expires_in_seconds": LINK_CODE_TTL_SECONDS}

--- a/bot/application.py
+++ b/bot/application.py
@@ -4,7 +4,16 @@ import logging
 from telegram import Update
 from telegram.ext import Application, CommandHandler, MessageHandler, TypeHandler, filters
 
-from bot.commands import cmd_start, cmd_delete, cmd_list, cmd_profile, cmd_search, cmd_show, cmd_token
+from bot.commands import (
+    cmd_delete,
+    cmd_link,
+    cmd_list,
+    cmd_profile,
+    cmd_search,
+    cmd_show,
+    cmd_start,
+    cmd_token,
+)
 from bot.handlers import (
     handle_audio,
     handle_document,
@@ -52,6 +61,9 @@ def build_application(token: str) -> Application:
 
     # Web UI token
     app.add_handler(CommandHandler("token", cmd_token))
+
+    # Account linking (web ↔ Telegram)
+    app.add_handler(CommandHandler("link", cmd_link))
 
     # KB commands
     app.add_handler(CommandHandler("list", cmd_list))

--- a/bot/commands.py
+++ b/bot/commands.py
@@ -10,6 +10,8 @@ from bot.db import (
     get_item,
     get_or_create_user_by_telegram,
     get_user_profile,
+    link_telegram_to_user,
+    redeem_link_code,
     search_items,
     set_user_field,
     set_user_profile,
@@ -151,6 +153,50 @@ async def cmd_profile(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
         return
 
     await message.reply_text(f"<b>Your profile:</b>\n\n{html.escape(content)}", parse_mode="HTML")
+
+
+async def cmd_link(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """/link <code> — link this Telegram chat to an existing filter.fyi web account.
+
+    The user generates the 6-digit code from `/me` on the website while signed in,
+    then DMs the bot `/link 123456`. Their Telegram KB (if any) gets merged into
+    the web account; from then on, both surfaces share the same library.
+    """
+    user_id = get_or_create_user_by_telegram(update.effective_user.id)
+    args = context.args
+    if not args or len(args[0]) != 6 or not args[0].isdigit():
+        await update.message.reply_text(
+            "Usage: <code>/link 123456</code>\n\n"
+            "Get a 6-digit code from filter.fyi/me while signed in.",
+            parse_mode="HTML",
+        )
+        return
+
+    code = args[0]
+    web_user_id = redeem_link_code(code)
+    if web_user_id is None:
+        await update.message.reply_text(
+            "That code is invalid or expired. Generate a fresh one from filter.fyi/me."
+        )
+        return
+
+    if web_user_id == user_id:
+        await update.message.reply_text("This chat is already linked to that account.")
+        return
+
+    try:
+        link_telegram_to_user(
+            web_user_id=web_user_id,
+            telegram_chat_id=update.effective_user.id,
+        )
+    except ValueError as e:
+        logger.warning("Link rejected for tg=%s web=%s: %s", user_id, web_user_id, e)
+        await update.message.reply_text(f"Couldn't link: {e}")
+        return
+
+    await update.message.reply_text(
+        "✓ Linked! Your Telegram entries and your filter.fyi web library are now one library."
+    )
 
 
 async def cmd_token(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/bot/db.py
+++ b/bot/db.py
@@ -1,5 +1,7 @@
 import os
+import secrets
 import sqlite3
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 # DATA_DIR lets us point at a mounted volume in prod (Fly) while keeping the
@@ -38,9 +40,24 @@ CREATE TABLE IF NOT EXISTS items (
     FOREIGN KEY (user_id) REFERENCES users(id)
 )"""
 
+# Short-lived codes a logged-in web user generates to link their Telegram
+# account. The Telegram bot redeems the code via /link <code>, which stitches
+# the chat_id onto the existing web users row. One outstanding code per user.
+_CREATE_LINK_CODES_SQL = """\
+CREATE TABLE IF NOT EXISTS link_codes (
+    code       TEXT PRIMARY KEY,
+    user_id    INTEGER NOT NULL,
+    expires_at TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%S', 'now')),
+    FOREIGN KEY (user_id) REFERENCES users(id)
+)"""
+
 _CREATE_INDEXES_SQL = [
     "CREATE INDEX IF NOT EXISTS idx_items_user ON items(user_id, created_at DESC)",
+    "CREATE INDEX IF NOT EXISTS idx_link_codes_expires ON link_codes(expires_at)",
 ]
+
+LINK_CODE_TTL_SECONDS = 600
 
 
 def _get_conn() -> sqlite3.Connection:
@@ -117,8 +134,13 @@ def _init() -> None:
         else:
             conn.execute(_CREATE_USERS_SQL)
             conn.execute(_CREATE_ITEMS_SQL)
+        conn.execute(_CREATE_LINK_CODES_SQL)
         for stmt in _CREATE_INDEXES_SQL:
             conn.execute(stmt)
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
 
 
 _init()
@@ -276,3 +298,94 @@ def delete_item(item_id: int, user_id: int | None = None) -> None:
             )
         else:
             conn.execute("DELETE FROM items WHERE id = ?", (item_id,))
+
+
+# ---------------------------------------------------------------------------
+# Account linking (web ↔ Telegram)
+# ---------------------------------------------------------------------------
+
+def create_link_code(user_id: int) -> str:
+    """Generate a 6-digit code the given user can read in DM to link their Telegram chat.
+    Only one outstanding code per user; older codes for the same user are cleared."""
+    code = f"{secrets.randbelow(1_000_000):06d}"
+    expires_at = (
+        datetime.now(timezone.utc) + timedelta(seconds=LINK_CODE_TTL_SECONDS)
+    ).strftime("%Y-%m-%dT%H:%M:%S")
+    with _get_conn() as conn:
+        conn.execute("DELETE FROM link_codes WHERE user_id = ?", (user_id,))
+        conn.execute(
+            "INSERT INTO link_codes (code, user_id, expires_at) VALUES (?, ?, ?)",
+            (code, user_id, expires_at),
+        )
+    return code
+
+
+def redeem_link_code(code: str) -> int | None:
+    """Look up which web users.id this code points to, single-use. Returns None if
+    invalid or expired. Also opportunistically clears expired rows."""
+    now = _utcnow_iso()
+    with _get_conn() as conn:
+        row = conn.execute(
+            "SELECT user_id FROM link_codes WHERE code = ? AND expires_at > ?",
+            (code, now),
+        ).fetchone()
+        if not row:
+            return None
+        conn.execute("DELETE FROM link_codes WHERE code = ?", (code,))
+        conn.execute("DELETE FROM link_codes WHERE expires_at <= ?", (now,))
+        return row["user_id"]
+
+
+def link_telegram_to_user(web_user_id: int, telegram_chat_id: int) -> None:
+    """Stitch a Telegram chat onto the given web user. Idempotent.
+
+    If a separate `users` row already exists for `telegram_chat_id` (the typical
+    case — the person has been using the bot for a while), its items are moved
+    onto `web_user_id` and the orphan row is deleted. Web-side `profile` and
+    `api_token` win unless they're empty, in which case the Telegram-side values
+    are copied over. Raises ValueError if the web user is already linked to a
+    different Telegram chat.
+    """
+    with _get_conn() as conn:
+        web = conn.execute(
+            "SELECT id, telegram_chat_id, profile, api_token FROM users WHERE id = ?",
+            (web_user_id,),
+        ).fetchone()
+        if not web:
+            raise ValueError(f"web user {web_user_id} not found")
+        if web["telegram_chat_id"] is not None and web["telegram_chat_id"] != telegram_chat_id:
+            raise ValueError(
+                f"web user {web_user_id} is already linked to Telegram chat "
+                f"{web['telegram_chat_id']}"
+            )
+
+        tg = conn.execute(
+            "SELECT id, profile, api_token FROM users WHERE telegram_chat_id = ?",
+            (telegram_chat_id,),
+        ).fetchone()
+
+        if tg and tg["id"] == web_user_id:
+            return  # already linked, no-op
+
+        if tg:
+            conn.execute(
+                "UPDATE items SET user_id = ? WHERE user_id = ?",
+                (web_user_id, tg["id"]),
+            )
+            updates: dict[str, str] = {}
+            if not web["profile"] and tg["profile"]:
+                updates["profile"] = tg["profile"]
+            if not web["api_token"] and tg["api_token"]:
+                updates["api_token"] = tg["api_token"]
+            if updates:
+                set_clause = ", ".join(f"{k} = ?" for k in updates)
+                conn.execute(
+                    f"UPDATE users SET {set_clause} WHERE id = ?",
+                    list(updates.values()) + [web_user_id],
+                )
+            conn.execute("DELETE FROM users WHERE id = ?", (tg["id"],))
+
+        conn.execute(
+            "UPDATE users SET telegram_chat_id = ? WHERE id = ?",
+            (telegram_chat_id, web_user_id),
+        )

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,5 @@ faster-whisper>=1.0.0
 pdfplumber>=0.11.0
 # web UI file uploads
 python-multipart>=0.0.9
+# tests
+pytest>=8.0.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,80 @@
+"""Shared pytest fixtures.
+
+`bot/db.py` reads `DATA_DIR` at import time and runs `_init()`, so we have to
+set it (and the try-secret) **before** any `bot.*` import. The `autouse`
+fixture below handles that for every test, with a fresh temp directory and
+a cleanly re-imported `bot.db` module per test.
+"""
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import tempfile
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolated_data_dir(monkeypatch):
+    """Point bot.db at a fresh DATA_DIR for every test and reload the module.
+
+    Reloading is necessary because `bot.db._init()` runs at import time. Without
+    a reload, the second test would reuse the connection bound to the first
+    test's temp file.
+    """
+    tmp = tempfile.mkdtemp(prefix="filter-fyi-test-")
+    monkeypatch.setenv("DATA_DIR", tmp)
+    monkeypatch.setenv("FILTER_FYI_TRY_SECRET", "test-secret")
+
+    # Drop any cached bot.* modules so the next import sees the new DATA_DIR
+    for mod in list(sys.modules):
+        if mod == "bot" or mod.startswith("bot."):
+            del sys.modules[mod]
+
+
+@pytest.fixture
+def db():
+    """Fresh `bot.db` module bound to the isolated DATA_DIR."""
+    import bot.db
+    return bot.db
+
+
+@pytest.fixture
+def client(monkeypatch):
+    """FastAPI TestClient with `analyze` and `fetch_url` mocked so we don't hit
+    the network or the LLM. Tests that need different mock behavior can
+    monkeypatch over these defaults."""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    import bot.api
+
+    async def fake_fetch_url(url):
+        return {
+            "text": "Sample article body about retrieval-augmented generation.",
+            "title": "Hello RAG",
+            "source_type": "article",
+            "image_urls": [],
+        }
+
+    def fake_analyze(text, user_id=None):
+        return {
+            "main_idea": "RAG = retrieval-augmented generation.",
+            "why_it_matters": "Practical AI pattern.",
+            "category": "ai-engineering",
+            "suggested_experiment": "Try a small RAG demo.",
+            "time_required": "10 min read",
+            "verdict": "watch",
+        }
+
+    monkeypatch.setattr(bot.api, "fetch_url", fake_fetch_url)
+    monkeypatch.setattr(bot.api, "analyze", fake_analyze)
+
+    app = FastAPI()
+    app.include_router(bot.api.router)
+    return TestClient(app)
+
+
+@pytest.fixture
+def auth_headers():
+    return {"x-filter-fyi-secret": "test-secret"}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,152 @@
+"""HTTP-level tests for the Worker-facing endpoints (shared-secret gated)."""
+from __future__ import annotations
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Auth (shared secret)
+# ---------------------------------------------------------------------------
+
+class TestAuth:
+    def test_missing_header_returns_401(self, client):
+        r = client.post("/api/users/upsert", json={"email": "x@y.com"})
+        assert r.status_code == 401
+
+    def test_wrong_secret_returns_401(self, client):
+        r = client.post(
+            "/api/users/upsert",
+            json={"email": "x@y.com"},
+            headers={"x-filter-fyi-secret": "WRONG"},
+        )
+        assert r.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# POST /api/users/upsert
+# ---------------------------------------------------------------------------
+
+class TestUserUpsert:
+    def test_creates_user_and_is_idempotent(self, client, auth_headers):
+        r1 = client.post("/api/users/upsert", json={"email": "Alice@Example.com"}, headers=auth_headers)
+        r2 = client.post("/api/users/upsert", json={"email": "alice@example.com"}, headers=auth_headers)
+        assert r1.status_code == 200
+        assert r1.json()["user_id"] == r2.json()["user_id"]
+
+    def test_rejects_invalid_email(self, client, auth_headers):
+        r = client.post("/api/users/upsert", json={"email": "not-an-email"}, headers=auth_headers)
+        assert r.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# POST /api/library/add
+# ---------------------------------------------------------------------------
+
+class TestLibraryAdd:
+    def _make_user(self, client, auth_headers, email="alice@example.com"):
+        return client.post("/api/users/upsert", json={"email": email}, headers=auth_headers).json()["user_id"]
+
+    def test_analyses_url_and_persists_item(self, client, auth_headers):
+        uid = self._make_user(client, auth_headers)
+        r = client.post(
+            "/api/library/add",
+            json={"user_id": uid, "url": "https://example.com/rag", "user_note": "found it"},
+            headers=auth_headers,
+        )
+        assert r.status_code == 201
+        body = r.json()
+        assert body["verdict"] == "watch"
+        assert body["id"] is not None
+        assert "main_idea" in body["analysis"]
+
+    def test_rejects_invalid_url(self, client, auth_headers):
+        uid = self._make_user(client, auth_headers)
+        r = client.post(
+            "/api/library/add",
+            json={"user_id": uid, "url": "not-a-url"},
+            headers=auth_headers,
+        )
+        assert r.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# GET /api/library + GET /api/library/{id}
+# ---------------------------------------------------------------------------
+
+class TestLibrary:
+    def _user_with_one_item(self, client, auth_headers):
+        uid = client.post("/api/users/upsert", json={"email": "a@b.com"}, headers=auth_headers).json()["user_id"]
+        added = client.post(
+            "/api/library/add",
+            json={"user_id": uid, "url": "https://example.com/x"},
+            headers=auth_headers,
+        ).json()
+        return uid, added["id"]
+
+    def test_list_returns_lean_shape(self, client, auth_headers):
+        uid, item_id = self._user_with_one_item(client, auth_headers)
+        r = client.get(f"/api/library?user_id={uid}", headers=auth_headers)
+        assert r.status_code == 200
+        rows = r.json()
+        assert len(rows) == 1
+        row = rows[0]
+        assert set(row.keys()) == {"id", "source_type", "source", "verdict", "title", "created_at"}
+        assert row["verdict"] == "watch"
+        assert "RAG" in row["title"]
+
+    def test_show_returns_full_item(self, client, auth_headers):
+        uid, item_id = self._user_with_one_item(client, auth_headers)
+        r = client.get(f"/api/library/{item_id}?user_id={uid}", headers=auth_headers)
+        assert r.status_code == 200
+        body = r.json()
+        assert "content" in body and "analysis" in body
+        assert body["user_id"] == uid
+
+    def test_show_404_for_wrong_user(self, client, auth_headers):
+        uid, item_id = self._user_with_one_item(client, auth_headers)
+        r = client.get(f"/api/library/{item_id}?user_id=99999", headers=auth_headers)
+        assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# POST /api/claim
+# ---------------------------------------------------------------------------
+
+class TestClaim:
+    def test_inserts_batch_of_anon_rows(self, client, auth_headers):
+        uid = client.post("/api/users/upsert", json={"email": "a@b.com"}, headers=auth_headers).json()["user_id"]
+        r = client.post(
+            "/api/claim",
+            json={
+                "user_id": uid,
+                "rows": [
+                    {"url": "https://a.com", "source_type": "article", "verdict": "skim",
+                     "content_preview": "preview a", "analysis": {"main_idea": "A"}},
+                    {"url": "https://b.com", "source_type": "youtube", "verdict": "skip",
+                     "content_preview": "preview b", "analysis": {"main_idea": "B"}},
+                ],
+            },
+            headers=auth_headers,
+        )
+        assert r.status_code == 201
+        assert r.json()["count"] == 2
+
+        listing = client.get(f"/api/library?user_id={uid}", headers=auth_headers).json()
+        assert len(listing) == 2
+        verdicts = {row["verdict"] for row in listing}
+        assert verdicts == {"skim", "skip"}
+
+
+# ---------------------------------------------------------------------------
+# POST /api/link/start
+# ---------------------------------------------------------------------------
+
+class TestLinkStart:
+    def test_returns_6_digit_code_with_expiry(self, client, auth_headers):
+        uid = client.post("/api/users/upsert", json={"email": "a@b.com"}, headers=auth_headers).json()["user_id"]
+        r = client.post("/api/link/start", json={"user_id": uid}, headers=auth_headers)
+        assert r.status_code == 201
+        body = r.json()
+        assert len(body["code"]) == 6
+        assert body["code"].isdigit()
+        assert body["expires_in_seconds"] == 600

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,224 @@
+"""DB-layer tests: schema migration, user/item helpers, link codes, merge."""
+from __future__ import annotations
+
+import os
+import sqlite3
+
+import pytest
+
+
+def _seed_old_schema(db_path: str) -> None:
+    """Write a `profiles` + `items(user_id TEXT)` database the way pre-rebuild prod looked."""
+    c = sqlite3.connect(db_path)
+    c.executescript("""
+        CREATE TABLE items (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id TEXT NOT NULL DEFAULT '',
+            source_type TEXT NOT NULL DEFAULT 'unknown',
+            source TEXT NOT NULL DEFAULT '',
+            content TEXT NOT NULL DEFAULT '',
+            analysis TEXT NOT NULL DEFAULT '',
+            user_note TEXT NOT NULL DEFAULT '',
+            file_path TEXT NOT NULL DEFAULT '',
+            created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%S', 'now'))
+        );
+        CREATE TABLE profiles (
+            user_id TEXT PRIMARY KEY,
+            content TEXT NOT NULL DEFAULT '',
+            email TEXT UNIQUE,
+            api_token TEXT UNIQUE
+        );
+        INSERT INTO profiles VALUES ('98765', 'I am a developer.', NULL, NULL);
+        INSERT INTO profiles VALUES ('11111', 'I trade crypto.', 'real@tg.com', 'token_real');
+        INSERT INTO profiles VALUES ('web:ghost@example.com', 'unused', 'ghost@example.com', 'token_ghost');
+        INSERT INTO items (user_id, source_type, content, analysis) VALUES ('98765', 'note', 'hello A', '{}');
+        INSERT INTO items (user_id, source_type, content, analysis) VALUES ('11111', 'url', 'hello B', '{}');
+        INSERT INTO items (user_id, source_type, content, analysis) VALUES ('web:ghost@example.com', 'note', 'orphan web', '{}');
+        INSERT INTO items (user_id, source_type, content, analysis) VALUES ('', 'note', 'pre-multiuser', '{}');
+    """)
+    c.commit()
+    c.close()
+
+
+# ---------------------------------------------------------------------------
+# Migration from the old `profiles` schema
+# ---------------------------------------------------------------------------
+
+class TestMigration:
+    def test_fresh_install_creates_users_and_items(self, db):
+        # The autouse fixture runs _init() against a fresh dir; we should already
+        # have empty users + items + link_codes tables.
+        conn = db._get_conn()
+        names = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+        assert {"users", "items", "link_codes"}.issubset(names)
+        assert "profiles" not in names
+
+    def test_migration_moves_telegram_users_only(self, monkeypatch):
+        # Seed old schema, then import bot.db which triggers the migration
+        data_dir = os.environ["DATA_DIR"]
+        _seed_old_schema(os.path.join(data_dir, "research.db"))
+
+        import bot.db as db
+
+        conn = db._get_conn()
+        users = list(conn.execute("SELECT telegram_chat_id, email, api_token, profile FROM users ORDER BY telegram_chat_id"))
+        assert len(users) == 2, "web:<email> row should be dropped"
+        assert users[0]["telegram_chat_id"] == 11111
+        assert users[0]["email"] == "real@tg.com"
+        assert users[0]["api_token"] == "token_real"
+        assert users[0]["profile"] == "I trade crypto."
+        assert users[1]["telegram_chat_id"] == 98765
+        assert users[1]["profile"] == "I am a developer."
+
+    def test_migration_remaps_item_user_ids(self, monkeypatch):
+        data_dir = os.environ["DATA_DIR"]
+        _seed_old_schema(os.path.join(data_dir, "research.db"))
+
+        import bot.db as db
+
+        conn = db._get_conn()
+        items = list(conn.execute("SELECT id, user_id, content FROM items ORDER BY id"))
+        # The web:<email> item and the empty-user-id item are dropped (orphans).
+        assert len(items) == 2
+        assert items[0]["content"] == "hello A"
+        assert items[1]["content"] == "hello B"
+        # Items should reference real users.id INTEGERs, not the old text.
+        user_ids = {u["id"] for u in conn.execute("SELECT id FROM users")}
+        for item in items:
+            assert item["user_id"] in user_ids
+
+    def test_migration_preserves_item_ids(self, monkeypatch):
+        """`/show <id>` keeps working post-migration."""
+        data_dir = os.environ["DATA_DIR"]
+        _seed_old_schema(os.path.join(data_dir, "research.db"))
+
+        import bot.db as db
+
+        conn = db._get_conn()
+        # Old items 1 and 2 had user_ids '98765' and '11111' — they should still
+        # be items 1 and 2 with their content intact.
+        rows = list(conn.execute("SELECT id, content FROM items ORDER BY id"))
+        assert rows[0]["id"] == 1
+        assert rows[0]["content"] == "hello A"
+        assert rows[1]["id"] == 2
+        assert rows[1]["content"] == "hello B"
+
+    def test_init_is_idempotent(self, db):
+        """Running _init twice on the new schema should be a no-op."""
+        db._init()
+        db._init()
+        conn = db._get_conn()
+        names = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+        assert {"users", "items", "link_codes"}.issubset(names)
+
+
+# ---------------------------------------------------------------------------
+# User helpers
+# ---------------------------------------------------------------------------
+
+class TestUserHelpers:
+    def test_get_or_create_user_by_telegram(self, db):
+        uid = db.get_or_create_user_by_telegram(12345)
+        again = db.get_or_create_user_by_telegram(12345)
+        assert uid == again
+
+    def test_upsert_user_by_email_is_case_insensitive(self, db):
+        a = db.upsert_user_by_email("Alice@Example.com")
+        b = db.upsert_user_by_email("alice@example.com")
+        c = db.upsert_user_by_email("  alice@example.com  ")
+        assert a == b == c
+
+    def test_set_and_get_user_profile(self, db):
+        uid = db.get_or_create_user_by_telegram(1)
+        assert db.get_user_profile(uid) == ""
+        db.set_user_profile(uid, "I build chess engines.")
+        assert db.get_user_profile(uid) == "I build chess engines."
+
+
+# ---------------------------------------------------------------------------
+# Link codes
+# ---------------------------------------------------------------------------
+
+class TestLinkCodes:
+    def test_create_returns_6_digit_code(self, db):
+        uid = db.upsert_user_by_email("a@b.com")
+        code = db.create_link_code(uid)
+        assert len(code) == 6
+        assert code.isdigit()
+
+    def test_redeem_returns_user_id_then_consumes(self, db):
+        uid = db.upsert_user_by_email("a@b.com")
+        code = db.create_link_code(uid)
+        assert db.redeem_link_code(code) == uid
+        assert db.redeem_link_code(code) is None, "second redemption must fail"
+
+    def test_redeem_returns_none_for_invalid_code(self, db):
+        assert db.redeem_link_code("000000") is None
+
+    def test_one_outstanding_code_per_user(self, db):
+        uid = db.upsert_user_by_email("a@b.com")
+        first = db.create_link_code(uid)
+        second = db.create_link_code(uid)
+        # The first code is replaced by the second
+        assert db.redeem_link_code(first) is None
+        assert db.redeem_link_code(second) == uid
+
+
+# ---------------------------------------------------------------------------
+# link_telegram_to_user merge logic
+# ---------------------------------------------------------------------------
+
+class TestLinkTelegramMerge:
+    def test_moves_items_from_telegram_to_web_user(self, db):
+        web_uid = db.upsert_user_by_email("alice@example.com")
+        tg_uid = db.get_or_create_user_by_telegram(555111)
+        db.save_item(tg_uid, "note", "", "tg note", '{"verdict":"watch"}')
+
+        db.link_telegram_to_user(web_user_id=web_uid, telegram_chat_id=555111)
+
+        assert db.get_user(tg_uid) is None, "orphan tg row deleted"
+        web_items = db.get_all_items(web_uid)
+        assert len(web_items) == 1
+        assert web_items[0]["content"] == "tg note"
+
+    def test_fills_empty_web_profile_from_telegram(self, db):
+        web_uid = db.upsert_user_by_email("alice@example.com")
+        tg_uid = db.get_or_create_user_by_telegram(555111)
+        db.set_user_profile(tg_uid, "I love haiku.")
+
+        db.link_telegram_to_user(web_user_id=web_uid, telegram_chat_id=555111)
+
+        assert db.get_user(web_uid)["profile"] == "I love haiku."
+
+    def test_keeps_web_profile_when_set(self, db):
+        web_uid = db.upsert_user_by_email("alice@example.com")
+        db.set_user_profile(web_uid, "Already set on web.")
+        tg_uid = db.get_or_create_user_by_telegram(555111)
+        db.set_user_profile(tg_uid, "Conflicting tg version.")
+
+        db.link_telegram_to_user(web_user_id=web_uid, telegram_chat_id=555111)
+
+        assert db.get_user(web_uid)["profile"] == "Already set on web."
+
+    def test_attaches_telegram_chat_id(self, db):
+        web_uid = db.upsert_user_by_email("alice@example.com")
+        # No prior tg row at all — just attach
+        db.link_telegram_to_user(web_user_id=web_uid, telegram_chat_id=555111)
+        assert db.get_user(web_uid)["telegram_chat_id"] == 555111
+
+    def test_idempotent_relink(self, db):
+        web_uid = db.upsert_user_by_email("alice@example.com")
+        db.link_telegram_to_user(web_user_id=web_uid, telegram_chat_id=555111)
+        # Second call is a no-op (would raise on conflict otherwise)
+        db.link_telegram_to_user(web_user_id=web_uid, telegram_chat_id=555111)
+        assert db.get_user(web_uid)["telegram_chat_id"] == 555111
+
+    def test_raises_when_already_linked_to_different_chat(self, db):
+        web_uid = db.upsert_user_by_email("alice@example.com")
+        db.link_telegram_to_user(web_user_id=web_uid, telegram_chat_id=555111)
+        with pytest.raises(ValueError, match="already linked"):
+            db.link_telegram_to_user(web_user_id=web_uid, telegram_chat_id=999999)
+
+    def test_raises_when_web_user_not_found(self, db):
+        with pytest.raises(ValueError, match="not found"):
+            db.link_telegram_to_user(web_user_id=999, telegram_chat_id=555111)


### PR DESCRIPTION
## Summary
Step 2 of the unified-identity refactor — adds the backend endpoints the Cloudflare Worker will call once the frontend rewires land. All gated by the existing `x-filter-fyi-secret` header (same trust model as `/api/try`).

Also bootstraps the project's first **pytest** suite.

| Endpoint | Purpose |
|---|---|
| `POST /api/users/upsert` | Email → canonical `users.id` (Worker calls after magic-link verify) |
| `POST /api/library/add` | Signed-in `/api/try`: analyse + save; returns the `/api/try` response shape plus the new `id` |
| `GET /api/library?user_id=…` | Lean list for `/me` (id, source_type, source, verdict, title, created_at) |
| `GET /api/library/{id}?user_id=…` | Full item, scoped to user_id (404 if not owned) |
| `POST /api/claim` | Worker batch-pushes anon rows from D1 into `items` after claim |
| `POST /api/link/start` | Issues a 6-digit code (10-min single-use) stored in new `link_codes` table |

## Telegram
- New `/link <code>` command: user DMs the code from `/me`, bot redeems and merges. The merge moves the existing Telegram-side items onto the web user's row, fills empty `profile` / `api_token` from the Telegram side, then deletes the orphan row. Idempotent; raises if the web user is already linked to a different chat.

## DB
- New `link_codes` table (code PK, user_id FK, expires_at, created_at) + index on expires_at. Created in all three `_init()` branches — fresh, post-migration, and already-migrated.
- New helpers: `create_link_code`, `redeem_link_code`, `link_telegram_to_user`.

## Tests (new)
- `tests/conftest.py` — isolated DATA_DIR per test; FastAPI TestClient fixture with mocked `analyze` and `fetch_url`.
- `tests/test_db.py` — migration from old `profiles` schema, user/item helpers, link codes (single-use, one outstanding per user), `link_telegram_to_user` merge cases (items moved, empty profile filled from tg, web-side wins when set, idempotent re-link, conflict raises).
- `tests/test_api.py` — auth gating, every new endpoint, library shape, 404 for wrong user, claim batch.
- `make test` runs the suite. 30 tests, ~0.6s.

## Test plan

### Pre-merge
- [x] `make test` — all 30 tests green

### Post-deploy (Fly auto-deploys on merge)
- [ ] `flyctl logs` — `_init()` runs cleanly; `link_codes` table created
- [ ] `curl -H x-filter-fyi-secret:\$SECRET -d '{\"email\":\"...\"}' …/api/users/upsert` → `{user_id: N}`
- [ ] `curl -H x-filter-fyi-secret:\$SECRET -d '{\"user_id\":N,\"url\":\"…\"}' …/api/library/add` → verdict + id
- [ ] `curl -H x-filter-fyi-secret:\$SECRET …/api/library?user_id=N` → lean rows
- [ ] `curl -H x-filter-fyi-secret:\$SECRET -d '{\"user_id\":N}' …/api/link/start` → 6-digit code
- [ ] On Telegram (from a second account): `/link <code>` → merge verified by `sqlite3 research.db 'SELECT * FROM users'`

## What's next
Step 3 (frontend): Worker's magic-link verify calls `/api/users/upsert` and stores the returned id in `D1.sessions.user_id`. Separate PR in the frontend repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)