### PR TITLE
Add GET /api/users/{id} for link-status lookups

### DIFF
--- a/bot/api.py
+++ b/bot/api.py
@@ -21,6 +21,7 @@ from bot.db import (
     delete_item,
     get_all_items,
     get_item,
+    get_user,
     get_user_profile,
     save_item,
     search_items,
@@ -269,6 +270,23 @@ async def user_upsert(req: _UserUpsertRequest, _: None = Depends(_require_try_se
     if not email or "@" not in email:
         raise HTTPException(status_code=400, detail={"error": "invalid-email"})
     return {"user_id": upsert_user_by_email(email)}
+
+
+@router.get("/users/{user_id}")
+async def user_get(user_id: int, _: None = Depends(_require_try_secret)):
+    """Return user identifiers. `api_token` is exposed only as a presence
+    boolean (`has_api_token`) — never the literal token."""
+    row = get_user(user_id)
+    if not row:
+        raise HTTPException(status_code=404, detail={"error": "not-found"})
+    return {
+        "id": row["id"],
+        "email": row["email"],
+        "telegram_chat_id": row["telegram_chat_id"],
+        "has_api_token": bool(row["api_token"]),
+        "profile": row["profile"],
+        "created_at": row["created_at"],
+    }
 
 
 class _LibraryAddRequest(BaseModel):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -38,6 +38,38 @@ class TestUserUpsert:
         assert r.status_code == 400
 
 
+class TestUserGet:
+    def test_returns_user_identifiers_no_api_token_leak(self, client, auth_headers, db):
+        uid = client.post(
+            "/api/users/upsert", json={"email": "alice@example.com"}, headers=auth_headers
+        ).json()["user_id"]
+        db.set_user_field(uid, api_token="secret_token_xyz")
+
+        r = client.get(f"/api/users/{uid}", headers=auth_headers)
+        assert r.status_code == 200
+        body = r.json()
+        assert body["id"] == uid
+        assert body["email"] == "alice@example.com"
+        assert body["telegram_chat_id"] is None
+        assert body["has_api_token"] is True
+        assert "api_token" not in body, "raw token must not leak"
+
+    def test_telegram_chat_id_reflects_linked_state(self, client, auth_headers, db):
+        uid = client.post(
+            "/api/users/upsert", json={"email": "bob@example.com"}, headers=auth_headers
+        ).json()["user_id"]
+        # Not linked yet
+        assert client.get(f"/api/users/{uid}", headers=auth_headers).json()["telegram_chat_id"] is None
+
+        # Link
+        db.link_telegram_to_user(web_user_id=uid, telegram_chat_id=42)
+        assert client.get(f"/api/users/{uid}", headers=auth_headers).json()["telegram_chat_id"] == 42
+
+    def test_404_for_unknown_user(self, client, auth_headers):
+        r = client.get("/api/users/99999", headers=auth_headers)
+        assert r.status_code == 404
+
+
 # ---------------------------------------------------------------------------
 # POST /api/library/add
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Adds the small backend endpoint the frontend will use to show "Telegram linked ✓" on `/me`.

| Endpoint | Returns |
|---|---|
| `GET /api/users/{user_id}` | `{ id, email, telegram_chat_id, has_api_token, profile, created_at }` |

Gated by the same `x-filter-fyi-secret` header as the other Worker-facing endpoints. The literal `api_token` is **never** returned — only a `has_api_token` boolean.

## Tests added
- Returns the expected shape; `api_token` field absent from response.
- `telegram_chat_id` flips from null → set after `link_telegram_to_user` runs.
- 404 for unknown user_id.

All 35 tests green (`make test`).

## What's next
Frontend PR will:
- Call this endpoint in parallel with `GET /api/library` from `handleMe`.
- Add `user.telegram_linked` (boolean) to the `/api/me` Worker response.
- Render " · Telegram linked ✓" after the email on `/me`.

Frontend will skip the indicator gracefully if this endpoint isn't deployed yet, so merge order doesn't matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)