### PR TITLE
feat: capture analyze I/O traces for offline LLM-as-judge evals

### DIFF
--- a/bot/analyzer.py
+++ b/bot/analyzer.py
@@ -63,6 +63,25 @@ def _record_usage(
     )
 
 
+def _capture_trace(*, text: str, profile: str, output: dict, ctx: UsageContext | None) -> None:
+    """Best-effort write of one row to analyze_traces. Gated by env flag inside
+    `record_analyze_trace`; never raises into the caller."""
+    from bot.db import record_analyze_trace
+
+    c = ctx or UsageContext()
+    record_analyze_trace(
+        provider=_PROVIDER,
+        model=_MODEL,
+        source_type=c.source_type,
+        input_text=text,
+        profile_text=profile,
+        output=output,
+        user_id=c.user_id,
+        anon_id=c.anon_id,
+        job_id=c.job_id,
+    )
+
+
 def _anthropic_tokens(resp) -> tuple[int, int]:
     """Pull (input_tokens, output_tokens) off an Anthropic Messages response.
     Missing usage is treated as (0, 0) rather than raising — we'd rather log a
@@ -252,7 +271,9 @@ def analyze(text: str, user_id: int | None = None, *, ctx: UsageContext | None =
                           started_at=started, ctx=ctx)
             for block in resp.content:
                 if getattr(block, "type", None) == "tool_use" and block.name == "record_analysis":
-                    return _normalize(block.input)
+                    result = _normalize(block.input)
+                    _capture_trace(text=text, profile=profile, output=result, ctx=ctx)
+                    return result
             raise RuntimeError("Anthropic did not return a record_analysis tool_use block")
 
         resp = client.chat.completions.create(
@@ -268,7 +289,9 @@ def analyze(text: str, user_id: int | None = None, *, ctx: UsageContext | None =
             raw = json.loads(content)
         except json.JSONDecodeError as e:
             raise RuntimeError(f"OpenAI returned non-JSON content: {e}: {content[:200]}")
-        return _normalize(raw)
+        result = _normalize(raw)
+        _capture_trace(text=text, profile=profile, output=result, ctx=ctx)
+        return result
     except Exception as e:
         # Log the failed attempt so failure rate shows up next to spend.
         _record_usage(purpose="analyze", input_tokens=0, output_tokens=0,

--- a/bot/db.py
+++ b/bot/db.py
@@ -106,6 +106,8 @@ _CREATE_INDEXES_SQL = [
     "CREATE INDEX IF NOT EXISTS idx_llm_calls_ts ON llm_calls(ts DESC)",
     "CREATE INDEX IF NOT EXISTS idx_llm_calls_user ON llm_calls(user_id, ts DESC)",
     "CREATE INDEX IF NOT EXISTS idx_llm_calls_anon ON llm_calls(anon_id, ts DESC)",
+    "CREATE INDEX IF NOT EXISTS idx_analyze_traces_ts ON analyze_traces(ts DESC)",
+    "CREATE INDEX IF NOT EXISTS idx_analyze_traces_retention ON analyze_traces(retention_until)",
 ]
 
 # Per-call LLM usage log. One row per upstream API call (analyze, summary,
@@ -150,6 +152,34 @@ CREATE TABLE IF NOT EXISTS jobs (
 # retrieve its result. Pending jobs stay until they resolve or the server
 # restarts (the frontend times out its own polling after ~2 min).
 JOB_RETENTION_SECONDS = 3_600
+
+# Captured I/O for `purpose='analyze'` calls. Kept separate from `llm_calls`
+# so the retention policy and access controls for raw content are explicit
+# (llm_calls is metadata-only and can be kept forever; this table holds the
+# actual user input and structured model output and is purged on a fixed TTL).
+# Population is gated by ANALYZE_TRACE_CAPTURE=1 — off by default so prod
+# doesn't start retaining content without an explicit operator decision.
+# `retention_until` is set per row so changing the TTL doesn't retroactively
+# extend rows already written; the purge helper reads the column directly.
+_CREATE_ANALYZE_TRACES_SQL = """\
+CREATE TABLE IF NOT EXISTS analyze_traces (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts              TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%S', 'now')),
+    user_id         INTEGER,
+    anon_id         TEXT,
+    job_id          TEXT,
+    provider        TEXT    NOT NULL DEFAULT '',
+    model           TEXT    NOT NULL DEFAULT '',
+    source_type     TEXT    NOT NULL DEFAULT '',
+    input_text      TEXT    NOT NULL DEFAULT '',
+    profile_text    TEXT    NOT NULL DEFAULT '',
+    output_json     TEXT    NOT NULL DEFAULT '',
+    retention_until TEXT    NOT NULL
+)"""
+
+ANALYZE_TRACE_RETENTION_SECONDS = int(
+    os.getenv("ANALYZE_TRACE_RETENTION_SECONDS") or 30 * 24 * 3_600
+)
 
 # Allowed feedback signals. Explicit taps + cheap implicit proxies. Kept as an
 # allowlist so the data stays clean enough to learn from.
@@ -245,6 +275,7 @@ def _init() -> None:
         conn.execute(_CREATE_FEEDBACK_SQL)
         conn.execute(_CREATE_JOBS_SQL)
         conn.execute(_CREATE_LLM_CALLS_SQL)
+        conn.execute(_CREATE_ANALYZE_TRACES_SQL)
         for stmt in _CREATE_INDEXES_SQL:
             conn.execute(stmt)
 
@@ -679,6 +710,68 @@ def insert_llm_call(
         # Surface in logs but never propagate — see docstring.
         import logging as _logging
         _logging.getLogger(__name__).exception("insert_llm_call failed")
+
+
+# ---------------------------------------------------------------------------
+# Analyze trace capture (eval dataset source)
+# ---------------------------------------------------------------------------
+
+def analyze_trace_capture_enabled() -> bool:
+    """Read the env flag at call time so tests (and ops) can toggle without
+    reimporting the module. Truthy = "1", "true", "yes" (case-insensitive)."""
+    return (os.getenv("ANALYZE_TRACE_CAPTURE") or "").strip().lower() in {"1", "true", "yes"}
+
+
+def record_analyze_trace(
+    *,
+    provider: str,
+    model: str,
+    source_type: str,
+    input_text: str,
+    profile_text: str,
+    output: dict,
+    user_id: int | None = None,
+    anon_id: str | None = None,
+    job_id: str | None = None,
+) -> None:
+    """Persist one `analyze` call's input and structured output for offline eval.
+
+    No-op when ANALYZE_TRACE_CAPTURE is unset. Never raises into the caller —
+    trace capture is best-effort and must not break the analysis path.
+    """
+    if not analyze_trace_capture_enabled():
+        return
+    try:
+        retention_until = (
+            datetime.now(timezone.utc) + timedelta(seconds=ANALYZE_TRACE_RETENTION_SECONDS)
+        ).strftime("%Y-%m-%dT%H:%M:%S")
+        with _get_conn() as conn:
+            conn.execute(
+                "INSERT INTO analyze_traces (user_id, anon_id, job_id, provider, "
+                "model, source_type, input_text, profile_text, output_json, "
+                "retention_until) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    user_id, anon_id, job_id, provider, model, source_type,
+                    input_text or "", profile_text or "",
+                    json.dumps(output, ensure_ascii=False), retention_until,
+                ),
+            )
+    except Exception:
+        import logging as _logging
+        _logging.getLogger(__name__).exception("record_analyze_trace failed")
+
+
+def purge_expired_analyze_traces() -> int:
+    """Delete trace rows whose retention_until is in the past. Returns rowcount.
+
+    Meant to be called from a periodic task (same cadence as other cleanup).
+    """
+    now = _utcnow_iso()
+    with _get_conn() as conn:
+        cur = conn.execute(
+            "DELETE FROM analyze_traces WHERE retention_until <= ?", (now,)
+        )
+        return cur.rowcount
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_analyze_traces.py
+++ b/tests/test_analyze_traces.py
@@ -1,0 +1,258 @@
+"""Tests for analyze trace capture (Phase 1 of the LLM-as-judge eval workflow).
+
+The trace table is the dataset source for offline evals — every captured row
+is a real input/output pair we can later score against rubric variants. The
+contract this test file pins down:
+
+  1. Capture is gated by ANALYZE_TRACE_CAPTURE — off by default, on opt-in.
+     This matters because the table holds raw user content; flipping it on
+     must be an explicit operator decision, not a side effect of a deploy.
+  2. When enabled, `analyze()` writes exactly one trace row alongside the
+     existing `llm_calls` row, with provider/model/source_type and the
+     structured output JSON.
+  3. Writes are best-effort: a DB blip never breaks the analysis path.
+  4. `retention_until` is stamped per row and `purge_expired_analyze_traces`
+     deletes only rows whose TTL has elapsed.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+
+_TOOL_INPUT = {
+    "main_idea": "x", "why_it_matters": "y", "category": "c",
+    "quick_win": "qw", "bigger_play": "bp", "time_required": "5m",
+    "verdict": "watch",
+}
+
+
+class TestFlagGating:
+    def test_capture_disabled_by_default(self, db, monkeypatch):
+        monkeypatch.delenv("ANALYZE_TRACE_CAPTURE", raising=False)
+        assert db.analyze_trace_capture_enabled() is False
+        db.record_analyze_trace(
+            provider="anthropic", model="claude-haiku-4-5-20251001",
+            source_type="article", input_text="hello", profile_text="",
+            output={"main_idea": "x"},
+        )
+        assert _all_traces(db) == []
+
+    def test_capture_enabled_with_truthy_values(self, db, monkeypatch):
+        for val in ("1", "true", "TRUE", "yes"):
+            monkeypatch.setenv("ANALYZE_TRACE_CAPTURE", val)
+            assert db.analyze_trace_capture_enabled() is True
+
+    def test_capture_disabled_with_falsy_values(self, db, monkeypatch):
+        for val in ("0", "false", "", "no"):
+            monkeypatch.setenv("ANALYZE_TRACE_CAPTURE", val)
+            assert db.analyze_trace_capture_enabled() is False
+
+
+class TestRecordHelper:
+    def test_writes_row_with_all_columns(self, db, monkeypatch):
+        monkeypatch.setenv("ANALYZE_TRACE_CAPTURE", "1")
+        db.record_analyze_trace(
+            provider="anthropic", model="claude-haiku-4-5-20251001",
+            source_type="article",
+            input_text="the source text",
+            profile_text="about the user",
+            output={"main_idea": "x", "verdict": "watch"},
+            user_id=7, anon_id="anon-1", job_id="job-9",
+        )
+        rows = _all_traces(db)
+        assert len(rows) == 1
+        r = rows[0]
+        assert r["provider"] == "anthropic"
+        assert r["model"] == "claude-haiku-4-5-20251001"
+        assert r["source_type"] == "article"
+        assert r["input_text"] == "the source text"
+        assert r["profile_text"] == "about the user"
+        assert json.loads(r["output_json"]) == {"main_idea": "x", "verdict": "watch"}
+        assert r["user_id"] == 7
+        assert r["anon_id"] == "anon-1"
+        assert r["job_id"] == "job-9"
+        assert r["retention_until"] > r["ts"]
+
+    def test_anon_row_has_null_user_id(self, db, monkeypatch):
+        monkeypatch.setenv("ANALYZE_TRACE_CAPTURE", "1")
+        db.record_analyze_trace(
+            provider="anthropic", model="claude-haiku-4-5-20251001",
+            source_type="article", input_text="t", profile_text="",
+            output={"main_idea": "x"}, anon_id="anon-xyz",
+        )
+        row = _all_traces(db)[0]
+        assert row["user_id"] is None
+        assert row["anon_id"] == "anon-xyz"
+
+    def test_failure_to_write_does_not_raise(self, db, monkeypatch):
+        # If the DB blows up mid-write the analysis must still succeed —
+        # losing a trace row is acceptable, losing the user's analysis is not.
+        monkeypatch.setenv("ANALYZE_TRACE_CAPTURE", "1")
+
+        def boom(*_a, **_kw):
+            raise RuntimeError("disk gone")
+        monkeypatch.setattr(db, "_get_conn", boom)
+
+        db.record_analyze_trace(
+            provider="anthropic", model="claude-haiku-4-5-20251001",
+            source_type="article", input_text="t", profile_text="",
+            output={"main_idea": "x"},
+        )  # should NOT raise
+
+    def test_retention_respects_env(self, db, monkeypatch):
+        # Use a 1-hour TTL and assert retention_until lands ~1h in the future.
+        monkeypatch.setenv("ANALYZE_TRACE_CAPTURE", "1")
+        monkeypatch.setattr(db, "ANALYZE_TRACE_RETENTION_SECONDS", 3_600)
+        db.record_analyze_trace(
+            provider="anthropic", model="claude-haiku-4-5-20251001",
+            source_type="article", input_text="t", profile_text="",
+            output={"main_idea": "x"},
+        )
+        row = _all_traces(db)[0]
+        ts = datetime.fromisoformat(row["ts"]).replace(tzinfo=timezone.utc)
+        until = datetime.fromisoformat(row["retention_until"]).replace(tzinfo=timezone.utc)
+        delta = until - ts
+        assert timedelta(minutes=59) <= delta <= timedelta(minutes=61)
+
+
+class TestPurge:
+    def test_purge_drops_only_expired_rows(self, db, monkeypatch):
+        # Insert one row with retention in the past, one in the future. Only
+        # the expired one should be deleted; the live one stays untouched.
+        past = "2000-01-01T00:00:00"
+        future = "2999-01-01T00:00:00"
+        with db._get_conn() as conn:
+            conn.execute(
+                "INSERT INTO analyze_traces (provider, model, source_type, "
+                "input_text, profile_text, output_json, retention_until) "
+                "VALUES ('p','m','article','old','','{}',?)",
+                (past,),
+            )
+            conn.execute(
+                "INSERT INTO analyze_traces (provider, model, source_type, "
+                "input_text, profile_text, output_json, retention_until) "
+                "VALUES ('p','m','article','new','','{}',?)",
+                (future,),
+            )
+        deleted = db.purge_expired_analyze_traces()
+        assert deleted == 1
+        rows = _all_traces(db)
+        assert len(rows) == 1
+        assert rows[0]["input_text"] == "new"
+
+
+class TestAnalyzerHook:
+    def test_analyze_writes_trace_when_enabled(self, db, monkeypatch):
+        # End-to-end: with the flag on, one analyze() call produces one
+        # llm_calls row (existing contract) AND one analyze_traces row that
+        # carries the same input, the normalized output, and the source_type.
+        monkeypatch.setenv("ANALYZE_TRACE_CAPTURE", "1")
+        from bot import analyzer
+        monkeypatch.setattr(analyzer, "_PROVIDER", "anthropic")
+        monkeypatch.setattr(analyzer, "_MODEL", "claude-haiku-4-5-20251001")
+        fake = _FakeAnthropic(input_tokens=10, output_tokens=5, tool_input=_TOOL_INPUT)
+        monkeypatch.setattr(analyzer, "_get_client", lambda: fake)
+
+        analyzer.analyze("the source text", ctx=analyzer.UsageContext(
+            user_id=42, source_type="article", job_id="job-1",
+        ))
+
+        traces = _all_traces(db)
+        assert len(traces) == 1
+        t = traces[0]
+        assert t["input_text"] == "the source text"
+        assert t["source_type"] == "article"
+        assert t["user_id"] == 42
+        assert t["job_id"] == "job-1"
+        out = json.loads(t["output_json"])
+        assert out["main_idea"] == "x"
+        assert out["verdict"] == "watch"
+
+    def test_analyze_skips_trace_when_disabled(self, db, monkeypatch):
+        monkeypatch.delenv("ANALYZE_TRACE_CAPTURE", raising=False)
+        from bot import analyzer
+        monkeypatch.setattr(analyzer, "_PROVIDER", "anthropic")
+        monkeypatch.setattr(analyzer, "_MODEL", "claude-haiku-4-5-20251001")
+        fake = _FakeAnthropic(input_tokens=10, output_tokens=5, tool_input=_TOOL_INPUT)
+        monkeypatch.setattr(analyzer, "_get_client", lambda: fake)
+
+        analyzer.analyze("text", ctx=analyzer.UsageContext(user_id=1))
+
+        assert _all_traces(db) == []
+        # llm_calls must still be written — gating only affects traces.
+        with db._get_conn() as conn:
+            assert conn.execute("SELECT COUNT(*) FROM llm_calls").fetchone()[0] == 1
+
+    def test_analyze_failure_writes_no_trace(self, db, monkeypatch):
+        # A failed call has no normalized output to capture; we still log the
+        # error row in llm_calls (existing behaviour) but no trace.
+        monkeypatch.setenv("ANALYZE_TRACE_CAPTURE", "1")
+        from bot import analyzer
+        monkeypatch.setattr(analyzer, "_PROVIDER", "anthropic")
+        monkeypatch.setattr(analyzer, "_MODEL", "claude-haiku-4-5-20251001")
+
+        class Boom:
+            messages = SimpleNamespace(
+                create=lambda **kw: (_ for _ in ()).throw(RuntimeError("rate-limited"))
+            )
+        monkeypatch.setattr(analyzer, "_get_client", lambda: Boom())
+
+        try:
+            analyzer.analyze("text", ctx=analyzer.UsageContext(user_id=1))
+        except RuntimeError:
+            pass
+
+        assert _all_traces(db) == []
+
+    def test_openai_path_also_captures(self, db, monkeypatch):
+        monkeypatch.setenv("ANALYZE_TRACE_CAPTURE", "1")
+        from bot import analyzer
+        monkeypatch.setattr(analyzer, "_PROVIDER", "openai")
+        monkeypatch.setattr(analyzer, "_MODEL", "gpt-4o-mini")
+
+        fake = _FakeOpenAI(
+            prompt_tokens=20, completion_tokens=10,
+            content=json.dumps(_TOOL_INPUT),
+        )
+        monkeypatch.setattr(analyzer, "_get_client", lambda: fake)
+
+        analyzer.analyze("text", ctx=analyzer.UsageContext(
+            anon_id="anon-x", source_type="article",
+        ))
+        traces = _all_traces(db)
+        assert len(traces) == 1
+        assert traces[0]["provider"] == "openai"
+        assert traces[0]["model"] == "gpt-4o-mini"
+        assert traces[0]["anon_id"] == "anon-x"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _all_traces(db):
+    with db._get_conn() as conn:
+        return conn.execute("SELECT * FROM analyze_traces ORDER BY id").fetchall()
+
+
+class _FakeAnthropic:
+    def __init__(self, *, input_tokens, output_tokens, tool_input):
+        content = [SimpleNamespace(type="tool_use", name="record_analysis", input=tool_input)]
+        resp = SimpleNamespace(
+            content=content,
+            usage=SimpleNamespace(input_tokens=input_tokens, output_tokens=output_tokens),
+        )
+        self.messages = SimpleNamespace(create=lambda **kw: resp)
+
+
+class _FakeOpenAI:
+    def __init__(self, *, prompt_tokens, completion_tokens, content):
+        resp = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content=content))],
+            usage=SimpleNamespace(
+                prompt_tokens=prompt_tokens, completion_tokens=completion_tokens,
+            ),
+        )
+        self.chat = SimpleNamespace(completions=SimpleNamespace(create=lambda **kw: resp))


### PR DESCRIPTION
## Summary
- **Phase 1** of the LLM-as-judge eval workflow we sketched out. Adds an `analyze_traces` table that captures real input/output pairs from `analyzer.analyze()` so later phases can score prompt/model variants against actual traffic instead of hand-crafted cases.
- Lives in its own table (not `llm_calls`) so the retention policy and access story for raw user content is explicit. Each row carries its own `retention_until`; default TTL 30d, overridable via `ANALYZE_TRACE_RETENTION_SECONDS`.
- Capture is gated by `ANALYZE_TRACE_CAPTURE=1` and **off by default**. No deploy turns content retention on without an operator flipping the flag.

## What's in here
- `bot/db.py`: new `analyze_traces` schema + two indexes, `record_analyze_trace()` helper (best-effort, never raises), `purge_expired_analyze_traces()` for the periodic cleanup, `analyze_trace_capture_enabled()` env read.
- `bot/analyzer.py`: new `_capture_trace()` helper called from both Anthropic and OpenAI success paths in `analyze()`, after `_normalize()` and after the existing `_record_usage()` call. Failed analyses write no trace (no normalized output to capture).
- `tests/test_analyze_traces.py`: 12 tests across flag gating, write contract, anon rows, failure-safety, retention TTL math, the purge helper, both analyzer provider paths, and the failure path.

## Out of scope (next phases)
- Rubric design (the load-bearing thinking work).
- Inspect AI harness wiring (`evals/` dir, judges, run script).
- Admin dashboard tile for trace counts / quality trend.

## Test plan
- [x] `make test` — 164 passed, 0 failed.
- [ ] Deploy to staging with `ANALYZE_TRACE_CAPTURE=1`, run one `/api/try`, verify a row lands in `analyze_traces` with the expected input/output JSON.
- [ ] Verify prod stays untouched: `ANALYZE_TRACE_CAPTURE` not set → table exists but stays empty.
- [ ] After ~1 week of staging data, hand-pick 20 traces for the rubric calibration session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)