### PR TITLE
Fix: link_telegram_to_user UNIQUE conflict on api_token

### DIFF
--- a/bot/db.py
+++ b/bot/db.py
@@ -367,25 +367,30 @@ def link_telegram_to_user(web_user_id: int, telegram_chat_id: int) -> None:
         if tg and tg["id"] == web_user_id:
             return  # already linked, no-op
 
+        # Always set telegram_chat_id at the end. When a separate tg row exists,
+        # capture its donatable fields, move its items, then DELETE it BEFORE
+        # we copy anything onto the web row — both rows can't hold the same
+        # UNIQUE value (api_token, telegram_chat_id) simultaneously.
+        profile_to_copy = tg["profile"] if tg and not web["profile"] and tg["profile"] else None
+        api_token_to_copy = (
+            tg["api_token"] if tg and not web["api_token"] and tg["api_token"] else None
+        )
+
         if tg:
             conn.execute(
                 "UPDATE items SET user_id = ? WHERE user_id = ?",
                 (web_user_id, tg["id"]),
             )
-            updates: dict[str, str] = {}
-            if not web["profile"] and tg["profile"]:
-                updates["profile"] = tg["profile"]
-            if not web["api_token"] and tg["api_token"]:
-                updates["api_token"] = tg["api_token"]
-            if updates:
-                set_clause = ", ".join(f"{k} = ?" for k in updates)
-                conn.execute(
-                    f"UPDATE users SET {set_clause} WHERE id = ?",
-                    list(updates.values()) + [web_user_id],
-                )
             conn.execute("DELETE FROM users WHERE id = ?", (tg["id"],))
 
+        updates: dict[str, object] = {"telegram_chat_id": telegram_chat_id}
+        if profile_to_copy is not None:
+            updates["profile"] = profile_to_copy
+        if api_token_to_copy is not None:
+            updates["api_token"] = api_token_to_copy
+
+        set_clause = ", ".join(f"{k} = ?" for k in updates)
         conn.execute(
-            "UPDATE users SET telegram_chat_id = ? WHERE id = ?",
-            (telegram_chat_id, web_user_id),
+            f"UPDATE users SET {set_clause} WHERE id = ?",
+            list(updates.values()) + [web_user_id],
         )

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -222,3 +222,30 @@ class TestLinkTelegramMerge:
     def test_raises_when_web_user_not_found(self, db):
         with pytest.raises(ValueError, match="not found"):
             db.link_telegram_to_user(web_user_id=999, telegram_chat_id=555111)
+
+    def test_no_unique_conflict_when_tg_has_api_token_and_web_does_not(self, db):
+        """Regression: prior code UPDATED web.api_token = tg.api_token BEFORE
+        DELETEing tg, briefly violating users.api_token UNIQUE."""
+        web_uid = db.upsert_user_by_email("alice@example.com")
+        tg_uid = db.get_or_create_user_by_telegram(555111)
+        db.set_user_field(tg_uid, api_token="tok_xyz")
+
+        db.link_telegram_to_user(web_user_id=web_uid, telegram_chat_id=555111)
+
+        web_after = db.get_user(web_uid)
+        assert web_after["telegram_chat_id"] == 555111
+        assert web_after["api_token"] == "tok_xyz", "tg-side api_token should have moved over"
+        assert db.get_user(tg_uid) is None, "orphan tg row deleted"
+
+    def test_no_conflict_when_both_have_api_tokens(self, db):
+        """When both rows already have a token, web's wins — tg's is discarded
+        with its row (no UNIQUE violation either)."""
+        web_uid = db.upsert_user_by_email("alice@example.com")
+        db.set_user_field(web_uid, api_token="web_tok")
+        tg_uid = db.get_or_create_user_by_telegram(555111)
+        db.set_user_field(tg_uid, api_token="tg_tok")
+
+        db.link_telegram_to_user(web_user_id=web_uid, telegram_chat_id=555111)
+
+        assert db.get_user(web_uid)["api_token"] == "web_tok"
+        assert db.get_user(tg_uid) is None


### PR DESCRIPTION
## Summary
The `/link` Telegram command was throwing `sqlite3.IntegrityError: UNIQUE constraint failed: users.api_token` when the linker's Telegram-side row had an `api_token` (typical for accounts that existed pre-step-1 migration) and the web row didn't yet.

Root cause: the merge tried to `UPDATE users SET api_token = ?` on the web row *before* deleting the donor tg row. For one statement, both rows held the same token → UNIQUE violation. Transaction rolled back cleanly; no partial state.

## Fix
Capture the donatable fields (`profile`, `api_token`) into locals, **DELETE the tg row first**, then `UPDATE` the web row with the new `telegram_chat_id` and any copied fields in a single statement. The donor is gone before the recipient claims its UNIQUE values.

## Regression tests added
- `test_no_unique_conflict_when_tg_has_api_token_and_web_does_not` — exact repro of today's failure.
- `test_no_conflict_when_both_have_api_tokens` — web's token wins, tg's is discarded with the row.

All 32 tests pass locally (`make test`).

## How to recover after merge
1. Merge + Fly auto-deploy completes.
2. Visit `/me` → click **get a link code** → copy the fresh 6-digit code (the prior code was consumed when the failed attempt ran `redeem_link_code`).
3. In Telegram: `/link <new code>` → bot replies "✓ Linked!" → both surfaces share the same library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)