### PR TITLE
fix: ack Telegram webhook before handler chain runs

### DIFF
--- a/main.py
+++ b/main.py
@@ -151,6 +151,30 @@ def _webhook_secret_ok(provided: str | None) -> bool:
     return secrets.compare_digest(provided or "", WEBHOOK_SECRET)
 
 
+# Live references to in-flight webhook handlers. Background tasks can be
+# garbage-collected if nothing holds a reference to them — we add each task
+# here on creation and let `add_done_callback` clean it up on completion.
+_webhook_tasks: set[asyncio.Task] = set()
+
+
+async def _process_update_in_background(update: Update) -> None:
+    """Run the Telegram handler chain off the webhook request path.
+
+    Telegram retries any webhook call that doesn't ack within ~60s. Long-form
+    content (video transcribe → summarise → analyse) easily exceeds that, so
+    awaiting `process_update` inside the request handler turned the same
+    update into an N-times-retried storm — every retry started a fresh chain
+    while the previous one was still spending tokens. Decoupling the ack from
+    the work makes the timeout irrelevant. Errors are logged but not
+    re-raised — the task is fire-and-forget by design.
+    """
+    try:
+        await telegram_app.process_update(update)
+    except Exception:
+        update_id = getattr(update, "update_id", "?")
+        logger.exception("background process_update failed for update %s", update_id)
+
+
 @app.post("/webhook")
 async def webhook(request: Request) -> Response:
     if not telegram_app or not WEBHOOK_URL:
@@ -162,7 +186,13 @@ async def webhook(request: Request) -> Response:
         return Response(status_code=403)
     data = await request.json()
     update = Update.de_json(data, telegram_app.bot)
-    await telegram_app.process_update(update)
+    # Do NOT await — see _process_update_in_background. We must ack within
+    # Telegram's webhook timeout (~60s) regardless of how long the handler
+    # chain ends up running, or the same update will be redelivered and
+    # double-processed.
+    task = asyncio.create_task(_process_update_in_background(update))
+    _webhook_tasks.add(task)
+    task.add_done_callback(_webhook_tasks.discard)
     return Response(status_code=200)
 
 

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -1,10 +1,17 @@
-"""Tests for Telegram webhook authentication in main.py.
+"""Tests for Telegram webhook authentication and lifecycle in main.py.
 
 The /webhook route is the one public, unauthenticated-by-default surface on the
 backend, so it must reject any request that doesn't echo our secret token.
+
+It must also ack with 200 *before* the handler chain completes — Telegram
+retries any webhook call that doesn't ack within ~60s, so a slow handler
+(video transcribe → analyze easily exceeds that) used to get the same update
+redelivered and double-processed. The fire-and-forget tests below pin that.
 """
 from __future__ import annotations
 
+import asyncio
+import time
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -51,7 +58,7 @@ class TestWebhookRoute:
         monkeypatch.setattr(main_mod.Update, "de_json", lambda data, bot: {"ok": 1})
         return TestClient(main_mod.app), app_stub
 
-    def test_valid_secret_processes_update(self, client):
+    def test_valid_secret_processes_update(self, client, main_mod):
         c, app_stub = client
         r = c.post(
             "/webhook",
@@ -59,6 +66,10 @@ class TestWebhookRoute:
             headers={"X-Telegram-Bot-Api-Secret-Token": "s3cret"},
         )
         assert r.status_code == 200
+        # process_update runs on a background task created by the handler.
+        # We have to drain the task set before asserting on the mock —
+        # otherwise the assertion races the scheduled task.
+        _drain_webhook_tasks(main_mod)
         app_stub.process_update.assert_awaited_once()
 
     def test_invalid_secret_rejected_without_processing(self, client):
@@ -76,3 +87,108 @@ class TestWebhookRoute:
         r = c.post("/webhook", json={"update_id": 1})
         assert r.status_code == 403
         app_stub.process_update.assert_not_awaited()
+
+
+class TestWebhookFireAndForget:
+    """Webhook must ack 200 before the handler chain completes.
+
+    Telegram retries any webhook call that doesn't return 200 within ~60s.
+    Long content (video transcribe → analyse) easily blows past that; the
+    fix is to schedule processing as a background task and return 200
+    immediately. These tests pin that behaviour.
+    """
+
+    @pytest.fixture
+    def client(self, main_mod, monkeypatch):
+        app_stub = MagicMock()
+        # AsyncMock by default — individual tests can replace process_update
+        # with something that blocks to assert non-blocking ack.
+        app_stub.process_update = AsyncMock()
+        monkeypatch.setattr(main_mod, "telegram_app", app_stub)
+        monkeypatch.setattr(main_mod, "WEBHOOK_URL", "https://example.com")
+        monkeypatch.setattr(main_mod, "WEBHOOK_SECRET", "s3cret")
+        monkeypatch.setattr(main_mod.Update, "de_json", lambda data, bot: {"ok": 1})
+        return TestClient(main_mod.app), app_stub
+
+    def test_returns_200_before_long_handler_finishes(self, client, main_mod):
+        c, app_stub = client
+        # Block the handler "forever" until we explicitly release it. If the
+        # webhook awaited process_update, the request below would hang.
+        release = asyncio.Event()
+
+        async def blocking(_update):
+            await release.wait()
+
+        app_stub.process_update = blocking
+
+        t0 = time.monotonic()
+        r = c.post(
+            "/webhook",
+            json={"update_id": 99},
+            headers={"X-Telegram-Bot-Api-Secret-Token": "s3cret"},
+        )
+        elapsed = time.monotonic() - t0
+        assert r.status_code == 200
+        # Generous bound. The actual response is sub-millisecond, but TestClient
+        # + anyio overhead can add a bit. Anything well under "Telegram's 60s
+        # timeout" proves the non-blocking ack contract.
+        assert elapsed < 0.5, f"webhook blocked {elapsed:.2f}s on slow handler"
+
+        # The task is alive in _webhook_tasks. Let it finish so the test
+        # cleanup doesn't leak warnings about un-awaited coroutines.
+        _release_and_drain(main_mod, release)
+
+    def test_background_handler_exception_logged_not_propagated(
+        self, client, main_mod, caplog
+    ):
+        """A crashing handler must not break the webhook for subsequent calls.
+        The task is fire-and-forget; failures get logged to error_log via the
+        SQLite log handler, but the route always returns 200 to Telegram."""
+        c, app_stub = client
+
+        async def boom(_update):
+            raise RuntimeError("handler crashed mid-analyse")
+
+        app_stub.process_update = boom
+
+        import logging
+        with caplog.at_level(logging.ERROR, logger="main"):
+            r = c.post(
+                "/webhook",
+                json={"update_id": 7},
+                headers={"X-Telegram-Bot-Api-Secret-Token": "s3cret"},
+            )
+            assert r.status_code == 200
+            _drain_webhook_tasks(main_mod)
+        # Error was logged, not raised back into the request path.
+        assert any("background process_update failed" in rec.message for rec in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _drain_webhook_tasks(main_mod, timeout: float = 2.0) -> None:
+    """Block until every task currently in `_webhook_tasks` has completed.
+
+    Tests need this because the webhook route schedules `process_update` as a
+    background task and returns immediately. Asserting on the mock right after
+    the request would race the task.
+    """
+    end = time.monotonic() + timeout
+    while main_mod._webhook_tasks and time.monotonic() < end:
+        time.sleep(0.01)
+
+
+def _release_and_drain(main_mod, event: asyncio.Event, timeout: float = 2.0) -> None:
+    """Release a test-controlled blocking handler and wait for the task to
+    drain. Has to set the event from inside the same event loop the task
+    is running on — TestClient's anyio portal provides that loop."""
+    async def _set():
+        event.set()
+    # Use the portal that TestClient set up; falls back to creating one if
+    # the test happens to call this outside a request context.
+    from anyio.from_thread import start_blocking_portal
+    with start_blocking_portal() as portal:
+        portal.call(_set)
+    _drain_webhook_tasks(main_mod, timeout=timeout)


### PR DESCRIPTION
**Production incident fix.** While debugging "upstream unreachable" on the new admin cost dashboard, traced Fly returning 503 on `/health` for ~35s back to all uvicorn workers being blocked re-analysing the same long video repeatedly. Anthropic API logs showed the same video being processed over and over while the user's Telegram bot was firing duplicate "Analyzing..." replies.

## Root cause

\`main.py\`'s webhook route awaits the full Telegram handler chain inline:

\`\`\`python
@app.post("/webhook")
async def webhook(request):
    ...
    await telegram_app.process_update(update)   # ← blocks until handlers complete
    return Response(status_code=200)             # ← Telegram has long since given up
\`\`\`

For a long video, \`handle_video\` runs:

\`\`\`
download → transcribe (slow!) → save_file → analyze + summarise (LLM) → reply
\`\`\`

That easily exceeds Telegram's ~60s webhook timeout. Telegram considers the call failed, retries the same \`update_id\`, the new request fires another full chain while the previous one is still spending tokens, and so on. Each "completion" the user saw was actually a fresh retry, not a recovery — explains both the runaway Anthropic spend and the Fly machine becoming unresponsive (all worker slots blocked, including \`/health\`).

## Fix

Decouple the ack from the work. Schedule \`process_update\` as a background task, return 200 immediately:

\`\`\`python
_webhook_tasks: set[asyncio.Task] = set()

async def _process_update_in_background(update):
    try:
        await telegram_app.process_update(update)
    except Exception:
        logger.exception("background process_update failed for update %s", update.update_id)

@app.post("/webhook")
async def webhook(request):
    ...
    task = asyncio.create_task(_process_update_in_background(update))
    _webhook_tasks.add(task)
    task.add_done_callback(_webhook_tasks.discard)
    return Response(status_code=200)
\`\`\`

Same pattern as \`_background_tasks\` in \`bot/api.py:_run_job\`. Tracked in a set so tasks aren't GC'd mid-run. Errors log via the existing SQLite log handler (so they still show up in \`scan_errors\` reports) but never propagate back to the route.

## Tests

166 passed (was 164, +2 new):

- **Existing**: \`test_valid_secret_processes_update\` now drains \`_webhook_tasks\` before asserting on the mock — without the drain it races the scheduled task and is flaky.
- **New**: \`test_returns_200_before_long_handler_finishes\` — replaces \`process_update\` with a coroutine that blocks on an \`asyncio.Event\` "forever"; asserts the webhook returned 200 in <0.5s. Pins the non-blocking ack contract.
- **New**: \`test_background_handler_exception_logged_not_propagated\` — handler that raises \`RuntimeError\`; asserts request still 200s and the error was logged.

## Deploy + recovery sequence

1. **Merge** → Fly auto-deploys.
2. **Re-enable the Telegram webhook** (user had deleted it to stop the bleed):
   \`\`\`bash
   TOKEN=<bot_token>
   SECRET=<WEBHOOK_SECRET from fly.toml/env>
   curl -sS -X POST "https://api.telegram.org/bot$TOKEN/setWebhook" \\
     -d "url=https://filter-fyi-backend.fly.dev/webhook" \\
     -d "secret_token=$SECRET"
   curl -sS "https://api.telegram.org/bot$TOKEN/getWebhookInfo" | jq
   \`\`\`
3. **Verify**: send a short message to the bot. \`getWebhookInfo\` should show \`pending_update_count: 0\` and the bot should reply within seconds. Then try the long video again — bot should reply "Extracting and transcribing video audio..." once (not repeatedly).

## Cost of the incident

The runaway spent real tokens. Worth running a quick query against \`llm_calls\` for the affected window to see total impact:

\`\`\`bash
fly ssh console -a filter-fyi-backend -C "sqlite3 /data/research.db \\"SELECT COUNT(*) calls, printf('\$%.2f', SUM(cost_usd)) spent FROM llm_calls WHERE ts >= datetime('now', '-24 hours')\\""
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)