### PR TITLE
feat: add /api/admin/cost-overview endpoint

### DIFF
--- a/bot/admin.py
+++ b/bot/admin.py
@@ -1,0 +1,299 @@
+"""Admin observability endpoints — read-only aggregations over operational data.
+
+Auth is intentionally separate from the try-secret used by /api/try and /api/job:
+admin endpoints take their own `FILTER_FYI_ADMIN_SECRET` so the two can rotate
+independently and a try-secret leak doesn't grant admin access. The only
+legitimate caller is the Worker's admin.filter.fyi handler, which holds the
+matching secret as `BOT_ADMIN_KEY` and passes it as `x-filter-fyi-admin-secret`.
+
+Endpoints are kept "dumb SQL with one round-trip" — each returns one pre-rolled
+shape the Worker can render directly. Where a chart needs a continuous day
+series, this module fills in zero-call days so the renderer doesn't have to.
+
+Currently exposes:
+  GET /api/admin/cost-overview?days=N
+    All cost/usage aggregations for the last N days (default 30, max 365),
+    drawn from llm_calls. See `cost_overview()` for the response shape.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import secrets
+from datetime import datetime, timedelta, timezone
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Query
+
+# llm_calls lives on the same Fly SQLite as everything else; bot.db's private
+# connection helper is the canonical entry point. We don't re-implement it.
+from bot.db import _get_conn
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/admin")
+
+_MAX_DAYS = 365
+_DEFAULT_DAYS = 30
+_TOP_USERS_LIMIT = 10
+
+
+def _require_admin_secret(
+    x_filter_fyi_admin_secret: str | None = Header(default=None),
+) -> None:
+    """Validate the admin shared secret.
+
+    Mirrors `_require_try_secret`'s shape but reads a different env var so the
+    secrets can rotate independently. Fails closed when unset rather than
+    accepting any value — an unconfigured admin surface must never serve.
+    """
+    expected = os.getenv("FILTER_FYI_ADMIN_SECRET")
+    if not expected:
+        raise HTTPException(status_code=503, detail={"error": "service-unavailable"})
+    if not x_filter_fyi_admin_secret or not secrets.compare_digest(
+        x_filter_fyi_admin_secret, expected
+    ):
+        raise HTTPException(status_code=401, detail={"error": "unauthorized"})
+
+
+def _since_iso(days: int) -> str:
+    """ISO-8601 cutoff for `days` ago in UTC, formatted to match the storage
+    shape stamped by SQLite's `strftime('%Y-%m-%dT%H:%M:%S','now')` default."""
+    return (datetime.now(timezone.utc) - timedelta(days=days)).strftime(
+        "%Y-%m-%dT%H:%M:%S"
+    )
+
+
+def _day_range(days: int) -> list[str]:
+    """All YYYY-MM-DD day strings in the window, oldest first, inclusive of
+    today. Used to backfill 0-call days so the renderer always gets a
+    contiguous series for the sparkline."""
+    today = datetime.now(timezone.utc).date()
+    return [(today - timedelta(days=i)).isoformat() for i in range(days - 1, -1, -1)]
+
+
+def cost_overview(days: int) -> dict:
+    """Build the cost-overview payload from llm_calls.
+
+    Returned shape (all monetary values are USD, all token counts are integers):
+
+        {
+          "range_days": int,
+          "as_of": ISO-8601 UTC,
+          "kpis": {
+            "total_calls": int,
+            "total_cost_usd": float,
+            "total_input_tokens": int,
+            "total_output_tokens": int,
+            "errors": int,
+            "error_rate": float    # 0..1, 0 if total_calls == 0
+          },
+          "daily": [{day, calls, cost_usd, input_tokens, output_tokens, errors}, ...],
+          "by_source_type": [{source_type, calls, cost_usd, tokens}, ...],
+          "by_purpose":     [{purpose, calls, cost_usd, avg_latency_ms, errors}, ...],
+          "by_identity":    [
+              {"kind": "signed_in", "calls", "cost_usd", "unique_actors"},
+              {"kind": "anon",      "calls", "cost_usd", "unique_actors"}
+          ],
+          "top_users": [{user_id, calls, cost_usd}, ...]
+        }
+    """
+    since = _since_iso(days)
+    days_index = _day_range(days)
+
+    with _get_conn() as conn:
+        # KPIs (all statuses; error_rate is errors / all calls).
+        kpi_row = conn.execute(
+            """
+            SELECT
+                COUNT(*)                                                AS total_calls,
+                COALESCE(SUM(cost_usd), 0)                              AS total_cost_usd,
+                COALESCE(SUM(input_tokens), 0)                          AS total_input_tokens,
+                COALESCE(SUM(output_tokens), 0)                         AS total_output_tokens,
+                COALESCE(SUM(CASE WHEN status='error' THEN 1 ELSE 0 END), 0) AS errors
+            FROM llm_calls
+            WHERE ts >= ?
+            """,
+            (since,),
+        ).fetchone()
+
+        # Daily series. Group by date-prefix of ts (we stamp 'YYYY-MM-DDTHH:MM:SS'
+        # so substr(1, 10) is the date) and backfill missing days below.
+        daily_rows = conn.execute(
+            """
+            SELECT
+                substr(ts, 1, 10)                                       AS day,
+                COUNT(*)                                                AS calls,
+                COALESCE(SUM(cost_usd), 0)                              AS cost_usd,
+                COALESCE(SUM(input_tokens), 0)                          AS input_tokens,
+                COALESCE(SUM(output_tokens), 0)                         AS output_tokens,
+                SUM(CASE WHEN status='error' THEN 1 ELSE 0 END)         AS errors
+            FROM llm_calls
+            WHERE ts >= ?
+            GROUP BY day
+            ORDER BY day
+            """,
+            (since,),
+        ).fetchall()
+        by_day = {r["day"]: r for r in daily_rows}
+        daily = [
+            {
+                "day": d,
+                "calls": by_day[d]["calls"] if d in by_day else 0,
+                "cost_usd": by_day[d]["cost_usd"] if d in by_day else 0.0,
+                "input_tokens": by_day[d]["input_tokens"] if d in by_day else 0,
+                "output_tokens": by_day[d]["output_tokens"] if d in by_day else 0,
+                "errors": by_day[d]["errors"] if d in by_day else 0,
+            }
+            for d in days_index
+        ]
+
+        # Successful calls only — source_type breakdown is about what users are
+        # analysing, not what's failing. Failures are surfaced separately.
+        source_rows = conn.execute(
+            """
+            SELECT
+                COALESCE(NULLIF(source_type, ''), '(unknown)')          AS source_type,
+                COUNT(*)                                                AS calls,
+                COALESCE(SUM(cost_usd), 0)                              AS cost_usd,
+                COALESCE(SUM(input_tokens + output_tokens), 0)          AS tokens
+            FROM llm_calls
+            WHERE ts >= ? AND status = 'ok'
+            GROUP BY source_type
+            ORDER BY cost_usd DESC
+            """,
+            (since,),
+        ).fetchall()
+
+        # By purpose: include error count and avg latency (successful only —
+        # error rows have latency_ms but zero tokens, so they'd skew the avg).
+        purpose_rows = conn.execute(
+            """
+            SELECT
+                purpose,
+                COUNT(*)                                                AS calls,
+                COALESCE(SUM(cost_usd), 0)                              AS cost_usd,
+                CAST(COALESCE(AVG(CASE WHEN status='ok' THEN latency_ms END), 0) AS INTEGER) AS avg_latency_ms,
+                SUM(CASE WHEN status='error' THEN 1 ELSE 0 END)         AS errors
+            FROM llm_calls
+            WHERE ts >= ?
+            GROUP BY purpose
+            ORDER BY cost_usd DESC
+            """,
+            (since,),
+        ).fetchall()
+
+        # Identity split. Two separate queries rather than a CASE-WHEN GROUP BY
+        # keeps the unique-actor count clean (anon counts distinct anon_id,
+        # signed-in counts distinct user_id; the dimensions aren't comparable).
+        signed_in = conn.execute(
+            """
+            SELECT
+                COUNT(*)                          AS calls,
+                COALESCE(SUM(cost_usd), 0)        AS cost_usd,
+                COUNT(DISTINCT user_id)           AS unique_actors
+            FROM llm_calls
+            WHERE ts >= ? AND status = 'ok' AND user_id IS NOT NULL
+            """,
+            (since,),
+        ).fetchone()
+        anon = conn.execute(
+            """
+            SELECT
+                COUNT(*)                          AS calls,
+                COALESCE(SUM(cost_usd), 0)        AS cost_usd,
+                COUNT(DISTINCT anon_id)           AS unique_actors
+            FROM llm_calls
+            WHERE ts >= ? AND status = 'ok' AND user_id IS NULL
+            """,
+            (since,),
+        ).fetchone()
+
+        # Top users by total cost. user_id only — emails are deliberately not
+        # exposed in this response (admin auth is gated by Cloudflare Access,
+        # but we still keep PII out of the analytics surface).
+        top_user_rows = conn.execute(
+            """
+            SELECT
+                user_id,
+                COUNT(*)                          AS calls,
+                COALESCE(SUM(cost_usd), 0)        AS cost_usd
+            FROM llm_calls
+            WHERE ts >= ? AND status = 'ok' AND user_id IS NOT NULL
+            GROUP BY user_id
+            ORDER BY cost_usd DESC
+            LIMIT ?
+            """,
+            (since, _TOP_USERS_LIMIT),
+        ).fetchall()
+
+    total_calls = kpi_row["total_calls"] or 0
+    errors = kpi_row["errors"] or 0
+    error_rate = (errors / total_calls) if total_calls > 0 else 0.0
+
+    return {
+        "range_days": days,
+        "as_of": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "kpis": {
+            "total_calls": total_calls,
+            "total_cost_usd": round(kpi_row["total_cost_usd"], 6),
+            "total_input_tokens": kpi_row["total_input_tokens"] or 0,
+            "total_output_tokens": kpi_row["total_output_tokens"] or 0,
+            "errors": errors,
+            "error_rate": round(error_rate, 4),
+        },
+        "daily": daily,
+        "by_source_type": [
+            {
+                "source_type": r["source_type"],
+                "calls": r["calls"],
+                "cost_usd": round(r["cost_usd"], 6),
+                "tokens": r["tokens"],
+            }
+            for r in source_rows
+        ],
+        "by_purpose": [
+            {
+                "purpose": r["purpose"],
+                "calls": r["calls"],
+                "cost_usd": round(r["cost_usd"], 6),
+                "avg_latency_ms": r["avg_latency_ms"],
+                "errors": r["errors"],
+            }
+            for r in purpose_rows
+        ],
+        "by_identity": [
+            {
+                "kind": "signed_in",
+                "calls": signed_in["calls"] or 0,
+                "cost_usd": round(signed_in["cost_usd"], 6),
+                "unique_actors": signed_in["unique_actors"] or 0,
+            },
+            {
+                "kind": "anon",
+                "calls": anon["calls"] or 0,
+                "cost_usd": round(anon["cost_usd"], 6),
+                "unique_actors": anon["unique_actors"] or 0,
+            },
+        ],
+        "top_users": [
+            {
+                "user_id": r["user_id"],
+                "calls": r["calls"],
+                "cost_usd": round(r["cost_usd"], 6),
+            }
+            for r in top_user_rows
+        ],
+    }
+
+
+@router.get("/cost-overview")
+async def cost_overview_endpoint(
+    days: int = Query(default=_DEFAULT_DAYS, ge=1, le=_MAX_DAYS),
+    _: None = Depends(_require_admin_secret),
+) -> dict:
+    """Cost & usage rollup across `llm_calls` for the last `days` days.
+
+    Caller is the Worker's admin dashboard. Response is pre-shaped for direct
+    rendering — see `cost_overview()` for the full shape.
+    """
+    return cost_overview(days)

--- a/main.py
+++ b/main.py
@@ -128,8 +128,10 @@ async def lifespan(app: FastAPI):
 app = FastAPI(lifespan=lifespan)
 
 from bot.api import router as api_router  # noqa: E402
+from bot.admin import router as admin_router  # noqa: E402
 
 app.include_router(api_router)
+app.include_router(admin_router)
 
 _STATIC_DIR = Path(__file__).parent / "bot" / "static"
 

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,0 +1,275 @@
+"""Tests for the /api/admin/* endpoints.
+
+Three things matter here:
+  1. Auth — the admin secret is separate from the try-secret. Wrong/missing
+     header rejects; misconfigured server (no secret) fails closed.
+  2. Aggregations — the SQL queries against `llm_calls` produce the shape and
+     numbers the Worker's renderer expects (totals, daily series with
+     zero-filled days, source/purpose breakdowns, identity split, top users).
+  3. Date filtering — only rows inside the window count.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def admin_client(monkeypatch):
+    """A TestClient mounted on the admin router with the secret pre-set."""
+    monkeypatch.setenv("FILTER_FYI_ADMIN_SECRET", "test-admin-secret")
+    import bot.admin
+    app = FastAPI()
+    app.include_router(bot.admin.router)
+    return TestClient(app)
+
+
+@pytest.fixture
+def admin_headers():
+    return {"x-filter-fyi-admin-secret": "test-admin-secret"}
+
+
+def _stamp(db, *, days_ago: int = 0, **overrides) -> None:
+    """Insert one llm_calls row with `ts` set N days in the past.
+
+    `insert_llm_call` uses sqlite's `strftime('now')` default for `ts`, so it
+    can't be used directly for backdated rows — write through a raw cursor
+    instead. Defaults match a successful Anthropic analyze call.
+    """
+    ts = (datetime.now(timezone.utc) - timedelta(days=days_ago)).strftime(
+        "%Y-%m-%dT%H:%M:%S"
+    )
+    row = {
+        "user_id": None,
+        "anon_id": None,
+        "job_id": None,
+        "provider": "anthropic",
+        "model": "claude-haiku-4-5-20251001",
+        "purpose": "analyze",
+        "source_type": "article",
+        "input_tokens": 100,
+        "output_tokens": 50,
+        "cost_usd": 0.00035,
+        "latency_ms": 500,
+        "status": "ok",
+        "error": "",
+    }
+    row.update(overrides)
+    with db._get_conn() as conn:
+        conn.execute(
+            "INSERT INTO llm_calls (ts, user_id, anon_id, job_id, provider, "
+            "model, purpose, source_type, input_tokens, output_tokens, "
+            "cost_usd, latency_ms, status, error) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                ts, row["user_id"], row["anon_id"], row["job_id"], row["provider"],
+                row["model"], row["purpose"], row["source_type"],
+                row["input_tokens"], row["output_tokens"], row["cost_usd"],
+                row["latency_ms"], row["status"], row["error"],
+            ),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Auth
+# ---------------------------------------------------------------------------
+
+class TestAdminAuth:
+    def test_correct_secret_accepted(self, admin_client, admin_headers):
+        r = admin_client.get("/api/admin/cost-overview", headers=admin_headers)
+        assert r.status_code == 200
+
+    def test_missing_header_rejected(self, admin_client):
+        r = admin_client.get("/api/admin/cost-overview")
+        assert r.status_code == 401
+
+    def test_wrong_secret_rejected(self, admin_client):
+        r = admin_client.get(
+            "/api/admin/cost-overview",
+            headers={"x-filter-fyi-admin-secret": "nope"},
+        )
+        assert r.status_code == 401
+
+    def test_no_configured_secret_fails_closed(self, admin_client, monkeypatch):
+        # An admin endpoint with no secret configured must never serve, even
+        # when the caller provides a (random) header.
+        monkeypatch.delenv("FILTER_FYI_ADMIN_SECRET", raising=False)
+        r = admin_client.get(
+            "/api/admin/cost-overview",
+            headers={"x-filter-fyi-admin-secret": "anything"},
+        )
+        assert r.status_code == 503
+
+    def test_admin_secret_independent_of_try_secret(self, admin_client, monkeypatch):
+        # Setting the try-secret alone must not grant admin access. The point
+        # of separating the two is that a try-secret leak doesn't give admin.
+        monkeypatch.setenv("FILTER_FYI_TRY_SECRET", "test-secret")
+        r = admin_client.get(
+            "/api/admin/cost-overview",
+            headers={"x-filter-fyi-secret": "test-secret"},
+        )
+        assert r.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Cost overview shape & aggregations
+# ---------------------------------------------------------------------------
+
+class TestCostOverviewEmpty:
+    def test_empty_table_returns_zero_kpis_and_daily_backfill(
+        self, admin_client, admin_headers
+    ):
+        r = admin_client.get(
+            "/api/admin/cost-overview?days=7", headers=admin_headers
+        )
+        assert r.status_code == 200
+        body = r.json()
+        assert body["range_days"] == 7
+        assert body["kpis"] == {
+            "total_calls": 0,
+            "total_cost_usd": 0.0,
+            "total_input_tokens": 0,
+            "total_output_tokens": 0,
+            "errors": 0,
+            "error_rate": 0.0,
+        }
+        # Daily series still has 7 entries (the backfill is what the
+        # renderer relies on for a contiguous sparkline).
+        assert len(body["daily"]) == 7
+        assert all(d["calls"] == 0 and d["cost_usd"] == 0.0 for d in body["daily"])
+        assert body["by_source_type"] == []
+        assert body["by_purpose"] == []
+        assert body["top_users"] == []
+        # by_identity is always two rows even when empty.
+        kinds = {row["kind"] for row in body["by_identity"]}
+        assert kinds == {"signed_in", "anon"}
+
+
+class TestCostOverviewWithData:
+    def test_kpis_sum_across_all_rows(self, db, admin_client, admin_headers):
+        _stamp(db, input_tokens=100, output_tokens=50, cost_usd=0.0005)
+        _stamp(db, input_tokens=200, output_tokens=80, cost_usd=0.001)
+        _stamp(db, status="error", input_tokens=0, output_tokens=0, cost_usd=0)
+
+        r = admin_client.get("/api/admin/cost-overview", headers=admin_headers)
+        body = r.json()
+        kpis = body["kpis"]
+        assert kpis["total_calls"] == 3
+        assert kpis["total_input_tokens"] == 300
+        assert kpis["total_output_tokens"] == 130
+        assert abs(kpis["total_cost_usd"] - 0.0015) < 1e-9
+        assert kpis["errors"] == 1
+        assert kpis["error_rate"] == round(1 / 3, 4)
+
+    def test_daily_groups_by_date_and_backfills_zero_days(
+        self, db, admin_client, admin_headers
+    ):
+        _stamp(db, days_ago=0, cost_usd=0.001)
+        _stamp(db, days_ago=0, cost_usd=0.002)  # same day → 0.003
+        _stamp(db, days_ago=2, cost_usd=0.004)  # gap day at days_ago=1
+
+        r = admin_client.get(
+            "/api/admin/cost-overview?days=3", headers=admin_headers
+        )
+        body = r.json()
+        daily = body["daily"]
+        # Series is ordered oldest-first across the full window.
+        assert len(daily) == 3
+        assert daily[0]["cost_usd"] - 0.004 < 1e-9  # 2 days ago
+        assert daily[1]["cost_usd"] == 0.0          # 1 day ago — backfilled
+        assert daily[1]["calls"] == 0
+        assert abs(daily[2]["cost_usd"] - 0.003) < 1e-9  # today
+
+    def test_by_source_type_sorts_by_cost_and_excludes_errors(
+        self, db, admin_client, admin_headers
+    ):
+        _stamp(db, source_type="article", cost_usd=0.001)
+        _stamp(db, source_type="article", cost_usd=0.002)
+        _stamp(db, source_type="photo", cost_usd=0.005)
+        _stamp(db, source_type="photo", status="error", cost_usd=0)  # excluded
+
+        r = admin_client.get("/api/admin/cost-overview", headers=admin_headers)
+        rows = r.json()["by_source_type"]
+        assert [row["source_type"] for row in rows] == ["photo", "article"]
+        assert rows[0]["calls"] == 1   # error excluded
+        assert rows[1]["calls"] == 2
+
+    def test_by_purpose_includes_errors_in_count_but_not_avg_latency(
+        self, db, admin_client, admin_headers
+    ):
+        _stamp(db, purpose="analyze", latency_ms=400)
+        _stamp(db, purpose="analyze", latency_ms=600)
+        # Error rows have latency_ms but zero tokens — excluding them from the
+        # avg keeps "how long does a real call take" honest.
+        _stamp(db, purpose="analyze", status="error", latency_ms=10, cost_usd=0)
+        _stamp(db, purpose="summary", latency_ms=1200, cost_usd=0.002)
+
+        r = admin_client.get("/api/admin/cost-overview", headers=admin_headers)
+        by_purpose = {row["purpose"]: row for row in r.json()["by_purpose"]}
+        assert by_purpose["analyze"]["calls"] == 3
+        assert by_purpose["analyze"]["errors"] == 1
+        assert by_purpose["analyze"]["avg_latency_ms"] == 500  # (400+600)/2
+        assert by_purpose["summary"]["calls"] == 1
+        assert by_purpose["summary"]["errors"] == 0
+
+    def test_by_identity_splits_anon_and_signed_in(
+        self, db, admin_client, admin_headers
+    ):
+        _stamp(db, user_id=1, cost_usd=0.001)
+        _stamp(db, user_id=1, cost_usd=0.001)  # same user → 1 unique actor
+        _stamp(db, user_id=2, cost_usd=0.001)  # 2 distinct users total
+        _stamp(db, anon_id="anon-A", cost_usd=0.002)
+        _stamp(db, anon_id="anon-A", cost_usd=0.002)  # same anon → 1 unique
+        _stamp(db, anon_id="anon-B", cost_usd=0.002)  # 2 distinct anons total
+
+        r = admin_client.get("/api/admin/cost-overview", headers=admin_headers)
+        by_kind = {row["kind"]: row for row in r.json()["by_identity"]}
+        assert by_kind["signed_in"]["calls"] == 3
+        assert by_kind["signed_in"]["unique_actors"] == 2
+        assert by_kind["anon"]["calls"] == 3
+        assert by_kind["anon"]["unique_actors"] == 2
+
+    def test_top_users_capped_and_excludes_anon(
+        self, db, admin_client, admin_headers
+    ):
+        # 12 users, decreasing cost. Top 10 returned, anon row not in the list.
+        for i in range(12):
+            _stamp(db, user_id=i + 1, cost_usd=(12 - i) * 0.001)
+        _stamp(db, anon_id="anon-xyz", cost_usd=999)
+
+        r = admin_client.get("/api/admin/cost-overview", headers=admin_headers)
+        top = r.json()["top_users"]
+        assert len(top) == 10
+        assert top[0]["user_id"] == 1   # highest cost (12 * 0.001)
+        assert top[0]["cost_usd"] - 0.012 < 1e-9
+        assert all(t["user_id"] != "anon-xyz" for t in top)
+
+
+class TestRangeFiltering:
+    def test_rows_older_than_window_excluded(
+        self, db, admin_client, admin_headers
+    ):
+        _stamp(db, days_ago=2, cost_usd=0.001)
+        _stamp(db, days_ago=10, cost_usd=0.999)  # outside a 7-day window
+        r = admin_client.get(
+            "/api/admin/cost-overview?days=7", headers=admin_headers
+        )
+        body = r.json()
+        assert body["kpis"]["total_calls"] == 1
+        assert abs(body["kpis"]["total_cost_usd"] - 0.001) < 1e-9
+
+    def test_days_param_validated(self, admin_client, admin_headers):
+        # FastAPI's Query(ge=1, le=365) should reject out-of-range values.
+        assert admin_client.get(
+            "/api/admin/cost-overview?days=0", headers=admin_headers
+        ).status_code == 422
+        assert admin_client.get(
+            "/api/admin/cost-overview?days=10000", headers=admin_headers
+        ).status_code == 422


### PR DESCRIPTION
First admin observability endpoint. Supplies the **Cost** pillar of the admin.filter.fyi dashboard ([filter.fyi#22](https://github.com/johannespietsch/filter.fyi/pull/22)) by pre-rolling every aggregation the page needs in one round-trip — the Worker just renders, no math.

## What's in

**[bot/admin.py](bot/admin.py)** — new module:
- APIRouter at `/api/admin`
- \`_require_admin_secret\` dependency reading **\`FILTER_FYI_ADMIN_SECRET\`** (separate from \`FILTER_FYI_TRY_SECRET\`; the two rotate independently and a try-secret leak doesn't grant admin)
- \`GET /api/admin/cost-overview?days=N\` (default 30, max 365)

Response shape:
\`\`\`json
{
  "range_days": 30,
  "as_of": "2026-06-01T...",
  "kpis": { "total_calls", "total_cost_usd", "total_input_tokens",
            "total_output_tokens", "errors", "error_rate" },
  "daily": [{ "day", "calls", "cost_usd", "input_tokens",
              "output_tokens", "errors" }, ...],
  "by_source_type": [{ "source_type", "calls", "cost_usd", "tokens" }, ...],
  "by_purpose":     [{ "purpose", "calls", "cost_usd",
                       "avg_latency_ms", "errors" }, ...],
  "by_identity":    [
    { "kind": "signed_in", "calls", "cost_usd", "unique_actors" },
    { "kind": "anon",      "calls", "cost_usd", "unique_actors" }
  ],
  "top_users": [{ "user_id", "calls", "cost_usd" }, ...]
}
\`\`\`

Design choices worth flagging:
- **Daily series is zero-filled** to a contiguous N-day window so the renderer doesn't have to know about gaps — the sparkline can just iterate.
- **\`avg_latency_ms\` uses successful calls only.** Error rows have latency but zero tokens, so including them would skew the "how long does a real call take" answer.
- **\`top_users\` is user_id only — no email.** Admin auth is gated by Cloudflare Access, but keeping PII out of analytics responses is cheap defense in depth ([[feedback_data_isolation]] in spirit).
- **By-identity is two separate queries** rather than a CASE-WHEN GROUP BY — \`unique_actors\` counts distinct user_id for signed-in rows and distinct anon_id for anon rows, and the two dimensions aren't sensibly combined.

## Tests

14 new in [tests/test_admin.py](tests/test_admin.py):
- Auth: correct/missing/wrong header, fail-closed when secret unset, try-secret-isn't-admin
- Empty table → zero KPIs + N-day backfilled \`daily\` series
- KPIs sum across all statuses including errors
- Daily groups by date and backfills gap days with zeros
- \`by_source_type\` sorts by cost, excludes errors
- \`by_purpose\` counts errors but excludes them from avg latency
- \`by_identity\` splits anon and signed_in with correct unique-actor counts
- \`top_users\` capped at 10, excludes anon rows
- Range filtering: older rows excluded; \`days\` param validated (422 outside 1..365)

Full suite: **151 passed**.

## Deploy

1. Merge → Fly auto-deploys
2. Set the admin secret on Fly:
   \`\`\`bash
   fly secrets set FILTER_FYI_ADMIN_SECRET=$(openssl rand -hex 32) -a filter-fyi-backend
   \`\`\`
3. Set the same value as \`BOT_ADMIN_KEY\` on the Worker (paired filter.fyi PR will use this).

## Follow-up

Paired frontend PR on filter.fyi: \`/cost\` route in \`src/admin.ts\` fetching this endpoint and rendering the six tiles (KPIs, daily sparkline, by source_type, by purpose, identity split, top users).

🤖 Generated with [Claude Code](https://claude.com/claude-code)