### PR TITLE
generic fetch: clear Cloudflare challenges via curl_cffi

### DIFF
--- a/bot/fetcher.py
+++ b/bot/fetcher.py
@@ -412,14 +412,19 @@ async def _pdf_fetch(url: str) -> dict:
     return {"text": text[:MAX_CONTENT_CHARS], "title": title, "source_type": "pdf"}
 
 
+def _curl_cffi_get(url: str):
+    """Sync GET with Chrome TLS/HTTP2 impersonation. Clears Cloudflare managed
+    challenges that plain httpx trips on (e.g. blog.cathy-moore.com), and is a
+    drop-in superset for vanilla HTML article fetches."""
+    from curl_cffi import requests as cr
+    return cr.get(url, impersonate="chrome124", timeout=15, allow_redirects=True)
+
+
 async def _generic_fetch(url: str) -> dict:
     try:
-        async with httpx.AsyncClient(follow_redirects=True, timeout=15) as client:
-            resp = await client.get(
-                url,
-                headers={"User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"},
-            )
-            html = resp.text
+        loop = asyncio.get_running_loop()
+        resp = await loop.run_in_executor(None, _curl_cffi_get, url)
+        html = resp.text
     except Exception as e:
         logger.warning(f"Generic fetch failed for {url}: {e}")
         return {"text": "", "title": url, "source_type": "unknown"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,9 @@ trafilatura>=1.12.0
 playwright>=1.40.0
 beautifulsoup4>=4.12.0
 yt-dlp[default]>=2026.3.3
-# curl_cffi (browser impersonation) is pulled in by yt-dlp[default]
+# curl_cffi: Chrome TLS/HTTP2 impersonation — used by _generic_fetch to clear
+# Cloudflare managed challenges. Also a transitive dep of yt-dlp[default].
+curl_cffi>=0.7.0
 youtube-transcript-api>=1.2.4
 # transcription (requires ffmpeg installed on system)
 faster-whisper>=1.0.0


### PR DESCRIPTION
## Summary
- Users hitting `blog.cathy-moore.com/ai-tools-for-instructional-designers` (and other Cloudflare-managed-challenge sites) got the analyzer's `content-blocker` verdict because `httpx` only ever fetched the "Just a moment..." JS-redirect page (403, ~1.5KB) — never the real article.
- Switched `_generic_fetch` to `curl_cffi` with `impersonate="chrome124"`, run in the default executor. Real Chrome TLS+HTTP2 fingerprints clear the challenge.
- Promoted `curl_cffi` from transitive (via `yt-dlp[default]`) to an explicit `requirements.txt` pin so it can't silently disappear.

End-to-end verified on the reported URL: `source_type=article`, title *"Best AI Tools for Instructional Designers"*, 15,078 chars extracted by trafilatura. Existing fetcher tests (9) still pass.

## Test plan
- [x] Deploy to Fly, submit `https://blog.cathy-moore.com/ai-tools-for-instructional-designers` via the web UI — expect an `article` verdict (not `content-blocker`).
- [x] Re-submit a plain article (e.g. anything non-CF) to confirm no regression.
- [ ] Confirm `curl_cffi` is in the built image — first request to a generic URL should not 500 on import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)