### PR TITLE
Two-mode experiments: quick_win + bigger_play

### DIFF
--- a/bot/analyzer.py
+++ b/bot/analyzer.py
@@ -36,10 +36,15 @@ ANALYSIS_FIELDS = (
     "main_idea",
     "why_it_matters",
     "category",
-    "suggested_experiment",
+    "quick_win",
+    "bigger_play",
     "time_required",
     "verdict",
 )
+
+# Older stored items used a single `suggested_experiment`. Kept as a constant so
+# renderers can fall back to it; new analyses populate quick_win + bigger_play.
+LEGACY_EXPERIMENT_FIELD = "suggested_experiment"
 
 VERDICTS = ("watch", "skim", "skip")
 
@@ -58,9 +63,21 @@ _TOOL_SCHEMA = {
             "type": "string",
             "description": "Short topic tag (kebab-case), e.g. 'ai-engineering', 'productivity', 'crypto-trading'.",
         },
-        "suggested_experiment": {
+        "quick_win": {
             "type": "string",
-            "description": "A concrete next step the user could try in under a day.",
+            "description": (
+                "A concrete, scoped action this person can finish in 30–90 minutes "
+                "THIS WEEKEND — low activation energy, no setup marathon. Specific to "
+                "their situation, not generic advice."
+            ),
+        },
+        "bigger_play": {
+            "type": "string",
+            "description": (
+                "A more ambitious multi-session/multi-week project for when they're "
+                "ready to commit — the deeper arc that builds real capability. Make "
+                "the difference from the quick win clear."
+            ),
         },
         "time_required": {
             "type": "string",
@@ -97,7 +114,12 @@ DEFAULT_PROFILE = (
 
 _PROMPT = """You are my personal AI research analyst.
 {profile_block}
-Analyze the following content and produce a structured analysis covering the required fields. Be concrete and specific to this person.
+Analyze the following content and produce a structured analysis covering the required fields. Be concrete and specific to this person — `why_it_matters` should speak to their situation, not give generic advice.
+
+For the action, give TWO distinct tiers, both grounded in this content:
+- `quick_win`: something they can actually finish in 30–90 minutes this weekend (low activation energy).
+- `bigger_play`: the more ambitious multi-week arc for when they're ready to commit.
+Make the difference between the two obvious; don't just restate one as the other.
 
 CONTENT:
 {text}"""
@@ -129,7 +151,7 @@ def _normalize(raw: dict) -> dict:
 
 
 def analyze(text: str, user_id: int | None = None) -> dict:
-    """Returns a dict with keys: main_idea, why_it_matters, category, suggested_experiment, time_required, verdict."""
+    """Returns a dict with keys: main_idea, why_it_matters, category, quick_win, bigger_play, time_required, verdict."""
     profile = _load_profile(user_id)
     profile_block = f"\nAbout the person you are analysing for:\n{profile}\n" if profile else ""
     prompt = _PROMPT.format(profile_block=profile_block, text=text)
@@ -276,7 +298,9 @@ _LEGACY_FIELD_LABELS = {
     "main_idea": "Main idea",
     "why_it_matters": "Why it matters",
     "category": "Category",
-    "suggested_experiment": "Suggested experiment",
+    "quick_win": "Quick win (30–90 min)",
+    "bigger_play": "Bigger play (when you're ready)",
+    "suggested_experiment": "Suggested experiment",  # legacy items
     "time_required": "Time required to explore",
     "verdict": "Verdict",
 }

--- a/bot/formatting.py
+++ b/bot/formatting.py
@@ -7,7 +7,9 @@ _SECTION_EMOJIS = {
     "main_idea": "💡",
     "why_it_matters": "🎯",
     "category": "🏷",
-    "suggested_experiment": "🧪",
+    "quick_win": "⚡",
+    "bigger_play": "🚀",
+    "suggested_experiment": "🧪",  # legacy rows
     "time_required": "⏱",
     "verdict": "🧭",
 }
@@ -16,7 +18,9 @@ _FIELD_LABELS = {
     "main_idea": "Main idea",
     "why_it_matters": "Why it matters",
     "category": "Category",
-    "suggested_experiment": "Suggested experiment",
+    "quick_win": "Quick win (30–90 min)",
+    "bigger_play": "Bigger play (when you're ready)",
+    "suggested_experiment": "Suggested experiment",  # legacy rows
     "time_required": "Time required to explore",
     "verdict": "Verdict",
 }
@@ -57,6 +61,8 @@ _LEGACY_LABEL_LOOKUP = {
     "main idea": "main_idea",
     "why it matters": "why_it_matters",
     "category": "category",
+    "quick win": "quick_win",
+    "bigger play": "bigger_play",
     "suggested experiment": "suggested_experiment",
     "time required to explore": "time_required",
     "verdict": "verdict",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,7 +62,8 @@ def client(monkeypatch):
             "main_idea": "RAG = retrieval-augmented generation.",
             "why_it_matters": "Practical AI pattern.",
             "category": "ai-engineering",
-            "suggested_experiment": "Try a small RAG demo.",
+            "quick_win": "Wire up a 20-doc RAG demo this afternoon.",
+            "bigger_play": "Build an evaluated RAG pipeline over your own corpus.",
             "time_required": "10 min read",
             "verdict": "watch",
         }

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -31,3 +31,26 @@ class TestSummarizeContent:
         assert small == 512                                     # floor
         assert large == analyzer._SUMMARY_MAX_OUTPUT_TOKENS     # cap
         assert small < large
+
+
+class TestNormalizeTwoModeExperiment:
+    def test_keeps_quick_win_and_bigger_play(self):
+        from bot import analyzer
+
+        out = analyzer._normalize({
+            "main_idea": "x", "why_it_matters": "y", "category": "c",
+            "quick_win": "do this in an hour", "bigger_play": "the multi-week arc",
+            "time_required": "10 min", "verdict": "watch",
+        })
+        assert out["quick_win"] == "do this in an hour"
+        assert out["bigger_play"] == "the multi-week arc"
+        assert "suggested_experiment" not in out  # old field dropped from new schema
+        assert set(out.keys()) == set(analyzer.ANALYSIS_FIELDS)
+
+    def test_missing_fields_default_to_empty(self):
+        from bot import analyzer
+
+        out = analyzer._normalize({"verdict": "skip"})
+        assert out["quick_win"] == ""
+        assert out["bigger_play"] == ""
+        assert out["verdict"] == "skip"


### PR DESCRIPTION
## Why
The "Why it matters" + experiment is the verdict card's secret weapon — but a single `suggested_experiment` often described **4–6 weeks of work**. That's a project plan, not a "try this," so it risks the same "I'll get to it" fate as the original content. There's a real difference between **activation energy** and **commitment**.

## What
Split the experiment into two tiers in the analysis schema:
- **`quick_win`** — a scoped action finishable in **30–90 minutes this weekend**.
- **`bigger_play`** — the **multi-week arc** for when they're ready to commit.

The tool-schema descriptions and the prompt both instruct the model to produce both and make the difference obvious (not restate one as the other).

## Back-compat
- `ANALYSIS_FIELDS` now carries `quick_win` + `bigger_play`; `suggested_experiment` is kept as `LEGACY_EXPERIMENT_FIELD` and in the Telegram/plain-text label + lookup maps so **older stored rows still render**.
- New analyses populate the two new fields; we don't migrate old rows.

## Tests
`_normalize` keeps both fields and drops the legacy key; missing fields default to empty. Full suite: **110 pass**.

## Paired frontend PR
The verdict card + library renderers (filter.fyi) render the two tiers with a fallback to the old single field — separate PR; deploy this backend first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)