### PR TITLE
DB backup (Litestream) + retention prune + ops docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,12 @@ WORKDIR /app
 
 # Litestream — continuous SQLite backup to object storage. Only activated at
 # runtime when LITESTREAM_REPLICA_URL is set (see docker-entrypoint.sh).
+# TARGETARCH is auto-populated by BuildKit (amd64 on Fly, arm64 on Apple
+# Silicon) and matches Litestream's release naming; the default keeps non-
+# BuildKit builders on amd64 to mirror prod.
 ARG LITESTREAM_VERSION=0.3.13
-RUN curl -fsSL "https://github.com/benbjohnson/litestream/releases/download/v${LITESTREAM_VERSION}/litestream-v${LITESTREAM_VERSION}-linux-amd64.tar.gz" \
+ARG TARGETARCH=amd64
+RUN curl -fsSL "https://github.com/benbjohnson/litestream/releases/download/v${LITESTREAM_VERSION}/litestream-v${LITESTREAM_VERSION}-linux-${TARGETARCH}.tar.gz" \
       | tar -xz -C /usr/local/bin litestream
 
 COPY requirements.txt .

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
+# Litestream — continuous SQLite backup to object storage. Only activated at
+# runtime when LITESTREAM_REPLICA_URL is set (see docker-entrypoint.sh).
+ARG LITESTREAM_VERSION=0.3.13
+RUN curl -fsSL "https://github.com/benbjohnson/litestream/releases/download/v${LITESTREAM_VERSION}/litestream-v${LITESTREAM_VERSION}-linux-amd64.tar.gz" \
+      | tar -xz -C /usr/local/bin litestream
+
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
@@ -29,10 +35,13 @@ RUN playwright install --with-deps chromium \
     && rm -rf /var/lib/apt/lists/*
 
 COPY . .
+RUN chmod +x docker-entrypoint.sh
 
 # DATA_DIR is mounted at runtime (Fly volume). Default keeps local dev working.
 ENV DATA_DIR=/data
 
 EXPOSE 8080
 
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]
+# Entrypoint runs the app under Litestream when LITESTREAM_REPLICA_URL is set,
+# otherwise plain uvicorn (identical to the previous CMD).
+ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/bot/db.py
+++ b/bot/db.py
@@ -445,6 +445,42 @@ def prune_error_log(older_than_iso: str) -> int:
         return cur.rowcount or 0
 
 
+# How long to keep diagnostic error_log rows. The daily scanner only looks back
+# 24h, so anything older is just disk.
+ERROR_LOG_RETENTION_DAYS = 30
+
+
+def _ts(dt) -> str:
+    """Format a datetime to the storage timestamp shape (UTC, no tz suffix)."""
+    return dt.strftime("%Y-%m-%dT%H:%M:%S")
+
+
+def prune_maintenance(now=None) -> dict:
+    """Delete rows nothing needs to keep, to bound unbounded disk growth.
+
+    Idempotent and safe to run repeatedly (e.g. daily). Covers:
+      - error_log older than ERROR_LOG_RETENTION_DAYS
+      - url_cache rows past their TTL
+      - link_codes that have already expired (unredeemed)
+    `now` is injectable for tests. Returns per-table delete counts.
+    """
+    from datetime import datetime, timedelta, timezone
+
+    now = now or datetime.now(timezone.utc)
+    err_cutoff = _ts(now - timedelta(days=ERROR_LOG_RETENTION_DAYS))
+    cache_cutoff = _ts(now - timedelta(seconds=URL_CACHE_TTL_SECONDS))
+    now_str = _ts(now)
+    with _get_conn() as conn:
+        errors = conn.execute("DELETE FROM error_log WHERE ts < ?", (err_cutoff,)).rowcount or 0
+        cache = conn.execute(
+            "DELETE FROM url_cache WHERE fetched_at < ?", (cache_cutoff,)
+        ).rowcount or 0
+        codes = conn.execute(
+            "DELETE FROM link_codes WHERE expires_at < ?", (now_str,)
+        ).rowcount or 0
+    return {"error_log": errors, "url_cache": cache, "link_codes": codes}
+
+
 def link_telegram_to_user(web_user_id: int, telegram_chat_id: int) -> None:
     """Stitch a Telegram chat onto the given web user. Idempotent.
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Entrypoint that optionally wraps the app in Litestream for continuous SQLite
+# backup. If LITESTREAM_REPLICA_URL is unset (local dev, un-provisioned envs),
+# we exec the app directly so behaviour is identical to before.
+set -e
+
+APP_CMD="uvicorn main:app --host 0.0.0.0 --port 8080"
+
+if [ -z "$LITESTREAM_REPLICA_URL" ]; then
+  echo "[entrypoint] LITESTREAM_REPLICA_URL unset — starting without backup"
+  exec $APP_CMD
+fi
+
+CONFIG=/app/litestream.yml
+DB_PATH="${DATA_DIR:-/data}/research.db"
+
+# Restore from the replica if this volume has no database yet (fresh machine or
+# recovered volume). No-op when a replica doesn't exist; never clobbers a DB
+# that's already present (-if-db-not-exists).
+echo "[entrypoint] attempting Litestream restore (if needed) for $DB_PATH"
+litestream restore -config "$CONFIG" -if-db-not-exists -if-replica-exists "$DB_PATH" || \
+  echo "[entrypoint] restore skipped/failed (continuing)"
+
+echo "[entrypoint] starting app under Litestream replication"
+exec litestream replicate -config "$CONFIG" -exec "$APP_CMD"

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,0 +1,81 @@
+# Operations
+
+Runtime, durability, and maintenance notes for the filter.fyi backend (Fly).
+
+## Data durability — backups
+
+The canonical data (users, items, link codes) is a single SQLite file at
+`${DATA_DIR}/research.db` on a **single Fly volume**. A volume is attached to
+one machine at a time and is **not** itself a backup. Two layers protect it:
+
+### 1. Fly volume snapshots (baseline)
+Fly takes automatic daily snapshots of the volume (default 5-day retention).
+Verify / extend retention:
+
+```sh
+fly volumes list
+fly volumes snapshots list <volume-id>
+fly volumes update <volume-id> --snapshot-retention 30
+```
+
+Snapshots are coarse (up to ~24h of data loss, not point-in-time).
+
+### 2. Litestream continuous replication (recommended, point-in-time)
+[Litestream](https://litestream.io) streams the SQLite WAL to object storage,
+giving near-real-time, point-in-time recovery. It's baked into the image but
+**only runs when `LITESTREAM_REPLICA_URL` is set** — otherwise the container
+starts plain uvicorn (see `docker-entrypoint.sh`), so local dev is unaffected.
+
+To enable, provision an S3-compatible bucket (Fly's Tigris, Backblaze B2,
+Cloudflare R2, …) and set Fly secrets:
+
+```sh
+fly secrets set \
+  LITESTREAM_REPLICA_URL="s3://<bucket>/filter-fyi-backend" \
+  LITESTREAM_ACCESS_KEY_ID="<key>" \
+  LITESTREAM_SECRET_ACCESS_KEY="<secret>"
+# For non-AWS endpoints also set the endpoint, e.g. Tigris:
+#   LITESTREAM_REPLICA_URL="s3://<bucket>/filter-fyi-backend?endpoint=https://fly.storage.tigris.dev"
+```
+
+Config: [`litestream.yml`](../litestream.yml) (30-day retention, daily
+snapshots). On boot the entrypoint runs `litestream restore -if-db-not-exists`,
+so a fresh/recovered volume self-heals from the replica.
+
+**Restore manually:**
+```sh
+litestream restore -config litestream.yml -o /data/research.db "$LITESTREAM_REPLICA_URL"
+```
+
+> Test a restore into a throwaway path before relying on it.
+
+## Disk growth & retention
+
+The Fly volume is fixed-size; unbounded tables will eventually fill it and take
+the app down. `bot.db.prune_maintenance()` deletes rows nothing needs:
+- `error_log` older than 30 days (the scanner only looks back 24h)
+- `url_cache` past its TTL
+- expired, unredeemed `link_codes`
+
+Run it daily — either a scheduled Fly machine or cron:
+```sh
+python -m scripts.prune
+```
+
+Stored media (transcribed mp4s under `data/files/`) is the other growth vector;
+files for deleted users are removed by account erasure, but monitor disk usage:
+```sh
+fly volumes list           # check % used
+```
+
+## Required environment / secrets
+
+| Var | Purpose |
+| --- | --- |
+| `FILTER_FYI_TRY_SECRET` | Shared secret with the Cloudflare Worker (must match) |
+| `TELEGRAM_TOKEN` | Telegram bot token (omit to run web-only) |
+| `WEBHOOK_URL` | Public base URL for Telegram webhook mode |
+| `TELEGRAM_WEBHOOK_SECRET` | Required in webhook mode — verifies inbound updates |
+| `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` | LLM provider (Anthropic preferred) |
+| `LITESTREAM_REPLICA_URL` (+ keys) | Enables continuous backup (optional but recommended) |
+| `SCAN_ERRORS_ENABLED`, `GH_APP_*` | Daily error-log → GitHub-issue scanner |

--- a/litestream.yml
+++ b/litestream.yml
@@ -1,0 +1,18 @@
+# Litestream continuous backup for the SQLite database on the Fly volume.
+#
+# Active only when LITESTREAM_REPLICA_URL is set — docker-entrypoint.sh runs
+# the app under `litestream replicate` when it is, and plain uvicorn when it
+# isn't (so local dev and un-provisioned environments are unaffected).
+#
+# LITESTREAM_REPLICA_URL example (S3-compatible, e.g. Tigris/Backblaze/R2):
+#   s3://my-bucket/filter-fyi-backend
+# with LITESTREAM_ACCESS_KEY_ID / LITESTREAM_SECRET_ACCESS_KEY in the env.
+#
+# Docs: https://litestream.io/reference/config/
+dbs:
+  - path: ${DATA_DIR}/research.db
+    replicas:
+      - url: ${LITESTREAM_REPLICA_URL}
+        # Keep ~30 days of point-in-time history.
+        retention: 720h
+        snapshot-interval: 24h

--- a/scripts/prune.py
+++ b/scripts/prune.py
@@ -1,0 +1,29 @@
+"""Delete rows nothing needs to keep, to bound disk growth on the Fly volume.
+
+Run periodically (e.g. a daily Fly scheduled machine or cron):
+
+    python -m scripts.prune
+
+Prunes old error_log rows, expired url_cache entries, and expired link codes.
+Safe to run repeatedly. See bot.db.prune_maintenance for the policy.
+"""
+from __future__ import annotations
+
+import logging
+
+from bot.db import prune_maintenance
+
+logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    counts = prune_maintenance()
+    logger.info(
+        "prune: error_log=%(error_log)s url_cache=%(url_cache)s link_codes=%(link_codes)s",
+        counts,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -300,3 +300,54 @@ class TestUrlCache:
             db.get_cached_fetch("https://example.com/a", max_age_seconds=3600)["text"]
             == "stale"
         )
+
+
+class TestPruneMaintenance:
+    """prune_maintenance() bounds disk growth without touching live rows."""
+
+    def test_prunes_old_rows_only(self, db):
+        from datetime import datetime, timezone
+
+        OLD = "2000-01-01T00:00:00"   # well past every retention window
+        NEW = "2999-01-01T00:00:00"   # far future — always kept
+
+        with db._get_conn() as conn:
+            conn.execute(
+                "INSERT INTO error_log (ts, logger, level, message) VALUES (?, 'x', 'WARNING', 'old')",
+                (OLD,),
+            )
+            conn.execute(
+                "INSERT INTO error_log (ts, logger, level, message) VALUES (?, 'x', 'WARNING', 'new')",
+                (NEW,),
+            )
+            conn.execute(
+                "INSERT INTO url_cache (url, payload, fetched_at) VALUES ('https://old', '{}', ?)",
+                (OLD,),
+            )
+            conn.execute(
+                "INSERT INTO url_cache (url, payload, fetched_at) VALUES ('https://new', '{}', ?)",
+                (NEW,),
+            )
+            uid = conn.execute("INSERT INTO users (email) VALUES ('a@b.com')").lastrowid
+            conn.execute(
+                "INSERT INTO link_codes (code, user_id, expires_at) VALUES ('OLD', ?, ?)",
+                (uid, OLD),
+            )
+            conn.execute(
+                "INSERT INTO link_codes (code, user_id, expires_at) VALUES ('NEW', ?, ?)",
+                (uid, NEW),
+            )
+
+        counts = db.prune_maintenance(now=datetime(2026, 5, 20, tzinfo=timezone.utc))
+        assert counts == {"error_log": 1, "url_cache": 1, "link_codes": 1}
+
+        with db._get_conn() as conn:
+            assert [r["message"] for r in conn.execute("SELECT message FROM error_log")] == ["new"]
+            assert [r["url"] for r in conn.execute("SELECT url FROM url_cache")] == ["https://new"]
+            assert [r["code"] for r in conn.execute("SELECT code FROM link_codes")] == ["NEW"]
+
+    def test_idempotent_on_empty(self, db):
+        from datetime import datetime, timezone
+
+        counts = db.prune_maintenance(now=datetime(2026, 5, 20, tzinfo=timezone.utc))
+        assert counts == {"error_log": 0, "url_cache": 0, "link_codes": 0}


### PR DESCRIPTION
## Why
Two pre-launch durability gaps:
1. The canonical SQLite DB (`users`, `items`, …) lives on **one Fly volume with no real backup** — volume loss = total data loss.
2. `error_log`, `url_cache`, and expired `link_codes` grow without bound on a fixed-size volume.

## What

### Backups — Litestream (opt-in, zero-impact when unset)
- Litestream is baked into the image. `docker-entrypoint.sh` runs the app under `litestream replicate` **only when `LITESTREAM_REPLICA_URL` is set**; otherwise it execs plain uvicorn — identical to the old `CMD`, so local dev and un-provisioned envs are unaffected.
- On boot it runs `litestream restore -if-db-not-exists`, so a fresh or recovered volume self-heals from the replica.
- `litestream.yml`: 30-day point-in-time retention, daily snapshots.

### Retention
- `db.prune_maintenance()` deletes `error_log` >30d, `url_cache` past TTL, and expired `link_codes`. Run daily via `python -m scripts.prune` (scheduled Fly machine / cron).

### Docs
- `docs/OPERATIONS.md`: backups + manual restore, Fly volume snapshots, disk monitoring, and the required env/secrets matrix.

## Deploy notes
- **No change** to current behaviour until you provision a bucket and set `LITESTREAM_REPLICA_URL` (+ access keys) as Fly secrets — see OPERATIONS.md.
- The Dockerfile now uses `ENTRYPOINT` (the script) instead of `CMD`. The no-replica path runs the exact same uvicorn command.
- Schedule `python -m scripts.prune` daily (not wired into the app process, to keep this decoupled from the webhook PR's `main.py` changes).

## Tests
`prune_maintenance` covered for old-rows-only + idempotency on empty. Full suite green (60 on this branch).

⚠️ Couldn't build the Docker image in this environment — the Litestream download URL / version and the entrypoint were checked by hand and `sh -n`. Worth one local `docker build` before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)