### PR TITLE
feat: LLM result cache + hit-rate tile data + ops runbook

### DIFF
--- a/bot/admin.py
+++ b/bot/admin.py
@@ -94,7 +94,13 @@ def cost_overview(days: int) -> dict:
               {"kind": "signed_in", "calls", "cost_usd", "unique_actors"},
               {"kind": "anon",      "calls", "cost_usd", "unique_actors"}
           ],
-          "top_users": [{user_id, calls, cost_usd}, ...]
+          "top_users": [{user_id, calls, cost_usd}, ...],
+          "cache": {
+            "hits": int,
+            "cost_saved_usd": float,   # sum of estimated savings on hits
+            "hit_rate": float,         # 0..1 over (hits + cacheable upstream)
+            "by_purpose": [{purpose, hits, cost_saved_usd}, ...]
+          }
         }
     """
     since = _since_iso(days)
@@ -226,9 +232,50 @@ def cost_overview(days: int) -> dict:
             (since, _TOP_USERS_LIMIT),
         ).fetchall()
 
+        # Cache hits: total + per-purpose breakdown + estimated savings.
+        # "Saved" is the sum of cost_saved_usd stamped at hit time (which
+        # itself was the trailing 7-day average cost-per-call of that
+        # purpose). Honest if pricing/usage have been stable; conservative
+        # if the recent average was below the actual cost of THIS specific
+        # input. Either way it's the right order of magnitude.
+        cache_row = conn.execute(
+            """
+            SELECT
+                COUNT(*)                              AS hits,
+                COALESCE(SUM(cost_saved_usd), 0)      AS cost_saved_usd
+            FROM llm_cache_hits
+            WHERE ts >= ?
+            """,
+            (since,),
+        ).fetchone()
+        cache_by_purpose_rows = conn.execute(
+            """
+            SELECT
+                purpose,
+                COUNT(*)                              AS hits,
+                COALESCE(SUM(cost_saved_usd), 0)      AS cost_saved_usd
+            FROM llm_cache_hits
+            WHERE ts >= ?
+            GROUP BY purpose
+            ORDER BY hits DESC
+            """,
+            (since,),
+        ).fetchall()
+
     total_calls = kpi_row["total_calls"] or 0
     errors = kpi_row["errors"] or 0
     error_rate = (errors / total_calls) if total_calls > 0 else 0.0
+
+    hits_total = cache_row["hits"] or 0
+    cost_saved = cache_row["cost_saved_usd"] or 0.0
+    # Hit rate = hits / (hits + upstream-calls). Upstream-calls here counts
+    # only `purpose IN ('analyze', 'summary')` to keep the dimension honest
+    # (image and other purposes don't run through the cache yet).
+    cacheable_calls = sum(
+        r["calls"] for r in purpose_rows if r["purpose"] in ("analyze", "summary")
+    )
+    hit_rate_denom = hits_total + cacheable_calls
+    hit_rate = (hits_total / hit_rate_denom) if hit_rate_denom > 0 else 0.0
 
     return {
         "range_days": days,
@@ -283,6 +330,19 @@ def cost_overview(days: int) -> dict:
             }
             for r in top_user_rows
         ],
+        "cache": {
+            "hits": hits_total,
+            "cost_saved_usd": round(cost_saved, 6),
+            "hit_rate": round(hit_rate, 4),
+            "by_purpose": [
+                {
+                    "purpose": r["purpose"],
+                    "hits": r["hits"],
+                    "cost_saved_usd": round(r["cost_saved_usd"], 6),
+                }
+                for r in cache_by_purpose_rows
+            ],
+        },
     }
 
 

--- a/bot/analyzer.py
+++ b/bot/analyzer.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import logging
 import os
@@ -242,6 +243,64 @@ def _normalize(raw: dict) -> dict:
     return out
 
 
+# ---------------------------------------------------------------------------
+# Result caching
+# ---------------------------------------------------------------------------
+#
+# Both analyze() and summarize_content() check a content-addressed cache
+# (bot.db.llm_cache) before calling the LLM. Cache keys hash every input that
+# affects the output: provider, model, prompt template, response schema where
+# applicable, profile text, and the input content. Any change to those inputs
+# changes the key, so a prompt or model bump auto-invalidates without any
+# explicit version flag. Cache misses pay the LLM cost as before; hits skip
+# the upstream call entirely.
+#
+# Cache hits are not written to `llm_calls` — that table is "upstream API
+# calls made". Hits are visible via Fly logs (logger.info) and we'll add a
+# hit-rate tile to the admin dashboard separately once we have a feel for
+# how often this fires.
+
+def _cache_key_analyze(text: str, profile: str) -> str:
+    h = hashlib.sha256()
+    h.update(b"analyze\x00")
+    h.update(_PROVIDER.encode()); h.update(b"\x00")
+    h.update(_MODEL.encode()); h.update(b"\x00")
+    h.update(_PROMPT.encode()); h.update(b"\x00")
+    h.update(json.dumps(_TOOL_SCHEMA, sort_keys=True).encode()); h.update(b"\x00")
+    h.update((profile or "").encode()); h.update(b"\x00")
+    h.update(text.encode())
+    return h.hexdigest()
+
+
+def _cache_key_summary(text: str) -> str:
+    h = hashlib.sha256()
+    h.update(b"summary\x00")
+    h.update(_PROVIDER.encode()); h.update(b"\x00")
+    h.update(_MODEL.encode()); h.update(b"\x00")
+    h.update(_SUMMARY_PROMPT.encode()); h.update(b"\x00")
+    h.update(text.encode())
+    return h.hexdigest()
+
+
+def _try_cache_get(cache_key: str):
+    """Best-effort cache read. A DB blip should never break analysis — fall
+    through to the LLM if the lookup fails for any reason."""
+    try:
+        from bot.db import get_cached_llm_result
+        return get_cached_llm_result(cache_key)
+    except Exception:
+        logger.exception("llm_cache read failed; treating as miss")
+        return None
+
+
+def _try_cache_set(cache_key: str, purpose: str, payload: str) -> None:
+    try:
+        from bot.db import set_cached_llm_result
+        set_cached_llm_result(cache_key, purpose, payload)
+    except Exception:
+        logger.exception("llm_cache write failed; result not cached")
+
+
 def analyze(text: str, user_id: int | None = None, *, ctx: UsageContext | None = None) -> dict:
     """Returns a dict with keys: main_idea, why_it_matters, category, quick_win, bigger_play, time_required, verdict."""
     # Back-compat: callers that still pass `user_id` positionally get it merged
@@ -252,6 +311,23 @@ def analyze(text: str, user_id: int | None = None, *, ctx: UsageContext | None =
         ctx = UsageContext(user_id=user_id, anon_id=ctx.anon_id, job_id=ctx.job_id, source_type=ctx.source_type)
 
     profile = _load_profile(ctx.user_id)
+
+    # Content-addressed cache lookup. Key spans every input that affects the
+    # output, so a prompt/model/schema change auto-invalidates. Skips the
+    # upstream LLM call entirely on hit — no llm_calls row written because
+    # nothing was actually called.
+    cache_key = _cache_key_analyze(text, profile)
+    cached = _try_cache_get(cache_key)
+    if cached is not None:
+        try:
+            result = json.loads(cached)
+            if isinstance(result, dict) and all(k in result for k in ANALYSIS_FIELDS):
+                logger.info("analyze cache hit (key=%s...)", cache_key[:12])
+                return result
+        except json.JSONDecodeError:
+            # Cache row was corrupt — fall through and overwrite below.
+            logger.warning("analyze cache had non-JSON payload; refreshing")
+
     profile_block = f"\nAbout the person you are analysing for:\n{profile}\n" if profile else ""
     prompt = _PROMPT.format(profile_block=profile_block, text=text)
 
@@ -273,6 +349,7 @@ def analyze(text: str, user_id: int | None = None, *, ctx: UsageContext | None =
                 if getattr(block, "type", None) == "tool_use" and block.name == "record_analysis":
                     result = _normalize(block.input)
                     _capture_trace(text=text, profile=profile, output=result, ctx=ctx)
+                    _try_cache_set(cache_key, "analyze", json.dumps(result, ensure_ascii=False))
                     return result
             raise RuntimeError("Anthropic did not return a record_analysis tool_use block")
 
@@ -291,6 +368,7 @@ def analyze(text: str, user_id: int | None = None, *, ctx: UsageContext | None =
             raise RuntimeError(f"OpenAI returned non-JSON content: {e}: {content[:200]}")
         result = _normalize(raw)
         _capture_trace(text=text, profile=profile, output=result, ctx=ctx)
+        _try_cache_set(cache_key, "analyze", json.dumps(result, ensure_ascii=False))
         return result
     except Exception as e:
         # Log the failed attempt so failure rate shows up next to spend.
@@ -346,6 +424,17 @@ def summarize_content(text: str, *, ctx: UsageContext | None = None) -> str:
     text = (text or "").strip()
     if not text:
         return ""
+
+    # Cache: keyed purely by (provider, model, prompt template, content).
+    # Hit returns the cached summary as-is; miss runs the LLM and caches the
+    # successful output (NOT the truncation fallback below — that would
+    # poison subsequent calls for the same content).
+    cache_key = _cache_key_summary(text)
+    cached = _try_cache_get(cache_key)
+    if cached is not None:
+        logger.info("summary cache hit (key=%s...)", cache_key[:12])
+        return cached[:SUMMARY_MAX_CHARS]
+
     prompt = _SUMMARY_PROMPT.format(text=text)
     max_tokens = _summary_output_tokens(text)
     started = time.monotonic()
@@ -371,7 +460,11 @@ def summarize_content(text: str, *, ctx: UsageContext | None = None) -> str:
             out = (resp.choices[0].message.content or "").strip()
         _record_usage(purpose="summary", input_tokens=in_tok, output_tokens=out_tok,
                       started_at=started, ctx=ctx)
-        return out[:SUMMARY_MAX_CHARS] if out else text[:SUMMARY_MAX_CHARS]
+        if out:
+            _try_cache_set(cache_key, "summary", out[:SUMMARY_MAX_CHARS])
+            return out[:SUMMARY_MAX_CHARS]
+        # Empty model output — return the truncated source but don't cache.
+        return text[:SUMMARY_MAX_CHARS]
     except Exception as e:
         _record_usage(purpose="summary", input_tokens=0, output_tokens=0,
                       started_at=started, ctx=ctx, status="error", error=str(e)[:200])

--- a/bot/analyzer.py
+++ b/bot/analyzer.py
@@ -301,6 +301,25 @@ def _try_cache_set(cache_key: str, purpose: str, payload: str) -> None:
         logger.exception("llm_cache write failed; result not cached")
 
 
+def _record_cache_hit(*, purpose: str, ctx: UsageContext | None) -> None:
+    """Log one cache hit to `llm_cache_hits` with an estimated cost-saved
+    figure pulled from recent successful upstream calls of the same purpose.
+    Best-effort: a failure here must never break the analyse path."""
+    try:
+        from bot.db import estimate_avg_cost_per_call, record_cache_hit
+        c = ctx or UsageContext()
+        avg = estimate_avg_cost_per_call(purpose)
+        record_cache_hit(
+            purpose=purpose,
+            user_id=c.user_id,
+            anon_id=c.anon_id,
+            source_type=c.source_type,
+            cost_saved_usd=avg,
+        )
+    except Exception:
+        logger.exception("record_cache_hit failed; hit not logged")
+
+
 def analyze(text: str, user_id: int | None = None, *, ctx: UsageContext | None = None) -> dict:
     """Returns a dict with keys: main_idea, why_it_matters, category, quick_win, bigger_play, time_required, verdict."""
     # Back-compat: callers that still pass `user_id` positionally get it merged
@@ -323,6 +342,7 @@ def analyze(text: str, user_id: int | None = None, *, ctx: UsageContext | None =
             result = json.loads(cached)
             if isinstance(result, dict) and all(k in result for k in ANALYSIS_FIELDS):
                 logger.info("analyze cache hit (key=%s...)", cache_key[:12])
+                _record_cache_hit(purpose="analyze", ctx=ctx)
                 return result
         except json.JSONDecodeError:
             # Cache row was corrupt — fall through and overwrite below.
@@ -433,6 +453,7 @@ def summarize_content(text: str, *, ctx: UsageContext | None = None) -> str:
     cached = _try_cache_get(cache_key)
     if cached is not None:
         logger.info("summary cache hit (key=%s...)", cache_key[:12])
+        _record_cache_hit(purpose="summary", ctx=ctx)
         return cached[:SUMMARY_MAX_CHARS]
 
     prompt = _SUMMARY_PROMPT.format(text=text)

--- a/bot/db.py
+++ b/bot/db.py
@@ -109,6 +109,7 @@ _CREATE_INDEXES_SQL = [
     "CREATE INDEX IF NOT EXISTS idx_analyze_traces_ts ON analyze_traces(ts DESC)",
     "CREATE INDEX IF NOT EXISTS idx_analyze_traces_retention ON analyze_traces(retention_until)",
     "CREATE INDEX IF NOT EXISTS idx_processed_updates_ts ON processed_updates(ts)",
+    "CREATE INDEX IF NOT EXISTS idx_llm_cache_created_at ON llm_cache(created_at)",
 ]
 
 # Per-call LLM usage log. One row per upstream API call (analyze, summary,
@@ -196,6 +197,23 @@ CREATE TABLE IF NOT EXISTS processed_updates (
 )"""
 
 PROCESSED_UPDATES_RETENTION_SECONDS = 24 * 3_600  # 24h is well past any plausible retry
+
+# Content-addressed cache of LLM results (analyze + summary). Keyed by a hash
+# of everything that determines the output (provider, model, prompt template,
+# schema where applicable, profile text for analyze, input content). Any
+# change to those inputs auto-invalidates because the key changes. Stops the
+# same content from costing tokens twice — e.g. user retries, Telegram
+# delivers a duplicate, or the prompt is identical across two users with the
+# same profile.
+_CREATE_LLM_CACHE_SQL = """\
+CREATE TABLE IF NOT EXISTS llm_cache (
+    cache_key   TEXT PRIMARY KEY,
+    purpose     TEXT NOT NULL DEFAULT '',
+    payload     TEXT NOT NULL,
+    created_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%S', 'now'))
+)"""
+
+LLM_CACHE_TTL_SECONDS = 30 * 24 * 3_600  # 30d — disk bound, not correctness
 
 # Allowed feedback signals. Explicit taps + cheap implicit proxies. Kept as an
 # allowlist so the data stays clean enough to learn from.
@@ -293,6 +311,7 @@ def _init() -> None:
         conn.execute(_CREATE_LLM_CALLS_SQL)
         conn.execute(_CREATE_ANALYZE_TRACES_SQL)
         conn.execute(_CREATE_PROCESSED_UPDATES_SQL)
+        conn.execute(_CREATE_LLM_CACHE_SQL)
         for stmt in _CREATE_INDEXES_SQL:
             conn.execute(stmt)
 
@@ -639,6 +658,7 @@ def prune_maintenance(now=None) -> dict:
     now_str = _ts(now)
     jobs_cutoff = _ts(now - timedelta(seconds=JOB_RETENTION_SECONDS))
     updates_cutoff = _ts(now - timedelta(seconds=PROCESSED_UPDATES_RETENTION_SECONDS))
+    llm_cache_cutoff = _ts(now - timedelta(seconds=LLM_CACHE_TTL_SECONDS))
     with _get_conn() as conn:
         errors = conn.execute("DELETE FROM error_log WHERE ts < ?", (err_cutoff,)).rowcount or 0
         cache = conn.execute(
@@ -655,9 +675,12 @@ def prune_maintenance(now=None) -> dict:
         updates = conn.execute(
             "DELETE FROM processed_updates WHERE ts < ?", (updates_cutoff,)
         ).rowcount or 0
+        llm_cache = conn.execute(
+            "DELETE FROM llm_cache WHERE created_at < ?", (llm_cache_cutoff,)
+        ).rowcount or 0
     return {
         "error_log": errors, "url_cache": cache, "link_codes": codes,
-        "jobs": jobs, "processed_updates": updates,
+        "jobs": jobs, "processed_updates": updates, "llm_cache": llm_cache,
     }
 
 
@@ -718,6 +741,39 @@ def claim_telegram_update(update_id: int) -> bool:
             (update_id,),
         )
         return cur.rowcount > 0
+
+
+# ---------------------------------------------------------------------------
+# LLM result cache (content-addressed)
+# ---------------------------------------------------------------------------
+
+def get_cached_llm_result(cache_key: str) -> str | None:
+    """Return the cached payload for `cache_key`, or None on miss.
+
+    The caller knows what to do with the string (json.loads for analyze,
+    return as-is for summary). Keeping the table type-agnostic means we
+    can reuse the same machinery for any future LLM purpose.
+    """
+    with _get_conn() as conn:
+        row = conn.execute(
+            "SELECT payload FROM llm_cache WHERE cache_key = ?", (cache_key,)
+        ).fetchone()
+    return row["payload"] if row else None
+
+
+def set_cached_llm_result(cache_key: str, purpose: str, payload: str) -> None:
+    """Persist an LLM result. Uses ON CONFLICT DO UPDATE so concurrent first-
+    misses (two requests with the same input racing past `get_cached_llm_result`
+    returning None) settle on the later value rather than crash. Same payload
+    either way — both ran the same model on the same inputs."""
+    with _get_conn() as conn:
+        conn.execute(
+            "INSERT INTO llm_cache (cache_key, purpose, payload) VALUES (?, ?, ?) "
+            "ON CONFLICT(cache_key) DO UPDATE SET "
+            "  payload = excluded.payload, "
+            "  created_at = strftime('%Y-%m-%dT%H:%M:%S','now')",
+            (cache_key, purpose, payload),
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/bot/db.py
+++ b/bot/db.py
@@ -110,6 +110,8 @@ _CREATE_INDEXES_SQL = [
     "CREATE INDEX IF NOT EXISTS idx_analyze_traces_retention ON analyze_traces(retention_until)",
     "CREATE INDEX IF NOT EXISTS idx_processed_updates_ts ON processed_updates(ts)",
     "CREATE INDEX IF NOT EXISTS idx_llm_cache_created_at ON llm_cache(created_at)",
+    "CREATE INDEX IF NOT EXISTS idx_llm_cache_hits_ts ON llm_cache_hits(ts DESC)",
+    "CREATE INDEX IF NOT EXISTS idx_llm_cache_hits_purpose ON llm_cache_hits(purpose, ts DESC)",
 ]
 
 # Per-call LLM usage log. One row per upstream API call (analyze, summary,
@@ -215,6 +217,27 @@ CREATE TABLE IF NOT EXISTS llm_cache (
 
 LLM_CACHE_TTL_SECONDS = 30 * 24 * 3_600  # 30d — disk bound, not correctness
 
+# Hit log for the cache above. One row per cache hit so the admin dashboard
+# can show a "calls saved / cost avoided" tile alongside the regular spend
+# numbers. The actual cached payload lives in `llm_cache`; this table is
+# pure event log. Cost is captured at hit time (estimated from recent
+# average cost-per-call for the same purpose) so the savings number stays
+# honest even after a model/price change.
+_CREATE_LLM_CACHE_HITS_SQL = """\
+CREATE TABLE IF NOT EXISTS llm_cache_hits (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts            TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%S', 'now')),
+    purpose       TEXT    NOT NULL DEFAULT '',
+    user_id       INTEGER,
+    anon_id       TEXT,
+    source_type   TEXT    NOT NULL DEFAULT '',
+    cost_saved_usd REAL   NOT NULL DEFAULT 0
+)"""
+
+# Same retention as the cache itself — keep just long enough to show on the
+# dashboard's longest window.
+LLM_CACHE_HITS_RETENTION_SECONDS = 30 * 24 * 3_600
+
 # Allowed feedback signals. Explicit taps + cheap implicit proxies. Kept as an
 # allowlist so the data stays clean enough to learn from.
 FEEDBACK_SIGNALS = frozenset({
@@ -312,6 +335,7 @@ def _init() -> None:
         conn.execute(_CREATE_ANALYZE_TRACES_SQL)
         conn.execute(_CREATE_PROCESSED_UPDATES_SQL)
         conn.execute(_CREATE_LLM_CACHE_SQL)
+        conn.execute(_CREATE_LLM_CACHE_HITS_SQL)
         for stmt in _CREATE_INDEXES_SQL:
             conn.execute(stmt)
 
@@ -659,6 +683,7 @@ def prune_maintenance(now=None) -> dict:
     jobs_cutoff = _ts(now - timedelta(seconds=JOB_RETENTION_SECONDS))
     updates_cutoff = _ts(now - timedelta(seconds=PROCESSED_UPDATES_RETENTION_SECONDS))
     llm_cache_cutoff = _ts(now - timedelta(seconds=LLM_CACHE_TTL_SECONDS))
+    llm_cache_hits_cutoff = _ts(now - timedelta(seconds=LLM_CACHE_HITS_RETENTION_SECONDS))
     with _get_conn() as conn:
         errors = conn.execute("DELETE FROM error_log WHERE ts < ?", (err_cutoff,)).rowcount or 0
         cache = conn.execute(
@@ -678,9 +703,13 @@ def prune_maintenance(now=None) -> dict:
         llm_cache = conn.execute(
             "DELETE FROM llm_cache WHERE created_at < ?", (llm_cache_cutoff,)
         ).rowcount or 0
+        llm_cache_hits = conn.execute(
+            "DELETE FROM llm_cache_hits WHERE ts < ?", (llm_cache_hits_cutoff,)
+        ).rowcount or 0
     return {
         "error_log": errors, "url_cache": cache, "link_codes": codes,
         "jobs": jobs, "processed_updates": updates, "llm_cache": llm_cache,
+        "llm_cache_hits": llm_cache_hits,
     }
 
 
@@ -774,6 +803,51 @@ def set_cached_llm_result(cache_key: str, purpose: str, payload: str) -> None:
             "  created_at = strftime('%Y-%m-%dT%H:%M:%S','now')",
             (cache_key, purpose, payload),
         )
+
+
+def record_cache_hit(
+    *,
+    purpose: str,
+    user_id: int | None = None,
+    anon_id: str | None = None,
+    source_type: str = "",
+    cost_saved_usd: float = 0.0,
+) -> None:
+    """Log one cache hit. Best-effort — a DB blip here must never break the
+    analyse path. Cost saved is estimated by the caller from recent average
+    cost-per-call for the same purpose."""
+    try:
+        with _get_conn() as conn:
+            conn.execute(
+                "INSERT INTO llm_cache_hits (purpose, user_id, anon_id, source_type, cost_saved_usd) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (purpose, user_id, anon_id, source_type, float(cost_saved_usd)),
+            )
+    except Exception:
+        import logging as _logging
+        _logging.getLogger(__name__).exception("record_cache_hit failed")
+
+
+def estimate_avg_cost_per_call(purpose: str, lookback_days: int = 7) -> float:
+    """Average cost per *successful* upstream call of this purpose in the
+    recent past. Used to attach an estimated savings amount to cache hits.
+
+    Falls back to 0 when there's no data yet — the dashboard then shows
+    "calls saved" without a $ figure, which is still meaningful.
+    """
+    since = (
+        datetime.now(timezone.utc) - timedelta(days=lookback_days)
+    ).strftime("%Y-%m-%dT%H:%M:%S")
+    try:
+        with _get_conn() as conn:
+            row = conn.execute(
+                "SELECT AVG(cost_usd) AS avg_cost FROM llm_calls "
+                "WHERE purpose = ? AND status = 'ok' AND ts >= ? AND cost_usd > 0",
+                (purpose, since),
+            ).fetchone()
+        return float(row["avg_cost"] or 0.0)
+    except Exception:
+        return 0.0
 
 
 # ---------------------------------------------------------------------------

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -73,9 +73,122 @@ fly volumes list           # check % used
 | Var | Purpose |
 | --- | --- |
 | `FILTER_FYI_TRY_SECRET` | Shared secret with the Cloudflare Worker (must match) |
+| `FILTER_FYI_ADMIN_SECRET` | Shared secret for `/api/admin/*` — must match the Worker's `BOT_ADMIN_KEY`. Separate from `FILTER_FYI_TRY_SECRET` so the two can rotate independently |
 | `TELEGRAM_TOKEN` | Telegram bot token (omit to run web-only) |
 | `WEBHOOK_URL` | Public base URL for Telegram webhook mode |
 | `TELEGRAM_WEBHOOK_SECRET` | Required in webhook mode — verifies inbound updates |
 | `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` | LLM provider (Anthropic preferred) |
 | `LITESTREAM_REPLICA_URL` (+ keys) | Enables continuous backup (optional but recommended) |
 | `SCAN_ERRORS_ENABLED`, `GH_APP_*` | Daily error-log → GitHub-issue scanner |
+
+## Runbook — Fly is wedged / dashboard unreachable
+
+**Symptoms**
+
+- `admin.filter.fyi/cost` shows `upstream unreachable`.
+- `curl -i https://filter-fyi-backend.fly.dev/health` returns `503` from `server: Fly/...` (Fly's edge proxy) after a long delay (~30s).
+- `fly status -a filter-fyi-backend` says machines are `started`, but the dashboard is dark.
+
+The "machine started but app unresponsive" signature usually means the
+uvicorn worker slots are blocked — the configured `hard_limit` of 40
+concurrent requests in `fly.toml` is being soaked by long-running handlers,
+including `/health`.
+
+**Most common cause:** a Telegram retry storm. A handler chain (typically
+video transcribe → summarise → analyse) takes longer than Telegram's ~60s
+webhook timeout. Without the dedup + fire-and-forget in #34/#35, the same
+update gets retried in parallel, each retry spawning another handler
+chain, until every worker slot is held by a copy of the same work. After
+those PRs landed this should not recur, but it remains the diagnostic to
+rule out first.
+
+**1. Diagnose**
+
+```sh
+fly logs -a filter-fyi-backend | tail -50         # what is the app doing?
+fly checks list -a filter-fyi-backend             # consecutive /health failures?
+fly machine status <id> -a filter-fyi-backend     # OOM kills? restarts?
+
+# Has Telegram been retrying?
+TOKEN=$(fly ssh console -a filter-fyi-backend -C "printenv TELEGRAM_TOKEN")
+curl -sS "https://api.telegram.org/bot$TOKEN/getWebhookInfo" | jq '.result | {pending_update_count, last_error_message, last_error_date}'
+```
+
+A non-zero `pending_update_count` + a recent `last_error_date` is the
+smoking gun for the retry storm pattern.
+
+**2. Stop the bleed** (only needed if retries are still firing — i.e.
+`pending_update_count > 0`)
+
+```sh
+# Drops queued Telegram updates so they don't all replay against the new
+# code on restart.
+curl -sS "https://api.telegram.org/bot$TOKEN/deleteWebhook?drop_pending_updates=true"
+```
+
+**3. Restart the machine**
+
+Even after stopping new traffic, any handlers already mid-flight keep
+running until they finish. Restarting cleanly kills them.
+
+```sh
+fly machine list -a filter-fyi-backend
+fly machine restart <id> -a filter-fyi-backend
+sleep 30
+time curl -i https://filter-fyi-backend.fly.dev/health
+# Expect 200 in <200ms.
+```
+
+**4. Re-enable the Telegram webhook**
+
+If you ran step 2, the bot is offline until you re-register the webhook:
+
+```sh
+SECRET=$(fly ssh console -a filter-fyi-backend -C "printenv TELEGRAM_WEBHOOK_SECRET")
+curl -sS -X POST "https://api.telegram.org/bot$TOKEN/setWebhook" \
+  -d "url=https://filter-fyi-backend.fly.dev/webhook" \
+  -d "secret_token=$SECRET"
+curl -sS "https://api.telegram.org/bot$TOKEN/getWebhookInfo" | jq
+```
+
+**5. Quantify the damage**
+
+The runaway spent real tokens. The admin dashboard's Cost tile shows
+the day-level spike clearly; for an exact number:
+
+```sh
+fly ssh console -a filter-fyi-backend -C "sqlite3 /data/research.db \"\
+  SELECT date(ts) day, COUNT(*) calls, printf('\$%.4f', SUM(cost_usd)) spent \
+  FROM llm_calls \
+  WHERE ts >= datetime('now', '-2 days') \
+  GROUP BY day ORDER BY day\""
+```
+
+**6. Post-mortem checklist**
+
+- Was there a recently merged change touching webhook routing, the handler
+  chain, or `process_update`?
+- Did a specific input (a long video, a YouTube livestream) trigger it?
+- If yes, the input is probably worth adding to a fixture / fixture-like
+  manual test next time the relevant code changes.
+
+## Duplicate work — three layers of defense
+
+If you see "the same content was processed N times" — for any reason —
+walk these three caches/dedup layers in order. Each lives at a different
+level, so the right diagnosis depends on *which* dimension is duplicated:
+
+| Symptom | Layer | Where to look |
+| --- | --- | --- |
+| Same Telegram `update_id` arriving twice | `processed_updates` | `getWebhookInfo.pending_update_count`; Fly logs for `dropping duplicate webhook` |
+| Same `(model, prompt, profile, content)` analysed twice | `llm_cache` | `SELECT COUNT(*) FROM llm_cache`; Fly logs for `cache hit (key=…)` |
+| Same URL being re-fetched | `url_cache` | `SELECT url, fetched_at FROM url_cache WHERE url = ?` |
+
+Cache hits and dedup drops are best-effort: a DB blip on the cache path
+falls through to real work. None of them are correctness-critical — they
+exist to make the same input cheap, not to prevent it.
+
+The admin dashboard's Cost tile surfaces cache hit count, estimated cost
+saved, and hit rate, so a quick check at `admin.filter.fyi/cost` is
+usually the fastest way to spot a missing-cache regression after a
+prompt/model change.

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -252,6 +252,45 @@ class TestCostOverviewWithData:
         assert all(t["user_id"] != "anon-xyz" for t in top)
 
 
+class TestCacheStats:
+    """The /api/admin/cost-overview response carries a `cache` block with hit
+    counts and estimated savings — the data behind the dashboard's cache tile."""
+
+    def test_empty_cache_block_when_no_hits(self, admin_client, admin_headers):
+        body = admin_client.get(
+            "/api/admin/cost-overview", headers=admin_headers
+        ).json()
+        assert body["cache"] == {
+            "hits": 0,
+            "cost_saved_usd": 0.0,
+            "hit_rate": 0.0,
+            "by_purpose": [],
+        }
+
+    def test_hits_aggregated_with_estimated_savings(
+        self, db, admin_client, admin_headers
+    ):
+        # Two analyze hits (saving $0.002 each) + one summary hit ($0.01).
+        db.record_cache_hit(purpose="analyze", cost_saved_usd=0.002)
+        db.record_cache_hit(purpose="analyze", cost_saved_usd=0.002)
+        db.record_cache_hit(purpose="summary", cost_saved_usd=0.010)
+        # Plus one real upstream analyze (so hit_rate has a denominator).
+        _stamp(db, purpose="analyze")
+
+        body = admin_client.get(
+            "/api/admin/cost-overview", headers=admin_headers
+        ).json()
+        cache = body["cache"]
+        assert cache["hits"] == 3
+        assert abs(cache["cost_saved_usd"] - 0.014) < 1e-9
+        # hit_rate = 3 hits / (3 hits + 1 cacheable real call) = 0.75
+        assert cache["hit_rate"] == 0.75
+        by = {row["purpose"]: row for row in cache["by_purpose"]}
+        assert by["analyze"]["hits"] == 2
+        assert by["summary"]["hits"] == 1
+        assert abs(by["analyze"]["cost_saved_usd"] - 0.004) < 1e-9
+
+
 class TestRangeFiltering:
     def test_rows_older_than_window_excluded(
         self, db, admin_client, admin_headers

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -354,6 +354,7 @@ class TestPruneMaintenance:
 
         # Old + new processed_updates rows — old should prune (past 24h).
         # Old + new llm_cache rows — old should prune (past 30d TTL).
+        # Old + new llm_cache_hits rows — old should prune (past 30d TTL).
         with db._get_conn() as conn:
             conn.execute("INSERT INTO processed_updates (update_id, ts) VALUES (1, ?)", (OLD,))
             conn.execute("INSERT INTO processed_updates (update_id, ts) VALUES (2, ?)", (NEW,))
@@ -365,11 +366,17 @@ class TestPruneMaintenance:
                 "INSERT INTO llm_cache (cache_key, purpose, payload, created_at) VALUES ('k_new', 'analyze', '{}', ?)",
                 (NEW,),
             )
+            conn.execute(
+                "INSERT INTO llm_cache_hits (ts, purpose) VALUES (?, 'analyze')", (OLD,),
+            )
+            conn.execute(
+                "INSERT INTO llm_cache_hits (ts, purpose) VALUES (?, 'analyze')", (NEW,),
+            )
 
         counts = db.prune_maintenance(now=datetime(2026, 5, 20, tzinfo=timezone.utc))
         assert counts == {
             "error_log": 1, "url_cache": 1, "link_codes": 1, "jobs": 1,
-            "processed_updates": 1, "llm_cache": 1,
+            "processed_updates": 1, "llm_cache": 1, "llm_cache_hits": 1,
         }
 
         with db._get_conn() as conn:
@@ -379,6 +386,7 @@ class TestPruneMaintenance:
             assert {r["id"] for r in conn.execute("SELECT id FROM jobs")} == {"old-pending", "new-done"}
             assert [r["update_id"] for r in conn.execute("SELECT update_id FROM processed_updates")] == [2]
             assert [r["cache_key"] for r in conn.execute("SELECT cache_key FROM llm_cache")] == ["k_new"]
+            assert conn.execute("SELECT COUNT(*) AS n FROM llm_cache_hits").fetchone()["n"] == 1
 
     def test_idempotent_on_empty(self, db):
         from datetime import datetime, timezone
@@ -386,7 +394,7 @@ class TestPruneMaintenance:
         counts = db.prune_maintenance(now=datetime(2026, 5, 20, tzinfo=timezone.utc))
         assert counts == {
             "error_log": 0, "url_cache": 0, "link_codes": 0, "jobs": 0,
-            "processed_updates": 0, "llm_cache": 0,
+            "processed_updates": 0, "llm_cache": 0, "llm_cache_hits": 0,
         }
 
 
@@ -437,3 +445,56 @@ class TestLlmCache:
         db.set_cached_llm_result("k", "analyze", "v1")
         db.set_cached_llm_result("k", "analyze", "v2")
         assert db.get_cached_llm_result("k") == "v2"
+
+
+class TestCacheHitTracking:
+    """`record_cache_hit` and `estimate_avg_cost_per_call` back the dashboard's
+    "calls saved / cost avoided" tile."""
+
+    def test_record_cache_hit_writes_row(self, db):
+        db.record_cache_hit(
+            purpose="analyze", user_id=7, source_type="article",
+            cost_saved_usd=0.0006,
+        )
+        with db._get_conn() as conn:
+            rows = conn.execute("SELECT * FROM llm_cache_hits ORDER BY id").fetchall()
+        assert len(rows) == 1
+        r = rows[0]
+        assert r["purpose"] == "analyze"
+        assert r["user_id"] == 7
+        assert r["anon_id"] is None
+        assert r["source_type"] == "article"
+        assert abs(r["cost_saved_usd"] - 0.0006) < 1e-9
+        assert r["ts"]  # default-stamped
+
+    def test_record_cache_hit_failure_does_not_raise(self, db, monkeypatch):
+        # A DB blip on the hit-log path must NOT break the analyse path.
+        def boom(*_a, **_kw):
+            raise RuntimeError("disk gone")
+        monkeypatch.setattr(db, "_get_conn", boom)
+        db.record_cache_hit(purpose="analyze")  # should NOT raise
+
+    def test_estimate_avg_cost_uses_successful_calls_only(self, db):
+        # Two successful calls + one error row. The error has 0 cost and would
+        # drag the average down if we didn't filter it out.
+        db.insert_llm_call(
+            provider="anthropic", model="claude-haiku-4-5-20251001",
+            purpose="analyze", input_tokens=100, output_tokens=50,
+            cost_usd=0.001, latency_ms=400,
+        )
+        db.insert_llm_call(
+            provider="anthropic", model="claude-haiku-4-5-20251001",
+            purpose="analyze", input_tokens=100, output_tokens=50,
+            cost_usd=0.003, latency_ms=400,
+        )
+        db.insert_llm_call(
+            provider="anthropic", model="claude-haiku-4-5-20251001",
+            purpose="analyze", input_tokens=0, output_tokens=0,
+            cost_usd=0.0, latency_ms=10, status="error",
+        )
+        avg = db.estimate_avg_cost_per_call("analyze")
+        # (0.001 + 0.003) / 2 = 0.002 — error row excluded.
+        assert abs(avg - 0.002) < 1e-9
+
+    def test_estimate_avg_cost_falls_back_to_zero_with_no_data(self, db):
+        assert db.estimate_avg_cost_per_call("analyze") == 0.0

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -353,14 +353,23 @@ class TestPruneMaintenance:
             )
 
         # Old + new processed_updates rows — old should prune (past 24h).
+        # Old + new llm_cache rows — old should prune (past 30d TTL).
         with db._get_conn() as conn:
             conn.execute("INSERT INTO processed_updates (update_id, ts) VALUES (1, ?)", (OLD,))
             conn.execute("INSERT INTO processed_updates (update_id, ts) VALUES (2, ?)", (NEW,))
+            conn.execute(
+                "INSERT INTO llm_cache (cache_key, purpose, payload, created_at) VALUES ('k_old', 'analyze', '{}', ?)",
+                (OLD,),
+            )
+            conn.execute(
+                "INSERT INTO llm_cache (cache_key, purpose, payload, created_at) VALUES ('k_new', 'analyze', '{}', ?)",
+                (NEW,),
+            )
 
         counts = db.prune_maintenance(now=datetime(2026, 5, 20, tzinfo=timezone.utc))
         assert counts == {
             "error_log": 1, "url_cache": 1, "link_codes": 1, "jobs": 1,
-            "processed_updates": 1,
+            "processed_updates": 1, "llm_cache": 1,
         }
 
         with db._get_conn() as conn:
@@ -369,6 +378,7 @@ class TestPruneMaintenance:
             assert [r["code"] for r in conn.execute("SELECT code FROM link_codes")] == ["NEW"]
             assert {r["id"] for r in conn.execute("SELECT id FROM jobs")} == {"old-pending", "new-done"}
             assert [r["update_id"] for r in conn.execute("SELECT update_id FROM processed_updates")] == [2]
+            assert [r["cache_key"] for r in conn.execute("SELECT cache_key FROM llm_cache")] == ["k_new"]
 
     def test_idempotent_on_empty(self, db):
         from datetime import datetime, timezone
@@ -376,7 +386,7 @@ class TestPruneMaintenance:
         counts = db.prune_maintenance(now=datetime(2026, 5, 20, tzinfo=timezone.utc))
         assert counts == {
             "error_log": 0, "url_cache": 0, "link_codes": 0, "jobs": 0,
-            "processed_updates": 0,
+            "processed_updates": 0, "llm_cache": 0,
         }
 
 
@@ -408,3 +418,22 @@ class TestClaimTelegramUpdate:
             ).fetchone()
         assert row["update_id"] == 999
         assert row["ts"]  # default-stamped
+
+
+class TestLlmCache:
+    """Content-addressed cache helpers used by analyzer.py to avoid paying
+    LLM cost twice for identical (model, prompt, content) inputs."""
+
+    def test_round_trips_payload(self, db):
+        db.set_cached_llm_result("k1", "analyze", '{"hello": "world"}')
+        assert db.get_cached_llm_result("k1") == '{"hello": "world"}'
+
+    def test_miss_returns_none(self, db):
+        assert db.get_cached_llm_result("never-set") is None
+
+    def test_set_is_upsert(self, db):
+        """Concurrent first-misses (two requests racing past a None lookup)
+        must both succeed — the second insert UPDATEs rather than crashing."""
+        db.set_cached_llm_result("k", "analyze", "v1")
+        db.set_cached_llm_result("k", "analyze", "v2")
+        assert db.get_cached_llm_result("k") == "v2"

--- a/tests/test_llm_usage.py
+++ b/tests/test_llm_usage.py
@@ -147,6 +147,100 @@ class TestAnthropicCapture:
         assert r["cost_usd"] == 0.0
 
 
+class TestResultCache:
+    """analyze() and summarize_content() check llm_cache before calling the
+    LLM. A second call with identical (model, prompt, content) must skip the
+    upstream entirely — no llm_calls row written, no token spend, same
+    output returned."""
+
+    def test_analyze_second_call_is_a_cache_hit(self, db, monkeypatch):
+        from bot import analyzer
+        monkeypatch.setattr(analyzer, "_PROVIDER", "anthropic")
+        monkeypatch.setattr(analyzer, "_MODEL", "claude-haiku-4-5-20251001")
+
+        fake = _FakeAnthropic(input_tokens=100, output_tokens=50, tool_input={
+            "main_idea": "x", "why_it_matters": "y", "category": "c",
+            "quick_win": "qw", "bigger_play": "bp", "time_required": "5m",
+            "verdict": "watch",
+        })
+        monkeypatch.setattr(analyzer, "_get_client", lambda: fake)
+
+        first = analyzer.analyze("the same text", ctx=analyzer.UsageContext(
+            user_id=1, source_type="article"
+        ))
+        second = analyzer.analyze("the same text", ctx=analyzer.UsageContext(
+            user_id=1, source_type="article"
+        ))
+        # Identical output, but only ONE llm_calls row — the second call
+        # hit the cache and skipped the upstream.
+        assert first == second
+        rows = _all_llm_calls(db)
+        assert len(rows) == 1, f"expected 1 LLM call after cache hit, got {len(rows)}"
+
+    def test_analyze_invalidated_by_profile_change(self, db, monkeypatch):
+        """Same text but different profile → different cache key → real call."""
+        from bot import analyzer
+        monkeypatch.setattr(analyzer, "_PROVIDER", "anthropic")
+        monkeypatch.setattr(analyzer, "_MODEL", "claude-haiku-4-5-20251001")
+
+        # Two distinct users with distinct profiles. The user_id flows into
+        # _load_profile, which reads users.profile — set them explicitly so
+        # the cache key differs between them.
+        u1 = db.get_or_create_user_by_telegram(1)
+        u2 = db.get_or_create_user_by_telegram(2)
+        db.set_user_profile(u1, "Profile A")
+        db.set_user_profile(u2, "Profile B")
+
+        fake = _FakeAnthropic(input_tokens=100, output_tokens=50, tool_input={
+            "main_idea": "x", "why_it_matters": "y", "category": "c",
+            "quick_win": "qw", "bigger_play": "bp", "time_required": "5m",
+            "verdict": "watch",
+        })
+        monkeypatch.setattr(analyzer, "_get_client", lambda: fake)
+
+        analyzer.analyze("same text", ctx=analyzer.UsageContext(user_id=u1))
+        analyzer.analyze("same text", ctx=analyzer.UsageContext(user_id=u2))
+        # Two different profiles → two different cache keys → two upstream
+        # calls. (Cache only helps within a single profile-content pair.)
+        assert len(_all_llm_calls(db)) == 2
+
+    def test_summarize_content_second_call_is_a_cache_hit(self, db, monkeypatch):
+        from bot import analyzer
+        monkeypatch.setattr(analyzer, "_PROVIDER", "anthropic")
+        monkeypatch.setattr(analyzer, "_MODEL", "claude-haiku-4-5-20251001")
+
+        fake = _FakeAnthropic(input_tokens=500, output_tokens=200, text="A summary.")
+        monkeypatch.setattr(analyzer, "_get_client", lambda: fake)
+
+        first = analyzer.summarize_content("the source text")
+        second = analyzer.summarize_content("the source text")
+        assert first == second == "A summary."
+        rows = _all_llm_calls(db)
+        assert len(rows) == 1, f"expected 1 LLM call after cache hit, got {len(rows)}"
+
+    def test_summary_fallback_is_not_cached(self, db, monkeypatch):
+        """If the LLM call raises, summarize_content returns a truncated slice
+        as a safety fallback. That truncation must NOT poison the cache for
+        future calls — the next call with the same text should retry the LLM."""
+        from bot import analyzer
+        monkeypatch.setattr(analyzer, "_PROVIDER", "anthropic")
+        monkeypatch.setattr(analyzer, "_MODEL", "claude-haiku-4-5-20251001")
+
+        # First call: model raises → fallback returns truncated text.
+        class Boom:
+            messages = SimpleNamespace(create=lambda **kw: (_ for _ in ()).throw(RuntimeError("rate-limited")))
+        monkeypatch.setattr(analyzer, "_get_client", lambda: Boom())
+        result1 = analyzer.summarize_content("x" * 200)
+        assert result1.startswith("x")  # fallback truncation
+
+        # Second call: model succeeds → fresh upstream call, not the
+        # truncated fallback from before.
+        fake = _FakeAnthropic(input_tokens=10, output_tokens=5, text="proper summary")
+        monkeypatch.setattr(analyzer, "_get_client", lambda: fake)
+        result2 = analyzer.summarize_content("x" * 200)
+        assert result2 == "proper summary"
+
+
 class TestOpenAICapture:
     def test_analyze_reads_openai_usage(self, db, monkeypatch):
         from bot import analyzer

--- a/tests/test_llm_usage.py
+++ b/tests/test_llm_usage.py
@@ -176,6 +176,16 @@ class TestResultCache:
         assert first == second
         rows = _all_llm_calls(db)
         assert len(rows) == 1, f"expected 1 LLM call after cache hit, got {len(rows)}"
+        # The hit was logged with the second ctx's attribution.
+        with db._get_conn() as conn:
+            hits = conn.execute("SELECT * FROM llm_cache_hits").fetchall()
+        assert len(hits) == 1
+        assert hits[0]["purpose"] == "analyze"
+        assert hits[0]["user_id"] == 1
+        assert hits[0]["source_type"] == "article"
+        # cost_saved is estimate_avg_cost_per_call("analyze") at hit time —
+        # 100 input @ $1/MTok + 50 output @ $5/MTok = 0.00035.
+        assert abs(hits[0]["cost_saved_usd"] - 0.00035) < 1e-9
 
     def test_analyze_invalidated_by_profile_change(self, db, monkeypatch):
         """Same text but different profile → different cache key → real call."""
@@ -217,6 +227,11 @@ class TestResultCache:
         assert first == second == "A summary."
         rows = _all_llm_calls(db)
         assert len(rows) == 1, f"expected 1 LLM call after cache hit, got {len(rows)}"
+        with db._get_conn() as conn:
+            hits = conn.execute(
+                "SELECT purpose FROM llm_cache_hits"
+            ).fetchall()
+        assert [h["purpose"] for h in hits] == ["summary"]
 
     def test_summary_fallback_is_not_cached(self, db, monkeypatch):
         """If the LLM call raises, summarize_content returns a truncated slice


### PR DESCRIPTION
Three closely-tied pieces, shipped together because the dashboard tile only makes sense alongside the cache it observes, and the runbook documents the incident that motivated all of it. Rebased onto current main (clean after #35 merged).

## 1. Content-addressed LLM cache

The original scope. \`analyze()\` and \`summarize_content()\` now check a content-addressed cache before calling the LLM. Identical \`(provider, model, prompt, schema, profile, content)\` inputs return cached output instantly — no upstream call, no spend.

- Cache key = sha256 of every input that affects the output. Any change (model bump, prompt tweak, schema change, different profile) auto-invalidates because the key changes. No version flag to bump.
- Helpers are best-effort: a DB blip on the cache path falls through to the LLM rather than breaking analysis.
- Caching rules: success cached, exception NOT cached, summary truncation-fallback NOT cached.
- Concurrent first-misses safe (\`ON CONFLICT DO UPDATE\`).

## 2. Cache hit tracking + dashboard data

New table \`llm_cache_hits(ts, purpose, user_id, anon_id, source_type, cost_saved_usd)\` — one row per hit. The analyzer writes a row on every cache return; the value stamped in \`cost_saved_usd\` is the trailing 7-day average cost-per-call for that purpose (from \`llm_calls\`), so savings stays honest if pricing or usage changes.

\`/api/admin/cost-overview\` gains a \`cache\` block:

\`\`\`json
"cache": {
  "hits": int,
  "cost_saved_usd": float,
  "hit_rate": float,    // hits / (hits + cacheable upstream calls)
  "by_purpose": [{ "purpose", "hits", "cost_saved_usd" }, ...]
}
\`\`\`

\`hit_rate\` denominator counts only \`analyze\` + \`summary\` calls (image isn't cached yet). Empty backends return zero state so an old Worker doesn't crash on the new field.

Frontend tile rendering is in the paired filter.fyi PR (linked below).

## 3. Operations runbook (\`docs/OPERATIONS.md\`)

Two new sections capturing what we learned debugging the runaway loop:

- **"Fly is wedged / dashboard unreachable"** — symptom → diagnose → stop the bleed → restart → re-enable webhook → quantify spend. Exact commands for each step.
- **"Duplicate work — three layers of defense"** — table mapping symptom (same \`update_id\` / same content / same URL) to the right cache or dedup layer and the diagnostic to run. \`processed_updates\` (#35), \`llm_cache\` (this PR), \`url_cache\` (pre-existing).

Also adds \`FILTER_FYI_ADMIN_SECRET\` to the env table.

## Tests (12 new, 185 total)

| Area | New |
|---|---|
| Cache helpers | round-trip / miss / upsert (3) |
| Hit tracking | \`record_cache_hit\` write + failure-doesn't-raise (2) |
| Cost estimation | excludes error rows / zero fallback (2) |
| Pruning | new \`llm_cache_hits\` retention in \`prune_maintenance\` |
| End-to-end | analyzer cache hit asserts the \`llm_cache_hits\` row (purpose + user + source_type + savings) |
| Admin endpoint | empty cache block / aggregated stats with hit-rate denom |

\`make test\` → **185 passed**.

## Paired frontend PR

`filter.fyi#26` (link will be in next comment) — renders the cache tile from this response. Backend ships zero state when there's no data, so the order of deploy doesn't matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)