### PR TITLE
Authenticate the Telegram webhook with a secret token

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,6 +13,7 @@ Modes (auto-detected from environment):
 import asyncio
 import logging
 import os
+import secrets
 from contextlib import asynccontextmanager
 from datetime import datetime, time as dtime, timedelta, timezone
 from pathlib import Path
@@ -39,6 +40,10 @@ install_sqlite_log_handler()
 
 TOKEN = os.getenv("TELEGRAM_TOKEN")
 WEBHOOK_URL = os.getenv("WEBHOOK_URL")
+# Shared secret echoed by Telegram in the X-Telegram-Bot-Api-Secret-Token header.
+# Without it, anyone who learns the webhook URL could POST forged updates and act
+# as any chat. Required whenever WEBHOOK_URL is set (see lifespan + /webhook).
+WEBHOOK_SECRET = os.getenv("TELEGRAM_WEBHOOK_SECRET")
 
 telegram_app = None
 if TOKEN:
@@ -79,9 +84,20 @@ async def lifespan(app: FastAPI):
     if telegram_app:
         await telegram_app.initialize()
         if WEBHOOK_URL:
-            webhook_endpoint = f"{WEBHOOK_URL.rstrip('/')}/webhook"
-            await telegram_app.bot.set_webhook(webhook_endpoint)
-            logger.info("Telegram webhook set to %s", webhook_endpoint)
+            if not WEBHOOK_SECRET:
+                # Fail closed: registering an unauthenticated webhook would let
+                # anyone forge updates. Don't set it — the bot stays silent
+                # until TELEGRAM_WEBHOOK_SECRET is configured.
+                logger.error(
+                    "WEBHOOK_URL is set but TELEGRAM_WEBHOOK_SECRET is missing — "
+                    "refusing to register an unauthenticated webhook"
+                )
+            else:
+                webhook_endpoint = f"{WEBHOOK_URL.rstrip('/')}/webhook"
+                await telegram_app.bot.set_webhook(
+                    webhook_endpoint, secret_token=WEBHOOK_SECRET
+                )
+                logger.info("Telegram webhook set to %s", webhook_endpoint)
         else:
             # Dev / local: polling as a background task on uvicorn's event loop
             await telegram_app.updater.start_polling(allowed_updates=Update.ALL_TYPES)
@@ -123,10 +139,25 @@ async def serve_ui():
     return FileResponse(_STATIC_DIR / "index.html")
 
 
+def _webhook_secret_ok(provided: str | None) -> bool:
+    """True iff the request carries the configured Telegram secret token.
+
+    Fail closed: if no secret is configured, no request is accepted.
+    """
+    if not WEBHOOK_SECRET:
+        return False
+    return secrets.compare_digest(provided or "", WEBHOOK_SECRET)
+
+
 @app.post("/webhook")
 async def webhook(request: Request) -> Response:
     if not telegram_app or not WEBHOOK_URL:
         return Response(status_code=404)
+    # Reject anything that doesn't echo our secret token — this is the only
+    # thing standing between the public URL and forged Telegram updates.
+    if not _webhook_secret_ok(request.headers.get("X-Telegram-Bot-Api-Secret-Token")):
+        logger.warning("Rejected /webhook call with missing/invalid secret token")
+        return Response(status_code=403)
     data = await request.json()
     update = Update.de_json(data, telegram_app.bot)
     await telegram_app.process_update(update)

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -1,0 +1,78 @@
+"""Tests for Telegram webhook authentication in main.py.
+
+The /webhook route is the one public, unauthenticated-by-default surface on the
+backend, so it must reject any request that doesn't echo our secret token.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def main_mod(monkeypatch):
+    """Import main.py with Telegram disabled at import, then hand it back so
+    tests can monkeypatch the module-level globals the route reads."""
+    # No token at import => build_application() is skipped (no network/app build).
+    monkeypatch.setenv("TELEGRAM_TOKEN", "")
+    import main
+    return main
+
+
+class TestWebhookSecretCheck:
+    def test_correct_token_accepted(self, main_mod, monkeypatch):
+        monkeypatch.setattr(main_mod, "WEBHOOK_SECRET", "s3cret")
+        assert main_mod._webhook_secret_ok("s3cret") is True
+
+    def test_wrong_token_rejected(self, main_mod, monkeypatch):
+        monkeypatch.setattr(main_mod, "WEBHOOK_SECRET", "s3cret")
+        assert main_mod._webhook_secret_ok("nope") is False
+
+    def test_missing_header_rejected(self, main_mod, monkeypatch):
+        monkeypatch.setattr(main_mod, "WEBHOOK_SECRET", "s3cret")
+        assert main_mod._webhook_secret_ok(None) is False
+
+    def test_no_configured_secret_fails_closed(self, main_mod, monkeypatch):
+        monkeypatch.setattr(main_mod, "WEBHOOK_SECRET", None)
+        assert main_mod._webhook_secret_ok("anything") is False
+
+
+class TestWebhookRoute:
+    @pytest.fixture
+    def client(self, main_mod, monkeypatch):
+        # Wire up webhook mode with a stub Telegram app so the route runs.
+        app_stub = MagicMock()
+        app_stub.process_update = AsyncMock()
+        monkeypatch.setattr(main_mod, "telegram_app", app_stub)
+        monkeypatch.setattr(main_mod, "WEBHOOK_URL", "https://example.com")
+        monkeypatch.setattr(main_mod, "WEBHOOK_SECRET", "s3cret")
+        monkeypatch.setattr(main_mod.Update, "de_json", lambda data, bot: {"ok": 1})
+        return TestClient(main_mod.app), app_stub
+
+    def test_valid_secret_processes_update(self, client):
+        c, app_stub = client
+        r = c.post(
+            "/webhook",
+            json={"update_id": 1},
+            headers={"X-Telegram-Bot-Api-Secret-Token": "s3cret"},
+        )
+        assert r.status_code == 200
+        app_stub.process_update.assert_awaited_once()
+
+    def test_invalid_secret_rejected_without_processing(self, client):
+        c, app_stub = client
+        r = c.post(
+            "/webhook",
+            json={"update_id": 1},
+            headers={"X-Telegram-Bot-Api-Secret-Token": "wrong"},
+        )
+        assert r.status_code == 403
+        app_stub.process_update.assert_not_awaited()
+
+    def test_missing_secret_header_rejected(self, client):
+        c, app_stub = client
+        r = c.post("/webhook", json={"update_id": 1})
+        assert r.status_code == 403
+        app_stub.process_update.assert_not_awaited()


### PR DESCRIPTION
## Why
`/webhook` ([main.py](../blob/main/main.py)) processed any POST it received, and `set_webhook` registered no secret. Anyone who discovered the public webhook URL could POST forged Telegram updates and have the bot act as **any** chat.

## What
- Register the webhook with `secret_token=TELEGRAM_WEBHOOK_SECRET`.
- Verify the `X-Telegram-Bot-Api-Secret-Token` header on every `/webhook` call with a constant-time compare.
- **Fail closed:** if `TELEGRAM_WEBHOOK_SECRET` is unset in webhook mode, we refuse to register the webhook (logged as an error) and reject all `/webhook` calls with `403`. No unauthenticated path exists.

## Deploy note
⚠️ Requires a new env var **`TELEGRAM_WEBHOOK_SECRET`** (set as a Fly secret) before/with deploy. Until it's set, the bot won't register its webhook — that's intentional (fail-closed). Generate something high-entropy, e.g. `openssl rand -hex 32`.

## Tests
7 new tests in `tests/test_webhook.py`: the secret comparison (correct / wrong / missing / no-secret-configured) and the route (`200` with valid token, `403` otherwise, no update processed on reject).

🤖 Generated with [Claude Code](https://claude.com/claude-code)