### PR TITLE
Add async job flow for web URL analysis to fix Worker timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,9 +175,49 @@ Key endpoints (all under `/api`):
 | `POST /api/ingest/url` | Ingest a URL |
 | `POST /api/ingest/file` | Upload and ingest a file |
 
-### Public `/api/try` (anonymous)
+### Public API (anonymous)
 
-Used by the [filter.fyi](https://filter.fyi) landing page so anonymous visitors can submit a URL and get a verdict without signing up. Authenticated via a shared secret rather than a user token:
+Used by the [filter.fyi](https://filter.fyi) landing page so anonymous visitors can submit a URL and get a verdict without signing up. All endpoints authenticated via a shared secret (`x-filter-fyi-secret`) rather than a user token.
+
+#### Async job API (current)
+
+The Worker uses a two-step async flow to avoid Cloudflare's 25s upstream timeout:
+
+**Step 1 — start a job**
+
+```
+POST /api/job
+content-type: application/json
+x-filter-fyi-secret: <FILTER_FYI_TRY_SECRET>
+
+{ "url": "https://example.com/post" }
+```
+
+Response (202):
+
+```json
+{ "job_id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" }
+```
+
+The backend creates a DB row and immediately returns; the actual fetch → summarise → analyse pipeline runs as a background task.
+
+**Step 2 — poll for result**
+
+```
+GET /api/job/<job_id>
+x-filter-fyi-secret: <FILTER_FYI_TRY_SECRET>
+```
+
+| Response | Meaning |
+|----------|---------|
+| `{"status":"pending"}` | Still running |
+| `{"status":"done","result":"<JSON string>"}` | Complete — `result` is the same shape as the `/api/try` response below |
+| `{"status":"error","error":"<code>"}` | Failed — same error codes as `/api/try` |
+| 404 | Unknown or expired job (TTL: 1 hour) |
+
+#### Legacy sync endpoint
+
+`POST /api/try` is still active for backward compatibility but is no longer used by the Worker. It executes fetch + summarise + analyse synchronously, which can exceed the Worker timeout for slow pages.
 
 ```
 POST /api/try
@@ -187,7 +227,7 @@ x-filter-fyi-secret: <FILTER_FYI_TRY_SECRET>
 { "url": "https://example.com/post" }
 ```
 
-Response shape (the contract the Cloudflare Worker consumes):
+Response shape:
 
 ```jsonc
 {
@@ -218,7 +258,7 @@ Error responses (Worker maps these to user-friendly notices):
 | 502    | `{"error":"fetch-failed"}`      | Upstream fetch crashed                      |
 | 502    | `{"error":"analyze-failed"}`    | LLM call crashed                            |
 
-The endpoint is **stateless**: nothing is persisted to the bot's SQLite. The Worker is the system of record for anonymous tries (D1 `summaries` table, keyed by `anon_id` for later claim-on-signup).
+Both endpoints are **stateless**: nothing is persisted to the bot's SQLite. The Worker is the system of record for anonymous tries (D1 `anon_summaries` table, keyed by `anon_id` for later claim-on-signup).
 
 ## Deployment (Fly.io)
 

--- a/bot/api.py
+++ b/bot/api.py
@@ -1,3 +1,4 @@
+import asyncio
 import base64
 import io
 import json
@@ -5,6 +6,7 @@ import logging
 import os
 import secrets
 import tempfile
+import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 from urllib.parse import urlparse
@@ -20,16 +22,20 @@ from bot.fetch_errors import user_message as fetch_error_message
 from bot.db import (
     FEEDBACK_SIGNALS,
     LINK_CODE_TTL_SECONDS,
+    create_job,
     create_link_code,
     delete_item,
     delete_user,
     get_all_items,
     get_item,
+    get_job_record,
     get_user,
     get_user_profile,
     record_feedback,
     save_item,
     search_items,
+    set_job_done,
+    set_job_error,
     set_user_profile,
     upsert_user_by_email,
 )
@@ -40,6 +46,10 @@ from bot.transcriber import transcribe
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api")
+
+# Keeps references to running background tasks alive until they complete.
+# Without this, Python's GC may collect the task before it finishes.
+_background_tasks: set[asyncio.Task] = set()
 
 # Preview length sent to the Worker — keeps the payload compact while still
 # giving the UI something to render. The full extracted text only ever exists
@@ -553,6 +563,120 @@ async def library_delete(item_id: int, user_id: int, _: None = Depends(_require_
     if not get_item(item_id, user_id):
         raise HTTPException(status_code=404, detail={"error": "not-found"})
     delete_item(item_id, user_id)
+
+
+class _JobRequest(BaseModel):
+    url: str
+    user_id: int | None = None
+    user_note: str = ""
+
+
+@router.post("/job", status_code=202)
+async def start_job(req: _JobRequest, _: None = Depends(_require_try_secret)):
+    """Start an async analysis job and return a job_id immediately.
+
+    The Worker calls this instead of /api/try or /api/library/add. The browser
+    polls GET /api/job/:id until status → 'done' or 'error'. The background
+    task runs fetch → summarize → analyze(summary) in sequence; for signed-in
+    users it also saves the item to the backend DB.
+    """
+    url = (req.url or "").strip()
+    if not _is_http_url(url):
+        raise HTTPException(status_code=400, detail={"error": "invalid-url"})
+
+    job_id = str(uuid.uuid4())
+    create_job(job_id)
+
+    task = asyncio.create_task(_run_job(job_id, url, req.user_id, req.user_note))
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
+
+    return {"job_id": job_id}
+
+
+async def _run_job(job_id: str, url: str, user_id: int | None, user_note: str) -> None:
+    """Background task: fetch → summarize → analyze(summary) → optionally save."""
+    try:
+        try:
+            fetched = await fetch_url(url)
+        except Exception:
+            logger.exception("job %s: fetch_url crashed for %s", job_id, url)
+            set_job_error(job_id, "fetch-failed")
+            return
+
+        text = (fetched.get("text") or "").strip()
+        source_type = fetched.get("source_type") or "article"
+
+        if not text:
+            reason = fetched.get("reason")
+            if source_type in _VIDEO_SOURCE_TYPES:
+                set_job_error(job_id, "no-transcript")
+            else:
+                set_job_error(job_id, "extraction-failed")
+            return
+
+        loop = asyncio.get_running_loop()
+
+        # Summarise first — the summary is the canonical stored representation
+        # and the basis for the analysis verdict.
+        try:
+            summary = await loop.run_in_executor(None, lambda: summarize_content(text))
+        except Exception:
+            logger.exception("job %s: summarize_content crashed", job_id)
+            summary = text[:TRY_PREVIEW_CHARS]
+
+        try:
+            analysis = await loop.run_in_executor(None, lambda: analyze(summary, user_id))
+        except Exception:
+            logger.exception("job %s: analyze crashed", job_id)
+            set_job_error(job_id, "analyze-failed")
+            return
+
+        saved_id: int | None = None
+        if user_id is not None:
+            saved_id = save_item(
+                user_id=user_id,
+                source_type=source_type,
+                source=url,
+                content=summary,
+                analysis=to_json_str(analysis),
+                user_note=user_note,
+            )
+
+        verdict = analysis.pop("verdict", "skim")
+        result: dict = {
+            "url": url,
+            "title": fetched.get("title") or url,
+            "source_type": source_type,
+            "image_urls": fetched.get("image_urls") or [],
+            "content_preview": summary[:TRY_PREVIEW_CHARS],
+            "verdict": verdict,
+            "analysis": analysis,
+        }
+        if saved_id is not None:
+            result["id"] = saved_id
+
+        set_job_done(job_id, result)
+    except Exception:
+        logger.exception("job %s: unexpected failure", job_id)
+        set_job_error(job_id, "internal-error")
+
+
+@router.get("/job/{job_id}")
+async def get_job_status(job_id: str, _: None = Depends(_require_try_secret)):
+    """Poll for an async job's result."""
+    job = get_job_record(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail={"error": "not-found"})
+    if job["status"] == "done":
+        try:
+            result = json.loads(job["result"])
+        except Exception:
+            result = None
+        return {"status": "done", "result": result}
+    if job["status"] == "error":
+        return {"status": "error", "error": job["error"]}
+    return {"status": "pending"}
 
 
 class _ClaimRow(BaseModel):

--- a/bot/db.py
+++ b/bot/db.py
@@ -102,7 +102,25 @@ _CREATE_INDEXES_SQL = [
     "CREATE INDEX IF NOT EXISTS idx_error_log_fingerprint ON error_log(fingerprint)",
     "CREATE INDEX IF NOT EXISTS idx_feedback_user ON feedback(user_id, created_at DESC)",
     "CREATE INDEX IF NOT EXISTS idx_feedback_item ON feedback(item_id)",
+    "CREATE INDEX IF NOT EXISTS idx_jobs_updated_at ON jobs(updated_at DESC)",
 ]
+
+# Short-lived job records for the async analysis flow. The Worker starts a job
+# and returns immediately; the browser polls until status → 'done' or 'error'.
+_CREATE_JOBS_SQL = """\
+CREATE TABLE IF NOT EXISTS jobs (
+    id         TEXT PRIMARY KEY,
+    status     TEXT NOT NULL DEFAULT 'pending',
+    result     TEXT NOT NULL DEFAULT '',
+    error      TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%S', 'now')),
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%S', 'now'))
+)"""
+
+# Retain terminal jobs for 1 hour — long enough for any in-flight poll to
+# retrieve its result. Pending jobs stay until they resolve or the server
+# restarts (the frontend times out its own polling after ~2 min).
+JOB_RETENTION_SECONDS = 3_600
 
 # Allowed feedback signals. Explicit taps + cheap implicit proxies. Kept as an
 # allowlist so the data stays clean enough to learn from.
@@ -196,6 +214,7 @@ def _init() -> None:
         conn.execute(_CREATE_URL_CACHE_SQL)
         conn.execute(_CREATE_ERROR_LOG_SQL)
         conn.execute(_CREATE_FEEDBACK_SQL)
+        conn.execute(_CREATE_JOBS_SQL)
         for stmt in _CREATE_INDEXES_SQL:
             conn.execute(stmt)
 
@@ -324,13 +343,14 @@ def save_item(
     user_note: str = "",
     *,
     file_path: str = "",
-) -> None:
+) -> int:
     with _get_conn() as conn:
-        conn.execute(
+        cur = conn.execute(
             "INSERT INTO items (user_id, source_type, source, content, "
             "analysis, user_note, file_path) VALUES (?, ?, ?, ?, ?, ?, ?)",
             (user_id, source_type, source, content, analysis, user_note, file_path),
         )
+        return cur.lastrowid
 
 
 _ITEM_COLS = (
@@ -539,6 +559,7 @@ def prune_maintenance(now=None) -> dict:
     err_cutoff = _ts(now - timedelta(days=ERROR_LOG_RETENTION_DAYS))
     cache_cutoff = _ts(now - timedelta(seconds=URL_CACHE_TTL_SECONDS))
     now_str = _ts(now)
+    jobs_cutoff = _ts(now - timedelta(seconds=JOB_RETENTION_SECONDS))
     with _get_conn() as conn:
         errors = conn.execute("DELETE FROM error_log WHERE ts < ?", (err_cutoff,)).rowcount or 0
         cache = conn.execute(
@@ -547,8 +568,51 @@ def prune_maintenance(now=None) -> dict:
         codes = conn.execute(
             "DELETE FROM link_codes WHERE expires_at < ?", (now_str,)
         ).rowcount or 0
-    return {"error_log": errors, "url_cache": cache, "link_codes": codes}
+        # Only prune terminal states — pending jobs may still have a running task.
+        jobs = conn.execute(
+            "DELETE FROM jobs WHERE status != 'pending' AND updated_at < ?",
+            (jobs_cutoff,),
+        ).rowcount or 0
+    return {"error_log": errors, "url_cache": cache, "link_codes": codes, "jobs": jobs}
 
+
+# ---------------------------------------------------------------------------
+# Async jobs
+# ---------------------------------------------------------------------------
+
+def create_job(job_id: str) -> None:
+    with _get_conn() as conn:
+        conn.execute("INSERT INTO jobs (id) VALUES (?)", (job_id,))
+
+
+def set_job_done(job_id: str, result: dict) -> None:
+    body = json.dumps(result, ensure_ascii=False)
+    with _get_conn() as conn:
+        conn.execute(
+            "UPDATE jobs SET status = 'done', result = ?, updated_at = ? WHERE id = ?",
+            (body, _utcnow_iso(), job_id),
+        )
+
+
+def set_job_error(job_id: str, error: str) -> None:
+    with _get_conn() as conn:
+        conn.execute(
+            "UPDATE jobs SET status = 'error', error = ?, updated_at = ? WHERE id = ?",
+            (error, _utcnow_iso(), job_id),
+        )
+
+
+def get_job_record(job_id: str) -> sqlite3.Row | None:
+    with _get_conn() as conn:
+        return conn.execute(
+            "SELECT id, status, result, error FROM jobs WHERE id = ?",
+            (job_id,),
+        ).fetchone()
+
+
+# ---------------------------------------------------------------------------
+# Account linking (web ↔ Telegram)
+# ---------------------------------------------------------------------------
 
 def link_telegram_to_user(web_user_id: int, telegram_chat_id: int) -> None:
     """Stitch a Telegram chat onto the given web user. Idempotent.

--- a/scripts/prune.py
+++ b/scripts/prune.py
@@ -20,7 +20,8 @@ def main() -> None:
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
     counts = prune_maintenance()
     logger.info(
-        "prune: error_log=%(error_log)s url_cache=%(url_cache)s link_codes=%(link_codes)s",
+        "prune: error_log=%(error_log)s url_cache=%(url_cache)s "
+        "link_codes=%(link_codes)s jobs=%(jobs)s",
         counts,
     )
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -333,3 +333,112 @@ class TestLinkStart:
         assert len(body["code"]) == 6
         assert body["code"].isdigit()
         assert body["expires_in_seconds"] == 600
+
+
+# ---------------------------------------------------------------------------
+# POST /api/job + GET /api/job/{id}  (async analysis flow)
+# ---------------------------------------------------------------------------
+
+class TestJobFlow:
+    def test_start_job_returns_job_id(self, client, auth_headers):
+        r = client.post("/api/job", json={"url": "https://example.com/x"}, headers=auth_headers)
+        assert r.status_code == 202
+        assert isinstance(r.json().get("job_id"), str)
+
+    def test_start_job_rejects_invalid_url(self, client, auth_headers):
+        r = client.post("/api/job", json={"url": "not-a-url"}, headers=auth_headers)
+        assert r.status_code == 400
+
+    def test_start_job_requires_secret(self, client):
+        r = client.post("/api/job", json={"url": "https://example.com/x"})
+        assert r.status_code == 401
+
+    def test_get_job_404_for_unknown(self, client, auth_headers):
+        r = client.get("/api/job/unknown-id", headers=auth_headers)
+        assert r.status_code == 404
+
+    def test_run_job_signed_in_saves_item_and_completes(self, client, db, auth_headers):
+        import asyncio
+        import json
+        import bot.api
+
+        uid = client.post(
+            "/api/users/upsert", json={"email": "j@b.com"}, headers=auth_headers
+        ).json()["user_id"]
+        db.create_job("job-1")
+        asyncio.run(bot.api._run_job("job-1", "https://example.com/x", uid, "my note"))
+
+        rec = db.get_job_record("job-1")
+        assert rec["status"] == "done"
+        result = json.loads(rec["result"])
+        assert result["verdict"] == "watch"
+        assert result["id"] is not None
+        # Verdict is hoisted to the top level, not left inside analysis.
+        assert "verdict" not in result["analysis"]
+        # Item persisted for the signed-in user, storing the summary not raw text.
+        items = db.get_all_items(uid)
+        assert len(items) == 1
+        assert items[0]["content"] == "Neutral summary of the content."
+
+    def test_run_job_anonymous_does_not_save(self, client, db):
+        import asyncio
+        import json
+        import bot.api
+
+        db.create_job("job-2")
+        asyncio.run(bot.api._run_job("job-2", "https://example.com/x", None, ""))
+
+        rec = db.get_job_record("job-2")
+        assert rec["status"] == "done"
+        result = json.loads(rec["result"])
+        assert "id" not in result
+        assert db.get_all_items() == []
+
+    def test_run_job_analyzes_the_summary_not_raw_text(self, client, db, monkeypatch):
+        # The verdict must be derived from the stored summary, not the raw
+        # fetched text (the canonical-representation contract).
+        import asyncio
+        import bot.api
+
+        captured = {}
+
+        def capture_analyze(text, user_id=None):
+            captured["text"] = text
+            return {
+                "main_idea": "x", "why_it_matters": "y", "category": "c",
+                "quick_win": "q", "bigger_play": "b", "time_required": "t",
+                "verdict": "skim",
+            }
+
+        monkeypatch.setattr(bot.api, "analyze", capture_analyze)
+        db.create_job("job-3")
+        asyncio.run(bot.api._run_job("job-3", "https://example.com/x", None, ""))
+        assert captured["text"] == "Neutral summary of the content."
+
+    def test_run_job_no_text_sets_extraction_error(self, client, db, monkeypatch):
+        import asyncio
+        import bot.api
+
+        async def empty_fetch(url):
+            return {"text": "", "title": url, "source_type": "article", "reason": "no_text"}
+
+        monkeypatch.setattr(bot.api, "fetch_url", empty_fetch)
+        db.create_job("job-4")
+        asyncio.run(bot.api._run_job("job-4", "https://example.com/x", None, ""))
+        rec = db.get_job_record("job-4")
+        assert rec["status"] == "error"
+        assert rec["error"] == "extraction-failed"
+
+    def test_run_job_video_no_text_sets_no_transcript(self, client, db, monkeypatch):
+        import asyncio
+        import bot.api
+
+        async def empty_video_fetch(url):
+            return {"text": "", "title": url, "source_type": "youtube", "reason": "no_transcript"}
+
+        monkeypatch.setattr(bot.api, "fetch_url", empty_video_fetch)
+        db.create_job("job-5")
+        asyncio.run(bot.api._run_job("job-5", "https://example.com/x", None, ""))
+        rec = db.get_job_record("job-5")
+        assert rec["status"] == "error"
+        assert rec["error"] == "no-transcript"

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -337,17 +337,32 @@ class TestPruneMaintenance:
                 "INSERT INTO link_codes (code, user_id, expires_at) VALUES ('NEW', ?, ?)",
                 (uid, NEW),
             )
+            # Old terminal job → pruned. Old pending job → kept (task may still
+            # be running). New terminal job → kept (within retention window).
+            conn.execute(
+                "INSERT INTO jobs (id, status, updated_at) VALUES ('old-done', 'done', ?)",
+                (OLD,),
+            )
+            conn.execute(
+                "INSERT INTO jobs (id, status, updated_at) VALUES ('old-pending', 'pending', ?)",
+                (OLD,),
+            )
+            conn.execute(
+                "INSERT INTO jobs (id, status, updated_at) VALUES ('new-done', 'done', ?)",
+                (NEW,),
+            )
 
         counts = db.prune_maintenance(now=datetime(2026, 5, 20, tzinfo=timezone.utc))
-        assert counts == {"error_log": 1, "url_cache": 1, "link_codes": 1}
+        assert counts == {"error_log": 1, "url_cache": 1, "link_codes": 1, "jobs": 1}
 
         with db._get_conn() as conn:
             assert [r["message"] for r in conn.execute("SELECT message FROM error_log")] == ["new"]
             assert [r["url"] for r in conn.execute("SELECT url FROM url_cache")] == ["https://new"]
             assert [r["code"] for r in conn.execute("SELECT code FROM link_codes")] == ["NEW"]
+            assert {r["id"] for r in conn.execute("SELECT id FROM jobs")} == {"old-pending", "new-done"}
 
     def test_idempotent_on_empty(self, db):
         from datetime import datetime, timezone
 
         counts = db.prune_maintenance(now=datetime(2026, 5, 20, tzinfo=timezone.utc))
-        assert counts == {"error_log": 0, "url_cache": 0, "link_codes": 0}
+        assert counts == {"error_log": 0, "url_cache": 0, "link_codes": 0, "jobs": 0}


### PR DESCRIPTION
The web round-trip (fetch -> summarize -> analyze) regularly exceeded the Cloudflare Worker's 25s timeout once summarize_content was added to the hot path, surfacing as "worker did not finish" errors in the UI.

Replace the synchronous /api/try and /api/library/add web path with an async job: POST /api/job starts a background task and returns a job_id immediately; the browser polls GET /api/job/:id until done. The background task runs fetch -> summarize -> analyze(summary) in sequence (analysis is now grounded in the stored summary, the canonical representation) and persists items for signed-in users.

- New jobs table + CRUD; prune terminal jobs after 1h
- save_item now returns the new row id (drops the get_all_items()[0] hack)
- Old /api/try and /api/library/add kept for safe rollout; now superseded