### PR TITLE
feat: record per-call LLM usage to llm_calls table

### DIFF
--- a/bot/analyzer.py
+++ b/bot/analyzer.py
@@ -1,11 +1,84 @@
 import json
 import logging
 import os
+import time
+from dataclasses import dataclass
 from dotenv import load_dotenv
 
 load_dotenv()
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class UsageContext:
+    """Caller-supplied context for attributing one LLM call in `llm_calls`.
+
+    All fields are optional: legacy callers that don't pass a context still get
+    a row written, just with NULL user/anon/job and an empty source_type. The
+    analyzer functions accept this as a keyword-only `ctx` arg so adding new
+    attribution dimensions later is a non-breaking change.
+    """
+    user_id: int | None = None
+    anon_id: str | None = None
+    job_id: str | None = None
+    source_type: str = ""
+
+
+def _record_usage(
+    *,
+    purpose: str,
+    input_tokens: int,
+    output_tokens: int,
+    started_at: float,
+    ctx: UsageContext | None,
+    status: str = "ok",
+    error: str = "",
+) -> None:
+    """Best-effort write of one row to llm_calls. Never raises.
+
+    Pricing is stamped at write time from `bot.pricing` so historical rows keep
+    the cost they had at the time of the call even if we later bump prices.
+    """
+    from bot import pricing
+    from bot.db import insert_llm_call
+
+    latency_ms = int((time.monotonic() - started_at) * 1000)
+    cost = pricing.cost_usd(_MODEL, input_tokens, output_tokens)
+    c = ctx or UsageContext()
+    insert_llm_call(
+        provider=_PROVIDER,
+        model=_MODEL,
+        purpose=purpose,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cost_usd=cost,
+        latency_ms=latency_ms,
+        status=status,
+        error=error,
+        user_id=c.user_id,
+        anon_id=c.anon_id,
+        job_id=c.job_id,
+        source_type=c.source_type,
+    )
+
+
+def _anthropic_tokens(resp) -> tuple[int, int]:
+    """Pull (input_tokens, output_tokens) off an Anthropic Messages response.
+    Missing usage is treated as (0, 0) rather than raising — we'd rather log a
+    zero-token row than drop the call entirely."""
+    usage = getattr(resp, "usage", None)
+    if usage is None:
+        return 0, 0
+    return int(getattr(usage, "input_tokens", 0) or 0), int(getattr(usage, "output_tokens", 0) or 0)
+
+
+def _openai_tokens(resp) -> tuple[int, int]:
+    """Pull (prompt_tokens, completion_tokens) off an OpenAI Chat response."""
+    usage = getattr(resp, "usage", None)
+    if usage is None:
+        return 0, 0
+    return int(getattr(usage, "prompt_tokens", 0) or 0), int(getattr(usage, "completion_tokens", 0) or 0)
 
 _ANTHROPIC_KEY = os.getenv("ANTHROPIC_API_KEY")
 _OPENAI_KEY = os.getenv("OPENAI_API_KEY")
@@ -150,37 +223,57 @@ def _normalize(raw: dict) -> dict:
     return out
 
 
-def analyze(text: str, user_id: int | None = None) -> dict:
+def analyze(text: str, user_id: int | None = None, *, ctx: UsageContext | None = None) -> dict:
     """Returns a dict with keys: main_idea, why_it_matters, category, quick_win, bigger_play, time_required, verdict."""
-    profile = _load_profile(user_id)
+    # Back-compat: callers that still pass `user_id` positionally get it merged
+    # into the context so usage rows still attribute to a user.
+    if ctx is None:
+        ctx = UsageContext(user_id=user_id)
+    elif ctx.user_id is None and user_id is not None:
+        ctx = UsageContext(user_id=user_id, anon_id=ctx.anon_id, job_id=ctx.job_id, source_type=ctx.source_type)
+
+    profile = _load_profile(ctx.user_id)
     profile_block = f"\nAbout the person you are analysing for:\n{profile}\n" if profile else ""
     prompt = _PROMPT.format(profile_block=profile_block, text=text)
 
     client = _get_client()
-    if _PROVIDER == "anthropic":
-        resp = client.messages.create(
-            model=_MODEL,
-            max_tokens=1024,
-            tools=[_ANTHROPIC_TOOL],
-            tool_choice={"type": "tool", "name": "record_analysis"},
-            messages=[{"role": "user", "content": prompt}],
-        )
-        for block in resp.content:
-            if getattr(block, "type", None) == "tool_use" and block.name == "record_analysis":
-                return _normalize(block.input)
-        raise RuntimeError("Anthropic did not return a record_analysis tool_use block")
-
-    resp = client.chat.completions.create(
-        model=_MODEL,
-        response_format={"type": "json_object"},
-        messages=[{"role": "user", "content": prompt + _OPENAI_JSON_SUFFIX}],
-    )
-    content = resp.choices[0].message.content or "{}"
+    started = time.monotonic()
     try:
-        raw = json.loads(content)
-    except json.JSONDecodeError as e:
-        raise RuntimeError(f"OpenAI returned non-JSON content: {e}: {content[:200]}")
-    return _normalize(raw)
+        if _PROVIDER == "anthropic":
+            resp = client.messages.create(
+                model=_MODEL,
+                max_tokens=1024,
+                tools=[_ANTHROPIC_TOOL],
+                tool_choice={"type": "tool", "name": "record_analysis"},
+                messages=[{"role": "user", "content": prompt}],
+            )
+            in_tok, out_tok = _anthropic_tokens(resp)
+            _record_usage(purpose="analyze", input_tokens=in_tok, output_tokens=out_tok,
+                          started_at=started, ctx=ctx)
+            for block in resp.content:
+                if getattr(block, "type", None) == "tool_use" and block.name == "record_analysis":
+                    return _normalize(block.input)
+            raise RuntimeError("Anthropic did not return a record_analysis tool_use block")
+
+        resp = client.chat.completions.create(
+            model=_MODEL,
+            response_format={"type": "json_object"},
+            messages=[{"role": "user", "content": prompt + _OPENAI_JSON_SUFFIX}],
+        )
+        in_tok, out_tok = _openai_tokens(resp)
+        _record_usage(purpose="analyze", input_tokens=in_tok, output_tokens=out_tok,
+                      started_at=started, ctx=ctx)
+        content = resp.choices[0].message.content or "{}"
+        try:
+            raw = json.loads(content)
+        except json.JSONDecodeError as e:
+            raise RuntimeError(f"OpenAI returned non-JSON content: {e}: {content[:200]}")
+        return _normalize(raw)
+    except Exception as e:
+        # Log the failed attempt so failure rate shows up next to spend.
+        _record_usage(purpose="analyze", input_tokens=0, output_tokens=0,
+                      started_at=started, ctx=ctx, status="error", error=str(e)[:200])
+        raise
 
 
 _SUMMARY_PROMPT = """You are distilling source content into a faithful, reusable \
@@ -219,7 +312,7 @@ def _summary_output_tokens(text: str) -> int:
     return max(512, min(_SUMMARY_MAX_OUTPUT_TOKENS, approx_input_tokens // 4))
 
 
-def summarize_content(text: str) -> str:
+def summarize_content(text: str, *, ctx: UsageContext | None = None) -> str:
     """Distil source content into a faithful, length-scaled structured brief.
 
     Stored instead of the full fetched text: rich enough to re-derive verdicts
@@ -232,6 +325,7 @@ def summarize_content(text: str) -> str:
         return ""
     prompt = _SUMMARY_PROMPT.format(text=text)
     max_tokens = _summary_output_tokens(text)
+    started = time.monotonic()
     try:
         client = _get_client()
         if _PROVIDER == "anthropic":
@@ -240,6 +334,7 @@ def summarize_content(text: str) -> str:
                 max_tokens=max_tokens,
                 messages=[{"role": "user", "content": prompt}],
             )
+            in_tok, out_tok = _anthropic_tokens(resp)
             out = "".join(
                 b.text for b in resp.content if getattr(b, "type", None) == "text"
             ).strip()
@@ -249,45 +344,62 @@ def summarize_content(text: str) -> str:
                 max_tokens=max_tokens,
                 messages=[{"role": "user", "content": prompt}],
             )
+            in_tok, out_tok = _openai_tokens(resp)
             out = (resp.choices[0].message.content or "").strip()
+        _record_usage(purpose="summary", input_tokens=in_tok, output_tokens=out_tok,
+                      started_at=started, ctx=ctx)
         return out[:SUMMARY_MAX_CHARS] if out else text[:SUMMARY_MAX_CHARS]
     except Exception as e:
+        _record_usage(purpose="summary", input_tokens=0, output_tokens=0,
+                      started_at=started, ctx=ctx, status="error", error=str(e)[:200])
         logger.warning("summarize_content failed; storing truncated slice: %s", e)
         return text[:SUMMARY_MAX_CHARS]
 
 
-def analyze_image(b64: str, caption: str = "") -> str:
+def analyze_image(b64: str, caption: str = "", *, ctx: UsageContext | None = None) -> str:
     """Describe and extract key info from a base64-encoded JPEG image."""
     prompt = "Extract and describe all text and key information visible in this image."
     if caption:
         prompt += f" Context provided: {caption}"
 
     client = _get_client()
-    if _PROVIDER == "anthropic":
-        resp = client.messages.create(
+    started = time.monotonic()
+    try:
+        if _PROVIDER == "anthropic":
+            resp = client.messages.create(
+                model=_MODEL,
+                max_tokens=1024,
+                messages=[{
+                    "role": "user",
+                    "content": [
+                        {"type": "image", "source": {"type": "base64", "media_type": "image/jpeg", "data": b64}},
+                        {"type": "text", "text": prompt},
+                    ],
+                }],
+            )
+            in_tok, out_tok = _anthropic_tokens(resp)
+            _record_usage(purpose="image", input_tokens=in_tok, output_tokens=out_tok,
+                          started_at=started, ctx=ctx)
+            return resp.content[0].text
+
+        resp = client.chat.completions.create(
             model=_MODEL,
-            max_tokens=1024,
             messages=[{
                 "role": "user",
                 "content": [
-                    {"type": "image", "source": {"type": "base64", "media_type": "image/jpeg", "data": b64}},
                     {"type": "text", "text": prompt},
+                    {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{b64}"}},
                 ],
             }],
         )
-        return resp.content[0].text
-
-    resp = client.chat.completions.create(
-        model=_MODEL,
-        messages=[{
-            "role": "user",
-            "content": [
-                {"type": "text", "text": prompt},
-                {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{b64}"}},
-            ],
-        }],
-    )
-    return resp.choices[0].message.content
+        in_tok, out_tok = _openai_tokens(resp)
+        _record_usage(purpose="image", input_tokens=in_tok, output_tokens=out_tok,
+                      started_at=started, ctx=ctx)
+        return resp.choices[0].message.content
+    except Exception as e:
+        _record_usage(purpose="image", input_tokens=0, output_tokens=0,
+                      started_at=started, ctx=ctx, status="error", error=str(e)[:200])
+        raise
 
 
 # ---------------------------------------------------------------------------

--- a/bot/api.py
+++ b/bot/api.py
@@ -15,7 +15,7 @@ from fastapi import APIRouter, Depends, File, Form, Header, HTTPException, Uploa
 from fastapi.responses import FileResponse as FastAPIFileResponse
 from pydantic import BaseModel
 
-from bot.analyzer import analyze, analyze_image, summarize_content, to_json_str, to_plain_text
+from bot.analyzer import UsageContext, analyze, analyze_image, summarize_content, to_json_str, to_plain_text
 from bot.auth import require_token
 from bot.config import MAX_CONTENT_CHARS
 from bot.fetch_errors import user_message as fetch_error_message
@@ -113,7 +113,7 @@ async def submit_text(
     user_note: str = Form(""),
     user_id: int = Depends(require_token),
 ):
-    analysis = analyze(text, user_id)
+    analysis = analyze(text, ctx=UsageContext(user_id=user_id, source_type="note"))
     save_item(user_id, "note", "", text, to_json_str(analysis), user_note)
     return {"analysis": to_plain_text(analysis), "analysis_data": analysis}
 
@@ -130,9 +130,11 @@ async def submit_url(
             status_code=422,
             detail=fetch_error_message(fetched.get("reason"), url),
         )
-    analysis = analyze(fetched["text"], user_id)
+    source_type = fetched.get("source_type") or "article"
+    ctx = UsageContext(user_id=user_id, source_type=source_type)
+    analysis = analyze(fetched["text"], ctx=ctx)
     # Store a condensed summary, not a full copy of the fetched content.
-    save_item(user_id, "url", url, summarize_content(fetched["text"]), to_json_str(analysis), user_note)
+    save_item(user_id, "url", url, summarize_content(fetched["text"], ctx=ctx), to_json_str(analysis), user_note)
     return {"analysis": to_plain_text(analysis), "analysis_data": analysis}
 
 
@@ -161,7 +163,7 @@ async def submit_file(
     elif mime.startswith("image/"):
         stored_file_path = save_file(data, suffix)
         b64 = base64.b64encode(data).decode()
-        text = analyze_image(b64, user_note)
+        text = analyze_image(b64, user_note, ctx=UsageContext(user_id=user_id, source_type="photo"))
         source_type = "photo"
     elif mime.startswith("audio/") or suffix in (".ogg", ".mp3", ".m4a", ".wav", ".flac"):
         stored_file_path = save_file(data, suffix)
@@ -179,7 +181,7 @@ async def submit_file(
     if not text or not text.strip():
         raise HTTPException(status_code=422, detail="Could not extract text from file")
 
-    analysis = analyze(text, user_id)
+    analysis = analyze(text, ctx=UsageContext(user_id=user_id, source_type=source_type))
     save_item(user_id, source_type, name, text, to_json_str(analysis), user_note, file_path=stored_file_path)
     return {"analysis": to_plain_text(analysis), "analysis_data": analysis}
 
@@ -208,6 +210,10 @@ async def set_profile_endpoint(
 
 class TryRequest(BaseModel):
     url: str
+    # Optional: the Worker's anon UUID, used purely for usage attribution so we
+    # can group anon LLM spend per visitor in the admin dashboard. Server keeps
+    # accepting requests without it during the rollout.
+    anon_id: str | None = None
 
 
 def _require_try_secret(x_filter_fyi_secret: str | None = Header(default=None)) -> None:
@@ -271,8 +277,9 @@ async def try_url(req: TryRequest, _: None = Depends(_require_try_secret)):
             },
         )
 
+    ctx = UsageContext(anon_id=req.anon_id, source_type=source_type)
     try:
-        analysis = analyze(text, user_id=None)
+        analysis = analyze(text, ctx=ctx)
     except Exception as e:
         logger.exception("analyze crashed for %s: %s", url, e)
         raise HTTPException(status_code=502, detail={"error": "analyze-failed"})
@@ -283,7 +290,7 @@ async def try_url(req: TryRequest, _: None = Depends(_require_try_secret)):
 
     # The Worker stores content_preview in D1 (for claim-on-signup), so send the
     # condensed summary rather than a verbatim slice of the source.
-    summary = summarize_content(text)
+    summary = summarize_content(text, ctx=ctx)
 
     return {
         "url": url,
@@ -478,8 +485,9 @@ async def library_add(req: _LibraryAddRequest, _: None = Depends(_require_try_se
             },
         )
 
+    ctx = UsageContext(user_id=req.user_id, source_type=source_type)
     try:
-        analysis = analyze(text, user_id=req.user_id)
+        analysis = analyze(text, ctx=ctx)
     except Exception as e:
         logger.exception("analyze crashed for %s: %s", url, e)
         raise HTTPException(status_code=502, detail={"error": "analyze-failed"})
@@ -488,7 +496,7 @@ async def library_add(req: _LibraryAddRequest, _: None = Depends(_require_try_se
     # a full copy of the fetched third-party content. The full text stays in
     # memory only for this request; the summary is enough to re-derive verdicts
     # later under a different profile.
-    summary = summarize_content(text)
+    summary = summarize_content(text, ctx=ctx)
 
     save_item(
         user_id=req.user_id,
@@ -574,6 +582,9 @@ class _JobRequest(BaseModel):
     url: str
     user_id: int | None = None
     user_note: str = ""
+    # Optional anon UUID from the Worker (anon /api/job traffic). Same purpose
+    # as TryRequest.anon_id: per-visitor usage attribution only.
+    anon_id: str | None = None
 
 
 @router.post("/job", status_code=202)
@@ -592,14 +603,20 @@ async def start_job(req: _JobRequest, _: None = Depends(_require_try_secret)):
     job_id = str(uuid.uuid4())
     create_job(job_id)
 
-    task = asyncio.create_task(_run_job(job_id, url, req.user_id, req.user_note))
+    task = asyncio.create_task(_run_job(job_id, url, req.user_id, req.user_note, req.anon_id))
     _background_tasks.add(task)
     task.add_done_callback(_background_tasks.discard)
 
     return {"job_id": job_id}
 
 
-async def _run_job(job_id: str, url: str, user_id: int | None, user_note: str) -> None:
+async def _run_job(
+    job_id: str,
+    url: str,
+    user_id: int | None,
+    user_note: str,
+    anon_id: str | None = None,
+) -> None:
     """Background task: fetch → summarize → analyze(summary) → optionally save."""
     try:
         _job_steps[job_id] = "fetching"
@@ -621,19 +638,22 @@ async def _run_job(job_id: str, url: str, user_id: int | None, user_note: str) -
             return
 
         loop = asyncio.get_running_loop()
+        ctx = UsageContext(
+            user_id=user_id, anon_id=anon_id, job_id=job_id, source_type=source_type
+        )
 
         # Summarise first — the summary is the canonical stored representation
         # and the basis for the analysis verdict.
         _job_steps[job_id] = "summarizing"
         try:
-            summary = await loop.run_in_executor(None, lambda: summarize_content(text))
+            summary = await loop.run_in_executor(None, lambda: summarize_content(text, ctx=ctx))
         except Exception:
             logger.exception("job %s: summarize_content crashed", job_id)
             summary = text[:TRY_PREVIEW_CHARS]
 
         _job_steps[job_id] = "analyzing"
         try:
-            analysis = await loop.run_in_executor(None, lambda: analyze(summary, user_id))
+            analysis = await loop.run_in_executor(None, lambda: analyze(summary, ctx=ctx))
         except Exception:
             logger.exception("job %s: analyze crashed", job_id)
             set_job_error(job_id, "analyze-failed")

--- a/bot/db.py
+++ b/bot/db.py
@@ -103,7 +103,36 @@ _CREATE_INDEXES_SQL = [
     "CREATE INDEX IF NOT EXISTS idx_feedback_user ON feedback(user_id, created_at DESC)",
     "CREATE INDEX IF NOT EXISTS idx_feedback_item ON feedback(item_id)",
     "CREATE INDEX IF NOT EXISTS idx_jobs_updated_at ON jobs(updated_at DESC)",
+    "CREATE INDEX IF NOT EXISTS idx_llm_calls_ts ON llm_calls(ts DESC)",
+    "CREATE INDEX IF NOT EXISTS idx_llm_calls_user ON llm_calls(user_id, ts DESC)",
+    "CREATE INDEX IF NOT EXISTS idx_llm_calls_anon ON llm_calls(anon_id, ts DESC)",
 ]
+
+# Per-call LLM usage log. One row per upstream API call (analyze, summary,
+# image). `user_id` is NULL for anonymous /api/try; `anon_id` carries the
+# Worker's anon UUID so anon spend can be grouped per visitor and joined back
+# to D1's `anon_summaries` if needed. `source_type` is denormalised so a
+# "tokens by source_type" tile is one query without joining items. `status`
+# distinguishes successful calls from failed ones so failure rate and spend
+# share the same table.
+_CREATE_LLM_CALLS_SQL = """\
+CREATE TABLE IF NOT EXISTS llm_calls (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts            TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%S', 'now')),
+    user_id       INTEGER,
+    anon_id       TEXT,
+    job_id        TEXT,
+    provider      TEXT    NOT NULL DEFAULT '',
+    model         TEXT    NOT NULL DEFAULT '',
+    purpose       TEXT    NOT NULL DEFAULT '',
+    source_type   TEXT    NOT NULL DEFAULT '',
+    input_tokens  INTEGER NOT NULL DEFAULT 0,
+    output_tokens INTEGER NOT NULL DEFAULT 0,
+    cost_usd      REAL    NOT NULL DEFAULT 0,
+    latency_ms    INTEGER NOT NULL DEFAULT 0,
+    status        TEXT    NOT NULL DEFAULT 'ok',
+    error         TEXT    NOT NULL DEFAULT ''
+)"""
 
 # Short-lived job records for the async analysis flow. The Worker starts a job
 # and returns immediately; the browser polls until status → 'done' or 'error'.
@@ -215,6 +244,7 @@ def _init() -> None:
         conn.execute(_CREATE_ERROR_LOG_SQL)
         conn.execute(_CREATE_FEEDBACK_SQL)
         conn.execute(_CREATE_JOBS_SQL)
+        conn.execute(_CREATE_LLM_CALLS_SQL)
         for stmt in _CREATE_INDEXES_SQL:
             conn.execute(stmt)
 
@@ -608,6 +638,47 @@ def get_job_record(job_id: str) -> sqlite3.Row | None:
             "SELECT id, status, result, error FROM jobs WHERE id = ?",
             (job_id,),
         ).fetchone()
+
+
+# ---------------------------------------------------------------------------
+# LLM usage log
+# ---------------------------------------------------------------------------
+
+def insert_llm_call(
+    *,
+    provider: str,
+    model: str,
+    purpose: str,
+    input_tokens: int,
+    output_tokens: int,
+    cost_usd: float,
+    latency_ms: int,
+    status: str = "ok",
+    error: str = "",
+    user_id: int | None = None,
+    anon_id: str | None = None,
+    job_id: str | None = None,
+    source_type: str = "",
+) -> None:
+    """Record one upstream LLM call. Never raises into the caller — usage
+    logging is best-effort; failing to log must not break the analysis path."""
+    try:
+        with _get_conn() as conn:
+            conn.execute(
+                "INSERT INTO llm_calls (user_id, anon_id, job_id, provider, "
+                "model, purpose, source_type, input_tokens, output_tokens, "
+                "cost_usd, latency_ms, status, error) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    user_id, anon_id, job_id, provider, model, purpose,
+                    source_type, int(input_tokens), int(output_tokens),
+                    float(cost_usd), int(latency_ms), status, error,
+                ),
+            )
+    except Exception:
+        # Surface in logs but never propagate — see docstring.
+        import logging as _logging
+        _logging.getLogger(__name__).exception("insert_llm_call failed")
 
 
 # ---------------------------------------------------------------------------

--- a/bot/pricing.py
+++ b/bot/pricing.py
@@ -1,0 +1,30 @@
+"""Model pricing for cost attribution on LLM calls.
+
+Stored as a Python dict so price changes are a 1-line PR and deploy with code.
+If we want historical cost to stay accurate across a price change, we move this
+to a `model_prices(model, input_per_mtok, output_per_mtok, effective_from)`
+table later — until then, a price change is applied to all future rows and
+past rows keep the cost they were stamped with at write time.
+
+Prices are USD per million tokens, as (input, output). Sources:
+  - Anthropic:        https://www.anthropic.com/pricing
+  - OpenAI Platform:  https://openai.com/api/pricing
+Update both when bumping a model in analyzer._MODEL.
+"""
+from __future__ import annotations
+
+# (input_per_mtok, output_per_mtok)
+PRICES_PER_MTOK: dict[str, tuple[float, float]] = {
+    "claude-haiku-4-5-20251001": (1.00, 5.00),
+    "gpt-4o-mini": (0.15, 0.60),
+}
+
+
+def cost_usd(model: str, input_tokens: int, output_tokens: int) -> float:
+    """Compute USD cost for a single call. Unknown models cost 0 (we still
+    record tokens, so we can backfill cost later if needed)."""
+    prices = PRICES_PER_MTOK.get(model)
+    if not prices:
+        return 0.0
+    in_per, out_per = prices
+    return (input_tokens * in_per + output_tokens * out_per) / 1_000_000

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,7 +57,7 @@ def client(monkeypatch):
             "image_urls": [],
         }
 
-    def fake_analyze(text, user_id=None):
+    def fake_analyze(text, user_id=None, **_kwargs):
         return {
             "main_idea": "RAG = retrieval-augmented generation.",
             "why_it_matters": "Practical AI pattern.",
@@ -68,7 +68,7 @@ def client(monkeypatch):
             "verdict": "watch",
         }
 
-    def fake_summarize_content(text):
+    def fake_summarize_content(text, **_kwargs):
         return "Neutral summary of the content."
 
     monkeypatch.setattr(bot.api, "fetch_url", fake_fetch_url)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -402,7 +402,7 @@ class TestJobFlow:
 
         captured = {}
 
-        def capture_analyze(text, user_id=None):
+        def capture_analyze(text, user_id=None, **_kwargs):
             captured["text"] = text
             return {
                 "main_idea": "x", "why_it_matters": "y", "category": "c",

--- a/tests/test_llm_usage.py
+++ b/tests/test_llm_usage.py
@@ -1,0 +1,210 @@
+"""Tests for the LLM usage log.
+
+Covers the three things we need to keep honest:
+  1. Pricing math — known models compute, unknown models fall back to 0.
+  2. Schema + helper — `insert_llm_call` writes the columns we expect, and
+     a failure inside it never escapes into the analyzer.
+  3. End-to-end capture — each public analyzer function writes exactly one row
+     per upstream call, including failures (status='error', tokens=0).
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+
+class TestPricing:
+    def test_known_model_charges_input_and_output(self):
+        from bot import pricing
+        # claude-haiku-4-5: (1.0, 5.0) per MTok
+        c = pricing.cost_usd("claude-haiku-4-5-20251001", 1_000_000, 1_000_000)
+        assert c == 6.0
+        # 1k input + 2k output at $1/$5 per MTok = $0.001 + $0.010 = $0.011
+        c = pricing.cost_usd("claude-haiku-4-5-20251001", 1_000, 2_000)
+        assert round(c, 6) == 0.011
+
+    def test_unknown_model_costs_zero(self):
+        from bot import pricing
+        assert pricing.cost_usd("not-a-real-model", 10_000, 10_000) == 0.0
+
+
+class TestInsertHelper:
+    def test_writes_row_with_all_columns(self, db):
+        db.insert_llm_call(
+            provider="anthropic", model="claude-haiku-4-5-20251001",
+            purpose="analyze", input_tokens=100, output_tokens=50,
+            cost_usd=0.00035, latency_ms=420, status="ok", error="",
+            user_id=7, anon_id="abc-123", job_id="job-9", source_type="article",
+        )
+        rows = _all_llm_calls(db)
+        assert len(rows) == 1
+        r = rows[0]
+        assert r["provider"] == "anthropic"
+        assert r["model"] == "claude-haiku-4-5-20251001"
+        assert r["purpose"] == "analyze"
+        assert r["input_tokens"] == 100
+        assert r["output_tokens"] == 50
+        assert abs(r["cost_usd"] - 0.00035) < 1e-9
+        assert r["latency_ms"] == 420
+        assert r["status"] == "ok"
+        assert r["user_id"] == 7
+        assert r["anon_id"] == "abc-123"
+        assert r["job_id"] == "job-9"
+        assert r["source_type"] == "article"
+
+    def test_anon_row_has_null_user_id(self, db):
+        db.insert_llm_call(
+            provider="anthropic", model="claude-haiku-4-5-20251001",
+            purpose="analyze", input_tokens=10, output_tokens=5,
+            cost_usd=0.0, latency_ms=10, anon_id="anon-xyz",
+        )
+        row = _all_llm_calls(db)[0]
+        assert row["user_id"] is None
+        assert row["anon_id"] == "anon-xyz"
+
+    def test_failure_to_write_does_not_raise(self, db, monkeypatch):
+        # Simulate the DB being unavailable mid-call. The helper must swallow it
+        # so a logging blip never breaks an analysis request.
+        def boom(*_a, **_kw):
+            raise RuntimeError("disk gone")
+        monkeypatch.setattr(db, "_get_conn", boom)
+        db.insert_llm_call(
+            provider="anthropic", model="claude-haiku-4-5-20251001",
+            purpose="analyze", input_tokens=0, output_tokens=0,
+            cost_usd=0.0, latency_ms=0,
+        )  # should NOT raise
+
+
+class TestAnthropicCapture:
+    def test_analyze_logs_one_row_with_tokens_and_cost(self, db, monkeypatch):
+        from bot import analyzer
+        monkeypatch.setattr(analyzer, "_PROVIDER", "anthropic")
+        monkeypatch.setattr(analyzer, "_MODEL", "claude-haiku-4-5-20251001")
+
+        fake = _FakeAnthropic(input_tokens=200, output_tokens=80, tool_input={
+            "main_idea": "x", "why_it_matters": "y", "category": "c",
+            "quick_win": "qw", "bigger_play": "bp", "time_required": "5m",
+            "verdict": "watch",
+        })
+        monkeypatch.setattr(analyzer, "_get_client", lambda: fake)
+
+        out = analyzer.analyze("hello", ctx=analyzer.UsageContext(
+            user_id=42, source_type="article",
+        ))
+        assert out["verdict"] == "watch"
+
+        rows = _all_llm_calls(db)
+        assert len(rows) == 1
+        r = rows[0]
+        assert r["provider"] == "anthropic"
+        assert r["purpose"] == "analyze"
+        assert r["input_tokens"] == 200
+        assert r["output_tokens"] == 80
+        assert r["status"] == "ok"
+        assert r["user_id"] == 42
+        assert r["source_type"] == "article"
+        # 200 in @ $1/MTok + 80 out @ $5/MTok = 0.0002 + 0.0004 = 0.0006
+        assert abs(r["cost_usd"] - 0.0006) < 1e-9
+
+    def test_summarize_content_logs_summary_purpose(self, db, monkeypatch):
+        from bot import analyzer
+        monkeypatch.setattr(analyzer, "_PROVIDER", "anthropic")
+        monkeypatch.setattr(analyzer, "_MODEL", "claude-haiku-4-5-20251001")
+
+        fake = _FakeAnthropic(input_tokens=900, output_tokens=300, text="A summary.")
+        monkeypatch.setattr(analyzer, "_get_client", lambda: fake)
+
+        out = analyzer.summarize_content("a bit of text", ctx=analyzer.UsageContext(
+            anon_id="anon-1", source_type="article",
+        ))
+        assert out == "A summary."
+
+        rows = _all_llm_calls(db)
+        assert len(rows) == 1 and rows[0]["purpose"] == "summary"
+        assert rows[0]["anon_id"] == "anon-1"
+        assert rows[0]["input_tokens"] == 900 and rows[0]["output_tokens"] == 300
+
+    def test_failure_logs_error_row_and_reraises(self, db, monkeypatch):
+        from bot import analyzer
+        monkeypatch.setattr(analyzer, "_PROVIDER", "anthropic")
+        monkeypatch.setattr(analyzer, "_MODEL", "claude-haiku-4-5-20251001")
+
+        class Boom:
+            messages = SimpleNamespace(create=lambda **kw: (_ for _ in ()).throw(RuntimeError("rate-limited")))
+        monkeypatch.setattr(analyzer, "_get_client", lambda: Boom())
+
+        try:
+            analyzer.analyze("x", ctx=analyzer.UsageContext(user_id=1))
+            raise AssertionError("expected analyze to re-raise")
+        except RuntimeError:
+            pass
+
+        rows = _all_llm_calls(db)
+        assert len(rows) == 1
+        r = rows[0]
+        assert r["status"] == "error"
+        assert "rate-limited" in r["error"]
+        assert r["input_tokens"] == 0 and r["output_tokens"] == 0
+        assert r["cost_usd"] == 0.0
+
+
+class TestOpenAICapture:
+    def test_analyze_reads_openai_usage(self, db, monkeypatch):
+        from bot import analyzer
+        monkeypatch.setattr(analyzer, "_PROVIDER", "openai")
+        monkeypatch.setattr(analyzer, "_MODEL", "gpt-4o-mini")
+
+        fake = _FakeOpenAI(prompt_tokens=500, completion_tokens=120, content=(
+            '{"main_idea":"x","why_it_matters":"y","category":"c",'
+            '"quick_win":"qw","bigger_play":"bp","time_required":"5m","verdict":"skim"}'
+        ))
+        monkeypatch.setattr(analyzer, "_get_client", lambda: fake)
+
+        analyzer.analyze("hi", ctx=analyzer.UsageContext(user_id=9, source_type="article"))
+        rows = _all_llm_calls(db)
+        assert len(rows) == 1
+        assert rows[0]["provider"] == "openai"
+        assert rows[0]["model"] == "gpt-4o-mini"
+        assert rows[0]["input_tokens"] == 500
+        assert rows[0]["output_tokens"] == 120
+        # 500 in @ $0.15/MTok + 120 out @ $0.60/MTok = 0.000075 + 0.000072 = 0.000147
+        assert abs(rows[0]["cost_usd"] - 0.000147) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# Test fakes
+# ---------------------------------------------------------------------------
+
+def _all_llm_calls(db):
+    with db._get_conn() as conn:
+        return conn.execute("SELECT * FROM llm_calls ORDER BY id").fetchall()
+
+
+class _FakeAnthropic:
+    """Mimics just enough of the Anthropic client for the analyzer paths.
+
+    For `analyze` we need a tool_use block; for `summarize_content` we need a
+    text block. The constructor takes whichever the caller wants — they're
+    mutually exclusive in practice.
+    """
+    def __init__(self, *, input_tokens, output_tokens, tool_input=None, text=None):
+        if tool_input is not None:
+            content = [SimpleNamespace(type="tool_use", name="record_analysis", input=tool_input)]
+        else:
+            content = [SimpleNamespace(type="text", text=text or "")]
+        resp = SimpleNamespace(
+            content=content,
+            usage=SimpleNamespace(input_tokens=input_tokens, output_tokens=output_tokens),
+        )
+        self.messages = SimpleNamespace(create=lambda **kw: resp)
+
+
+class _FakeOpenAI:
+    def __init__(self, *, prompt_tokens, completion_tokens, content):
+        resp = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content=content))],
+            usage=SimpleNamespace(
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+            ),
+        )
+        self.chat = SimpleNamespace(completions=SimpleNamespace(create=lambda **kw: resp))


### PR DESCRIPTION
Starts collecting LLM token spend (and derivatives — cost, latency, status, attribution) so we don't lose this data while the admin dashboard is being built out separately.

## What lands

**New table** on Fly SQLite:

```sql
llm_calls(
  ts, user_id, anon_id, job_id, provider, model, purpose,
  source_type, input_tokens, output_tokens, cost_usd,
  latency_ms, status, error
)
```

Indexed on `ts`, `(user_id, ts)`, `(anon_id, ts)`.

**Capture** wraps the three LLM call sites in `bot/analyzer.py` (`analyze`, `summarize_content`, `analyze_image`). Each one writes exactly one row per upstream call — successful or failed.

- **Cost** is stamped at write time from `bot/pricing.py` so historical rows stay accurate if we bump prices later. Unknown models cost `0` but tokens are still recorded.
- **Failures** write `status='error'`, `tokens=0`, and re-raise — failure rate lives next to spend in the same table.
- **Best-effort logging**: `insert_llm_call` swallows DB errors so a logging blip never breaks an analysis.

**Worker contract** — additive only:
- `POST /api/try` and `POST /api/job` now accept optional `anon_id` in the body. Until the Worker is updated to pass it, anon rows have `anon_id=NULL` but tokens are still captured (`user_id=NULL` distinguishes anon from signed-in). Follow-up PR on the frontend repo to pass the cookie value through.

## Dashboard queries this unlocks (immediately)

- `$/day`, `$/user`, `$/source_type`, `$/purpose` (analyze vs summary vs image)
- Tokens/day, by provider/model
- Failure rate of LLM calls per day
- P50/P95 LLM latency
- Anon vs signed-in spend split

## Tests

9 new under [tests/test_llm_usage.py](tests/test_llm_usage.py):
- Pricing math (known + unknown models)
- Helper schema + best-effort failure swallowing
- Anthropic + OpenAI capture (tokens, cost, attribution)
- Failure → error-row flow

Existing fakes updated to accept the new `ctx` kwarg. Full suite: **137 passed**.

## Local verification

```bash
make test                       # runs the new tests too
make dev                        # then trigger /api/try via the frontend dev server
sqlite3 research.db "SELECT ts, purpose, source_type, input_tokens, output_tokens, cost_usd, status FROM llm_calls ORDER BY id DESC LIMIT 10;"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)