### PR TITLE
feat: expose full summary in /api/job done payload

### DIFF
--- a/bot/api.py
+++ b/bot/api.py
@@ -671,11 +671,15 @@ async def _run_job(
             )
 
         verdict = analysis.pop("verdict", "skim")
+        # `content` is the full stored brief, exposed so the result page can
+        # show the basis for the verdict. `content_preview` is kept for the
+        # Worker's D1 claim path, which stays on a 2k slice to bound row size.
         result: dict = {
             "url": url,
             "title": fetched.get("title") or url,
             "source_type": source_type,
             "image_urls": fetched.get("image_urls") or [],
+            "content": summary,
             "content_preview": summary[:TRY_PREVIEW_CHARS],
             "verdict": verdict,
             "analysis": analysis,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -394,6 +394,21 @@ class TestJobFlow:
         assert "id" not in result
         assert db.get_all_items() == []
 
+    def test_run_job_done_payload_exposes_full_summary(self, client, db):
+        # The result page renders the full stored brief in a "what we read"
+        # disclosure, so the done payload must carry `content` alongside the
+        # short `content_preview` used by the Worker's D1 claim path.
+        import asyncio
+        import json
+        import bot.api
+
+        db.create_job("job-content")
+        asyncio.run(bot.api._run_job("job-content", "https://example.com/x", None, ""))
+
+        result = json.loads(db.get_job_record("job-content")["result"])
+        assert result["content"] == "Neutral summary of the content."
+        assert result["content_preview"] == "Neutral summary of the content."
+
     def test_run_job_analyzes_the_summary_not_raw_text(self, client, db, monkeypatch):
         # The verdict must be derived from the stored summary, not the raw
         # fetched text (the canonical-representation contract).


### PR DESCRIPTION
## Summary
- The `/api/job` done payload now ships `content` (the full stored brief, up to ~32k chars) alongside the existing `content_preview`. The frontend uses this to render a "what we read" transparency disclosure under the verdict.
- `content_preview` (2k slice) stays as the field the Worker writes into D1 for the anon claim-on-signup path, so anon row size remains bounded.

## Test plan
- [x] `make test` (152 passed)
- [ ] On the linked frontend PR, paste a URL on `/` as an anon visitor → expand "show what we read" → see the full brief
- [ ] After signing up, the claimed item in `/me` still shows analysis (claim path unaffected)

Pairs with frontend PR: filter.fyi-frontend feat/show-summary-brief

🤖 Generated with [Claude Code](https://claude.com/claude-code)