### PR TITLE
feat: dedup Telegram webhooks by update_id (belt-and-braces)

### DIFF
--- a/bot/db.py
+++ b/bot/db.py
@@ -108,6 +108,7 @@ _CREATE_INDEXES_SQL = [
     "CREATE INDEX IF NOT EXISTS idx_llm_calls_anon ON llm_calls(anon_id, ts DESC)",
     "CREATE INDEX IF NOT EXISTS idx_analyze_traces_ts ON analyze_traces(ts DESC)",
     "CREATE INDEX IF NOT EXISTS idx_analyze_traces_retention ON analyze_traces(retention_until)",
+    "CREATE INDEX IF NOT EXISTS idx_processed_updates_ts ON processed_updates(ts)",
 ]
 
 # Per-call LLM usage log. One row per upstream API call (analyze, summary,
@@ -180,6 +181,21 @@ CREATE TABLE IF NOT EXISTS analyze_traces (
 ANALYZE_TRACE_RETENTION_SECONDS = int(
     os.getenv("ANALYZE_TRACE_RETENTION_SECONDS") or 30 * 24 * 3_600
 )
+
+# Telegram update-id dedup ledger. The webhook claims an `update_id` before
+# scheduling any background work; a second arrival of the same id (a
+# Telegram retry) finds the row already present and is dropped. This is the
+# belt-and-braces follow-up to the fire-and-forget webhook fix in #34 — even
+# if the handler chain ever blocks again, retries can't double-process.
+# Retention is short — Telegram's active retry window is minutes, but we keep
+# rows for a generous interval so a delayed retry still dedups cleanly.
+_CREATE_PROCESSED_UPDATES_SQL = """\
+CREATE TABLE IF NOT EXISTS processed_updates (
+    update_id  INTEGER PRIMARY KEY,
+    ts         TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%S', 'now'))
+)"""
+
+PROCESSED_UPDATES_RETENTION_SECONDS = 24 * 3_600  # 24h is well past any plausible retry
 
 # Allowed feedback signals. Explicit taps + cheap implicit proxies. Kept as an
 # allowlist so the data stays clean enough to learn from.
@@ -276,6 +292,7 @@ def _init() -> None:
         conn.execute(_CREATE_JOBS_SQL)
         conn.execute(_CREATE_LLM_CALLS_SQL)
         conn.execute(_CREATE_ANALYZE_TRACES_SQL)
+        conn.execute(_CREATE_PROCESSED_UPDATES_SQL)
         for stmt in _CREATE_INDEXES_SQL:
             conn.execute(stmt)
 
@@ -621,6 +638,7 @@ def prune_maintenance(now=None) -> dict:
     cache_cutoff = _ts(now - timedelta(seconds=URL_CACHE_TTL_SECONDS))
     now_str = _ts(now)
     jobs_cutoff = _ts(now - timedelta(seconds=JOB_RETENTION_SECONDS))
+    updates_cutoff = _ts(now - timedelta(seconds=PROCESSED_UPDATES_RETENTION_SECONDS))
     with _get_conn() as conn:
         errors = conn.execute("DELETE FROM error_log WHERE ts < ?", (err_cutoff,)).rowcount or 0
         cache = conn.execute(
@@ -634,7 +652,13 @@ def prune_maintenance(now=None) -> dict:
             "DELETE FROM jobs WHERE status != 'pending' AND updated_at < ?",
             (jobs_cutoff,),
         ).rowcount or 0
-    return {"error_log": errors, "url_cache": cache, "link_codes": codes, "jobs": jobs}
+        updates = conn.execute(
+            "DELETE FROM processed_updates WHERE ts < ?", (updates_cutoff,)
+        ).rowcount or 0
+    return {
+        "error_log": errors, "url_cache": cache, "link_codes": codes,
+        "jobs": jobs, "processed_updates": updates,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -669,6 +693,31 @@ def get_job_record(job_id: str) -> sqlite3.Row | None:
             "SELECT id, status, result, error FROM jobs WHERE id = ?",
             (job_id,),
         ).fetchone()
+
+
+# ---------------------------------------------------------------------------
+# Telegram update-id dedup
+# ---------------------------------------------------------------------------
+
+def claim_telegram_update(update_id: int) -> bool:
+    """Atomically reserve a Telegram update_id for processing.
+
+    Returns True if this is the first time we've seen this id and the caller
+    should proceed with the handler chain. Returns False if it was already
+    claimed (a Telegram retry, or a duplicate webhook delivery), meaning the
+    caller should ack 200 but do no work.
+
+    Implementation uses INSERT OR IGNORE so the check-and-set is a single
+    atomic operation — two simultaneous arrivals of the same id can both
+    pass an "exists" check but only one INSERT succeeds. SQLite reports the
+    successful insert via rowcount == 1.
+    """
+    with _get_conn() as conn:
+        cur = conn.execute(
+            "INSERT OR IGNORE INTO processed_updates (update_id) VALUES (?)",
+            (update_id,),
+        )
+        return cur.rowcount > 0
 
 
 # ---------------------------------------------------------------------------

--- a/main.py
+++ b/main.py
@@ -186,6 +186,18 @@ async def webhook(request: Request) -> Response:
         return Response(status_code=403)
     data = await request.json()
     update = Update.de_json(data, telegram_app.bot)
+    # Belt-and-braces dedup: even with the fire-and-forget fix below, an
+    # earlier blocked-handler era backlog (or any future bug that re-stalls
+    # the ack path) could see Telegram retrying the same update_id while a
+    # background task is still running. claim_telegram_update is an atomic
+    # INSERT OR IGNORE — only the first call gets True. Updates without an
+    # update_id (malformed payloads / test stubs) bypass dedup, since there's
+    # nothing meaningful to key on.
+    if update is not None and getattr(update, "update_id", None) is not None:
+        from bot.db import claim_telegram_update
+        if not claim_telegram_update(update.update_id):
+            logger.info("dropping duplicate webhook for update_id=%s", update.update_id)
+            return Response(status_code=200)
     # Do NOT await — see _process_update_in_background. We must ack within
     # Telegram's webhook timeout (~60s) regardless of how long the handler
     # chain ends up running, or the same update will be redelivered and

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -352,17 +352,59 @@ class TestPruneMaintenance:
                 (NEW,),
             )
 
+        # Old + new processed_updates rows — old should prune (past 24h).
+        with db._get_conn() as conn:
+            conn.execute("INSERT INTO processed_updates (update_id, ts) VALUES (1, ?)", (OLD,))
+            conn.execute("INSERT INTO processed_updates (update_id, ts) VALUES (2, ?)", (NEW,))
+
         counts = db.prune_maintenance(now=datetime(2026, 5, 20, tzinfo=timezone.utc))
-        assert counts == {"error_log": 1, "url_cache": 1, "link_codes": 1, "jobs": 1}
+        assert counts == {
+            "error_log": 1, "url_cache": 1, "link_codes": 1, "jobs": 1,
+            "processed_updates": 1,
+        }
 
         with db._get_conn() as conn:
             assert [r["message"] for r in conn.execute("SELECT message FROM error_log")] == ["new"]
             assert [r["url"] for r in conn.execute("SELECT url FROM url_cache")] == ["https://new"]
             assert [r["code"] for r in conn.execute("SELECT code FROM link_codes")] == ["NEW"]
             assert {r["id"] for r in conn.execute("SELECT id FROM jobs")} == {"old-pending", "new-done"}
+            assert [r["update_id"] for r in conn.execute("SELECT update_id FROM processed_updates")] == [2]
 
     def test_idempotent_on_empty(self, db):
         from datetime import datetime, timezone
 
         counts = db.prune_maintenance(now=datetime(2026, 5, 20, tzinfo=timezone.utc))
-        assert counts == {"error_log": 0, "url_cache": 0, "link_codes": 0, "jobs": 0}
+        assert counts == {
+            "error_log": 0, "url_cache": 0, "link_codes": 0, "jobs": 0,
+            "processed_updates": 0,
+        }
+
+
+class TestClaimTelegramUpdate:
+    """First arrival of an update_id claims it; subsequent calls return False
+    so the caller knows it's a retry and skips processing."""
+
+    def test_first_claim_returns_true(self, db):
+        assert db.claim_telegram_update(12345) is True
+
+    def test_second_claim_for_same_id_returns_false(self, db):
+        assert db.claim_telegram_update(12345) is True
+        assert db.claim_telegram_update(12345) is False
+        assert db.claim_telegram_update(12345) is False  # still false
+
+    def test_distinct_ids_each_claim(self, db):
+        assert db.claim_telegram_update(1) is True
+        assert db.claim_telegram_update(2) is True
+        assert db.claim_telegram_update(3) is True
+        # And they all stay claimed
+        assert db.claim_telegram_update(1) is False
+        assert db.claim_telegram_update(2) is False
+
+    def test_row_persists_for_dedup_window(self, db):
+        db.claim_telegram_update(999)
+        with db._get_conn() as conn:
+            row = conn.execute(
+                "SELECT update_id, ts FROM processed_updates WHERE update_id = 999"
+            ).fetchone()
+        assert row["update_id"] == 999
+        assert row["ts"]  # default-stamped

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -164,6 +164,50 @@ class TestWebhookFireAndForget:
         assert any("background process_update failed" in rec.message for rec in caplog.records)
 
 
+class TestWebhookDedup:
+    """A second arrival of the same Telegram update_id must NOT spawn another
+    handler run. Belt-and-braces for any future bug that re-stalls the ack
+    path — without this, a slow handler could still see N copies of the same
+    work scheduled in parallel before each retry ack'd.
+    """
+
+    @pytest.fixture
+    def client(self, main_mod, monkeypatch):
+        app_stub = MagicMock()
+        app_stub.process_update = AsyncMock()
+        monkeypatch.setattr(main_mod, "telegram_app", app_stub)
+        monkeypatch.setattr(main_mod, "WEBHOOK_URL", "https://example.com")
+        monkeypatch.setattr(main_mod, "WEBHOOK_SECRET", "s3cret")
+        # Use a real Update-like object with update_id so dedup engages.
+        monkeypatch.setattr(
+            main_mod.Update, "de_json",
+            lambda data, bot: type("U", (), {"update_id": data["update_id"]})(),
+        )
+        return TestClient(main_mod.app), app_stub
+
+    def test_duplicate_update_id_drops_silently(self, client, main_mod):
+        c, app_stub = client
+        hdr = {"X-Telegram-Bot-Api-Secret-Token": "s3cret"}
+
+        r1 = c.post("/webhook", json={"update_id": 42}, headers=hdr)
+        r2 = c.post("/webhook", json={"update_id": 42}, headers=hdr)
+        # Both ack 200 — we want Telegram to stop retrying — but only the
+        # first one scheduled work.
+        assert r1.status_code == 200
+        assert r2.status_code == 200
+        _drain_webhook_tasks(main_mod)
+        assert app_stub.process_update.await_count == 1
+
+    def test_distinct_update_ids_both_process(self, client, main_mod):
+        c, app_stub = client
+        hdr = {"X-Telegram-Bot-Api-Secret-Token": "s3cret"}
+
+        c.post("/webhook", json={"update_id": 100}, headers=hdr)
+        c.post("/webhook", json={"update_id": 101}, headers=hdr)
+        _drain_webhook_tasks(main_mod)
+        assert app_stub.process_update.await_count == 2
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Follow-up to #34. Defense-in-depth against the exact bug class that caused the recent runaway: same Telegram \`update_id\` arriving twice spawns one handler chain max, regardless of what's happening in the ack path.

## Why

#34 fixed the *cause* of the runaway (slow handler → missed 60s ack → Telegram retries). This PR locks down the *consequence*: even if some future bug ever re-stalls the request path (a deploy mid-handler, a network blip, a thread leak), Telegram retries of the same \`update_id\` can't double-process. A single new failure mode would have to invent itself for this to break.

## Change

- **New table** \`processed_updates(update_id PRIMARY KEY, ts)\` — tiny ledger.
- **Helper** \`claim_telegram_update(update_id) -> bool\` uses \`INSERT OR IGNORE\` so the check-and-set is one atomic op. Two simultaneous arrivals of the same id both attempt insert; only one wins (rowcount=1). The loser returns False and the webhook ack 200s without scheduling work. Telegram should still see 200 — the message *was* processed, by the first call.
- **Retention**: 24h via the existing \`prune_maintenance\` sweep. Telegram's active retry window is minutes; 24h is well past any plausible storm.
- **Edge case**: updates without an \`update_id\` (malformed payloads, test stubs) bypass dedup — nothing meaningful to key on.

## Why \`INSERT OR IGNORE\` and not a SELECT-then-INSERT

A \`SELECT 1 FROM processed_updates WHERE update_id=?\` followed by an \`INSERT\` is racey: two retries arriving in parallel could both see "not found" and both insert. The PRIMARY KEY would catch the second one, but only after both attempted work. \`INSERT OR IGNORE\` collapses the check and insert into a single atomic write — SQLite returns rowcount=1 on success, 0 on conflict. One round-trip, no race.

## Tests (6 new, 172 total)

| Test | What it pins |
|---|---|
| \`test_first_claim_returns_true\` | Cold ledger, first claim wins |
| \`test_second_claim_for_same_id_returns_false\` | Idempotency — repeated calls stay denied |
| \`test_distinct_ids_each_claim\` | Different ids are independent |
| \`test_row_persists_for_dedup_window\` | Row + timestamp actually stored |
| \`test_duplicate_update_id_drops_silently\` | End-to-end through the webhook route: 2nd call still 200s, but \`process_update\` only called once |
| \`test_distinct_update_ids_both_process\` | Different update_ids both schedule work |

Plus updates to the two existing \`prune_maintenance\` tests to assert the new \`processed_updates\` count in the return dict.

## Operational note

After merge, you'll see one new row in \`processed_updates\` per Telegram update — bounded by your Telegram traffic + 24h retention. At current scale this is rounding error on disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)