### PR TITLE
chore(fly): reduce machine memory from 2GB to 1GB

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -35,7 +35,7 @@ primary_region = 'fra'
     path = '/health'
 
 [[vm]]
-  memory = '2gb'
+  memory = '1gb'
   cpu_kind = 'shared'
   cpus = 2
-  memory_mb = 2048
+  memory_mb = 1024


### PR DESCRIPTION
## Summary
- Drop `[[vm]] memory` from 2 GB to 1 GB on the `filter-fyi-backend` Fly machine (fra).
- Driven by actual usage: Fly Prometheus shows peak memory of **381 MB** (p99 380, avg 336) over the last 11 days — under 19% of the 2 GB allocation.
- Saves the "Additional RAM" line on the Fly bill by roughly two-thirds (~$2.78/mo, ~$33/yr). Still leaves ~2.6× headroom over observed peak.

## Per-job memory ceiling (current pipeline)

Pipeline audit done while sizing this change:

| Component | Typical RSS | Notes |
|---|---|---|
| Python base process | ~120 MB | always resident |
| Whisper `base` int8 (resident weights) | ~140 MB | sticky after first transcription, never freed (`bot/transcriber.py:14`) |
| Whisper inference working set (≤3-min clip) | +150–250 MB transient | during `model.transcribe()` |
| Playwright Chromium (StreamYard path) | +200–300 MB per browser | `bot/fetcher.py:406` |
| yt-dlp audio download | +50–100 MB | brief |
| pdfplumber / LLM HTTP clients / trafilatura | negligible | — |

Single-job worst case today: ~800 MB peak when StreamYard (Chromium) + Whisper run end-to-end. Most jobs peak 300–500 MB. Matches the observed p99 of 380 MB.

## Risk on the smaller machine

The real risk on 1 GB isn't Whisper itself — it's **concurrency**. `bot/api.py:606` fires jobs with `asyncio.create_task` and there's no semaphore. The HTTP `hard_limit = 40` caps incoming requests but not work-in-flight from background tasks. Two concurrent Whisper + browser jobs could blow past 1 GB.

Other surfaces to watch before/when long-video async jobs land:
- Upgrading Whisper from `base` to `small`/`medium`/`large-v3` adds +200 MB / +700 MB / >1 GB resident respectively — `medium`+ won't fit on 1 GB.
- Removing the 180s Whisper cap (`bot/fetcher.py:94`) is roughly memory-safe in isolation (faster-whisper streams segment-by-segment), but raises the per-job duration window in which concurrency can stack.
- Large multi-hundred-page PDFs in pdfplumber can spike to 300–400 MB; not in current load but possible.

Suggested follow-up before async-jobs work lands: add a job-level `asyncio.Semaphore(1)` (or 2) around the executor calls in `bot/api.py:649`. Cheaper than over-provisioning RAM, and makes the machine's capacity explicit.

## Test plan
- [ ] Merge, then `fly deploy` from main
- [ ] Verify `/health` is passing after rollout
- [ ] Tail `fly logs` for OOM kills over the next ~24h
- [ ] Re-check `fly_instance_memory_mem_available` and `fly_instance_memory_pressure_some` to confirm headroom on the smaller machine

## Rollback
- One-line revert of fly.toml + redeploy, or `fly machine update --memory 2048 d8d441ec6167e8` for an immediate in-place bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)