### PR TITLE
YouTube: resilient fetch — description fallback, Whisper for short videos, JS runtime, impersonation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,14 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 # System deps:
 #   ffmpeg     — required by faster-whisper for audio/video decoding
+#   nodejs     — JS runtime yt-dlp uses to solve YouTube's signature challenges
+#                (without one, yt-dlp falls back to a deprecated path that 429s
+#                much more aggressively)
 #   ca-certs   — outbound TLS to Telegram / Anthropic / etc.
 #   curl       — useful for healthcheck debugging
 RUN apt-get update && apt-get install -y --no-install-recommends \
       ffmpeg \
+      nodejs \
       ca-certificates \
       curl \
     && rm -rf /var/lib/apt/lists/*

--- a/bot/fetcher.py
+++ b/bot/fetcher.py
@@ -18,6 +18,13 @@ def _youtube_thumbnail(video_id: str) -> str:
     return f"https://i.ytimg.com/vi/{video_id}/hqdefault.jpg"
 
 
+# Whisper fallback is only attempted for videos short enough that the
+# audio download + transcription has a real chance of completing within the
+# Worker's 25 s timeout on `/api/try` / `/api/library/add`. Long videos fall
+# back to title + uploader + description.
+_WHISPER_FALLBACK_MAX_DURATION_S = 180
+
+
 def _youtube_transcript(url: str) -> dict:
     from youtube_transcript_api import YouTubeTranscriptApi
 
@@ -38,10 +45,32 @@ def _youtube_transcript(url: str) -> dict:
             "image_urls": [thumb],
         }
     except Exception:
-        logger.info(f"No transcript for {video_id}, falling back to yt-dlp description")
-        result = _yt_dlp_extract(url)
-        result.setdefault("image_urls", []).append(thumb)
-        return result
+        logger.info(f"No transcript for {video_id}, falling back to yt-dlp")
+
+    extract = _yt_dlp_extract(url)
+
+    # If yt-dlp also got us a transcript (or extraction died entirely), use what
+    # we have. The Whisper branch only kicks in when we're left with a
+    # description-only answer AND the video is short enough.
+    if extract.get("has_transcript") or not extract.get("text"):
+        extract.setdefault("image_urls", []).append(thumb)
+        return extract
+
+    duration = extract.get("duration") or 0
+    if duration and duration <= _WHISPER_FALLBACK_MAX_DURATION_S:
+        logger.info(
+            f"YouTube {video_id}: no subtitles, trying audio + Whisper "
+            f"(duration {duration}s)"
+        )
+        whisper = _yt_dlp_transcribe(url)
+        if whisper.get("text"):
+            whisper["source_type"] = "youtube"
+            whisper.setdefault("image_urls", []).append(thumb)
+            return whisper
+        logger.info(f"YouTube {video_id}: Whisper fallback also failed, returning description")
+
+    extract.setdefault("image_urls", []).append(thumb)
+    return extract
 
 
 def _tweet_id_from_url(url: str) -> str | None:
@@ -135,34 +164,60 @@ def _fetch_tweet(url: str) -> dict:
 
 
 def _yt_dlp_extract(url: str) -> dict:
-    """Extract metadata + subtitles from a video URL via yt-dlp.
+    """Extract metadata + best-effort subtitles from a video URL via yt-dlp.
 
-    Returns info dict with text/title/source_type; does NOT transcribe audio
-    (use _yt_dlp_transcribe for that).
+    Two-pass: metadata first (cheap, hits a different YouTube endpoint and is
+    much less rate-limited than subtitle download), then a separate subtitle
+    pass whose failures are non-fatal — if YouTube 429s the subtitle download
+    we still return title + uploader + description so the analyser has
+    *something* to work with.
+
+    Returns: text, title, source_type, has_transcript (bool), duration (s).
     """
     import yt_dlp
     import tempfile, os
 
-    ydl_opts = {
-        "quiet": True,
-        "skip_download": True,
-        "ignore_no_formats_error": True,
-        "writesubtitles": True,
-        "writeautomaticsub": True,
-        "subtitleslangs": ["all"],   # grab whatever is available, filter after
-        "subtitlesformat": "vtt",
-        "outtmpl": os.path.join("%(id)s", "%(id)s.%(ext)s"),
-    }
+    # Pass 1: metadata only. No subtitle/audio downloads — far less likely to 429.
+    info = None
+    try:
+        with yt_dlp.YoutubeDL({
+            "quiet": True,
+            "skip_download": True,
+            "writesubtitles": False,
+            "ignore_no_formats_error": True,
+        }) as ydl:
+            info = ydl.extract_info(url, download=False)
+    except Exception as e:
+        logger.warning(f"yt-dlp metadata extract failed for {url}: {e}")
+
+    if not info:
+        return {"text": "", "title": url, "source_type": "unknown", "has_transcript": False, "duration": 0}
+
+    title = info.get("title") or url
+    uploader = info.get("uploader") or info.get("channel") or ""
+    description = info.get("description") or ""
+    duration = int(info.get("duration") or 0)
+    source_type = "youtube" if "vimeo" not in url and "youtube" in url else "video"
+
+    # Pass 2: best-effort subtitle download. A 429 here drops us back to the
+    # description; it does NOT take the whole extract down with it.
+    subtitle_text = ""
     try:
         with tempfile.TemporaryDirectory() as tmpdir:
-            ydl_opts["paths"] = {"home": tmpdir}
-            with yt_dlp.YoutubeDL(ydl_opts) as ydl:
-                info = ydl.extract_info(url, download=True)
-            if not info:
-                raise ValueError("yt-dlp returned no info")
+            sub_opts = {
+                "quiet": True,
+                "skip_download": True,
+                "ignore_no_formats_error": True,
+                "writesubtitles": True,
+                "writeautomaticsub": True,
+                "subtitleslangs": ["en", "en-US", "en-GB"],
+                "subtitlesformat": "vtt",
+                "paths": {"home": tmpdir},
+                "outtmpl": os.path.join("%(id)s", "%(id)s.%(ext)s"),
+            }
+            with yt_dlp.YoutubeDL(sub_opts) as ydl:
+                ydl.download([url])
 
-            # Walk the whole tmpdir — yt-dlp may nest files under a subdirectory
-            subtitle_text = ""
             for dirpath, _, filenames in os.walk(tmpdir):
                 for fname in filenames:
                     if not fname.endswith(".vtt"):
@@ -183,21 +238,21 @@ def _yt_dlp_extract(url: str) -> dict:
                         break
                 if subtitle_text:
                     break
-
-        uploader = info.get("uploader") or info.get("channel") or ""
-        title = info.get("title") or url
-        description = info.get("description") or ""
-
-        if subtitle_text:
-            text = f"{title}\nBy: {uploader}\n\nTranscript:\n{subtitle_text}"
-        else:
-            text = f"{title}\nBy: {uploader}\n\n{description}".strip()
-
-        source_type = "youtube" if "vimeo" not in url and "youtube" in url else "video"
-        return {"text": text[:MAX_CONTENT_CHARS], "title": title, "source_type": source_type}
     except Exception as e:
-        logger.warning(f"yt-dlp failed for {url}: {e}")
-        return {"text": "", "title": url, "source_type": "unknown"}
+        logger.info(f"yt-dlp subtitle download failed for {url} (continuing with description): {e}")
+
+    if subtitle_text:
+        text = f"{title}\nBy: {uploader}\n\nTranscript:\n{subtitle_text}"
+    else:
+        text = f"{title}\nBy: {uploader}\n\n{description}".strip()
+
+    return {
+        "text": text[:MAX_CONTENT_CHARS],
+        "title": title,
+        "source_type": source_type,
+        "has_transcript": bool(subtitle_text),
+        "duration": duration,
+    }
 
 
 def _yt_dlp_transcribe(url: str) -> dict:

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,8 +10,8 @@ requests>=2.31.0
 trafilatura>=1.12.0
 playwright>=1.40.0
 beautifulsoup4>=4.12.0
-yt-dlp>=2026.3.3
-curl_cffi>=0.7.0
+yt-dlp[default]>=2026.3.3
+# curl_cffi (browser impersonation) is pulled in by yt-dlp[default]
 youtube-transcript-api>=1.2.4
 # transcription (requires ffmpeg installed on system)
 faster-whisper>=1.0.0

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -1,0 +1,143 @@
+"""Tests for the YouTube fallback chain in bot.fetcher.
+
+The chain (highest-quality first → cheapest-degraded last):
+  youtube_transcript_api  →  yt-dlp subtitles  →  yt-dlp audio + Whisper
+                                                  (only for short videos)
+                                              →  description-only
+
+These tests mock yt-dlp and youtube_transcript_api so they run offline.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+
+YOUTUBE_URL = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+VIDEO_ID = "dQw4w9WgXcQ"
+
+
+class TestYouTubeFallbackChain:
+    def test_uses_transcript_api_when_available(self):
+        from bot import fetcher
+
+        with patch("youtube_transcript_api.YouTubeTranscriptApi") as TranscriptApi:
+            TranscriptApi.return_value.fetch.return_value = [
+                MagicMock(text="hello"),
+                MagicMock(text="world"),
+            ]
+            result = fetcher._youtube_transcript(YOUTUBE_URL)
+
+        assert "hello world" in result["text"]
+        assert result["source_type"] == "youtube"
+        assert any("ytimg.com" in u for u in result.get("image_urls", []))
+
+    def test_uses_yt_dlp_subtitles_when_transcript_api_fails(self):
+        from bot import fetcher
+
+        with patch("youtube_transcript_api.YouTubeTranscriptApi") as TranscriptApi, \
+             patch.object(fetcher, "_yt_dlp_extract") as extract, \
+             patch.object(fetcher, "_yt_dlp_transcribe") as transcribe:
+            TranscriptApi.return_value.fetch.side_effect = Exception("blocked")
+            extract.return_value = {
+                "text": "Title\nBy: ch\n\nTranscript:\nsubs body",
+                "title": "Title",
+                "source_type": "youtube",
+                "has_transcript": True,
+                "duration": 90,
+            }
+
+            result = fetcher._youtube_transcript(YOUTUBE_URL)
+
+        assert "subs body" in result["text"]
+        assert result["source_type"] == "youtube"
+        transcribe.assert_not_called()  # subtitles succeeded → no Whisper
+
+    def test_falls_back_to_whisper_for_short_video_without_subs(self):
+        from bot import fetcher
+
+        with patch("youtube_transcript_api.YouTubeTranscriptApi") as TranscriptApi, \
+             patch.object(fetcher, "_yt_dlp_extract") as extract, \
+             patch.object(fetcher, "_yt_dlp_transcribe") as transcribe:
+            TranscriptApi.return_value.fetch.side_effect = Exception("blocked")
+            extract.return_value = {
+                "text": "Title\nBy: ch\n\nshort description",
+                "title": "Title",
+                "source_type": "youtube",
+                "has_transcript": False,
+                "duration": 90,  # well under 180s
+            }
+            transcribe.return_value = {
+                "text": "Title\nBy: ch\n\nTranscript:\nspoken words",
+                "title": "Title",
+                "source_type": "video",  # transcribe doesn't know it's YouTube
+            }
+
+            result = fetcher._youtube_transcript(YOUTUBE_URL)
+
+        transcribe.assert_called_once_with(YOUTUBE_URL)
+        assert "spoken words" in result["text"]
+        assert result["source_type"] == "youtube"  # corrected back to youtube
+
+    def test_skips_whisper_for_long_video(self):
+        from bot import fetcher
+
+        with patch("youtube_transcript_api.YouTubeTranscriptApi") as TranscriptApi, \
+             patch.object(fetcher, "_yt_dlp_extract") as extract, \
+             patch.object(fetcher, "_yt_dlp_transcribe") as transcribe:
+            TranscriptApi.return_value.fetch.side_effect = Exception("blocked")
+            extract.return_value = {
+                "text": "Title\nBy: ch\n\nlong description",
+                "title": "Title",
+                "source_type": "youtube",
+                "has_transcript": False,
+                "duration": 1200,  # 20 min — would time out
+            }
+
+            result = fetcher._youtube_transcript(YOUTUBE_URL)
+
+        transcribe.assert_not_called()
+        assert "long description" in result["text"]
+
+    def test_returns_description_when_whisper_fallback_fails(self):
+        from bot import fetcher
+
+        with patch("youtube_transcript_api.YouTubeTranscriptApi") as TranscriptApi, \
+             patch.object(fetcher, "_yt_dlp_extract") as extract, \
+             patch.object(fetcher, "_yt_dlp_transcribe") as transcribe:
+            TranscriptApi.return_value.fetch.side_effect = Exception("blocked")
+            extract.return_value = {
+                "text": "Title\nBy: ch\n\ndescription text",
+                "title": "Title",
+                "source_type": "youtube",
+                "has_transcript": False,
+                "duration": 60,
+            }
+            transcribe.return_value = {"text": "", "title": "Title", "source_type": "unknown"}
+
+            result = fetcher._youtube_transcript(YOUTUBE_URL)
+
+        transcribe.assert_called_once()
+        assert "description text" in result["text"]
+        assert result["source_type"] == "youtube"
+
+    def test_propagates_empty_extract_without_calling_whisper(self):
+        """If yt-dlp extract failed entirely (e.g., 429 on metadata too),
+        don't waste time on Whisper — the audio download would also fail."""
+        from bot import fetcher
+
+        with patch("youtube_transcript_api.YouTubeTranscriptApi") as TranscriptApi, \
+             patch.object(fetcher, "_yt_dlp_extract") as extract, \
+             patch.object(fetcher, "_yt_dlp_transcribe") as transcribe:
+            TranscriptApi.return_value.fetch.side_effect = Exception("blocked")
+            extract.return_value = {
+                "text": "",
+                "title": YOUTUBE_URL,
+                "source_type": "unknown",
+                "has_transcript": False,
+                "duration": 0,
+            }
+
+            result = fetcher._youtube_transcript(YOUTUBE_URL)
+
+        transcribe.assert_not_called()
+        assert result["text"] == ""


### PR DESCRIPTION
## Summary
Bundles four small fixes for the YouTube 429s flagged in Fly logs. Each one is small individually; together they should restore most YouTube URLs to a working state.

| # | Change | Why |
|---|---|---|
| 1 | `_yt_dlp_extract` two-pass: metadata, then subtitles separately. Subtitle errors are non-fatal. Result now carries `has_transcript` + `duration`. | A 429 on the subtitle endpoint shouldn't lose the title + description. |
| 2 | `_youtube_transcript`: when subtitles fail, try `_yt_dlp_transcribe` (audio + Whisper) for videos ≤ 180 s. Longer videos fall back to description. | Audio endpoint is much less aggressively rate-limited; short cutoff keeps round-trip under the Worker's 25 s timeout. |
| 3 | `Dockerfile`: install `nodejs`. | yt-dlp logs `No supported JavaScript runtime could be found` — without one it uses a deprecated path that 429s much more. |
| 4 | `requirements.txt`: `yt-dlp[default]` (was `yt-dlp` + separate `curl_cffi`). | yt-dlp logs `no impersonate target is available` — the `[default]` extras pull in the right curl_cffi build. |

## Tests
6 new in `tests/test_fetcher.py` covering the YouTube fallback chain. **41 tests pass** (`make test`). Test mocks isolate from `yt_dlp` / `youtube-transcript-api` / Whisper so the suite stays offline + fast.

## Expected behaviour after deploy
For the failing URL (`youtube.com/watch?v=LcQz4fiZjfY`):
- youtube-transcript-api still 429s → continues to fall through (logs `No transcript for ...`)
- yt-dlp metadata pass succeeds (different endpoint, less rate-limited)
- yt-dlp subtitle pass may still 429 — but **doesn't kill the extract**
- If video ≤ 180 s: Whisper fallback attempted on the audio (less throttled endpoint)
- Otherwise: returns `title + uploader + description` — analyser produces a verdict from that

## Test plan

### Pre-merge
- [x] `make test` — 41 passed

### Post-deploy
- [ ] `flyctl logs` — the `No supported JavaScript runtime` and `no impersonate target is available` warnings should be gone (nodejs + yt-dlp[default] address those).
- [ ] Submit the previously-failing YouTube URL via Telegram → expect a verdict (from description if it's a long video; from Whisper transcript if short).
- [ ] Submit a short (< 3 min) YouTube URL with no captions → verify the Whisper branch fires in logs (`trying audio + Whisper`).
- [ ] Submit a long (> 30 min) YouTube URL → verify the description-only branch (no Whisper attempted).

## Not in this PR (follow-ups)
- URL → text/transcript caching (you flagged this as a definite next step).
- Cookies-from-browser auth for the truly hostile YouTube IP-block case.
- Async job queue for long videos that exceed the 180 s Whisper cutoff.
- More explicit user-facing messaging when we fall back to description-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)