### PR TITLE
fix: cache analyze_image too — fixes Telegram URL-with-images cache miss

### DIFF
--- a/bot/admin.py
+++ b/bot/admin.py
@@ -269,10 +269,9 @@ def cost_overview(days: int) -> dict:
     hits_total = cache_row["hits"] or 0
     cost_saved = cache_row["cost_saved_usd"] or 0.0
     # Hit rate = hits / (hits + upstream-calls). Upstream-calls here counts
-    # only `purpose IN ('analyze', 'summary')` to keep the dimension honest
-    # (image and other purposes don't run through the cache yet).
+    # purposes that go through the cache (`analyze`, `summary`, `image`).
     cacheable_calls = sum(
-        r["calls"] for r in purpose_rows if r["purpose"] in ("analyze", "summary")
+        r["calls"] for r in purpose_rows if r["purpose"] in ("analyze", "summary", "image")
     )
     hit_rate_denom = hits_total + cacheable_calls
     hit_rate = (hits_total / hit_rate_denom) if hit_rate_denom > 0 else 0.0

--- a/bot/analyzer.py
+++ b/bot/analyzer.py
@@ -282,6 +282,28 @@ def _cache_key_summary(text: str) -> str:
     return h.hexdigest()
 
 
+def _cache_key_image(b64: str, caption: str) -> str:
+    """Cache key for `analyze_image()` calls.
+
+    Keyed on the exact base64 image bytes + caption + model/provider.
+    Same image + same caption → same description, deterministically.
+
+    Why this matters even though analyze_image is rare: the Telegram URL
+    handler appends image descriptions to the article text before calling
+    `analyze()`. Without caching the image step, those descriptions vary
+    between calls (LLM non-determinism), the combined analyze input differs,
+    and the *analyze* cache misses too. So caching here is what makes the
+    end-to-end Telegram path actually hit `llm_cache`.
+    """
+    h = hashlib.sha256()
+    h.update(b"image\x00")
+    h.update(_PROVIDER.encode()); h.update(b"\x00")
+    h.update(_MODEL.encode()); h.update(b"\x00")
+    h.update(caption.encode()); h.update(b"\x00")
+    h.update(b64.encode())
+    return h.hexdigest()
+
+
 def _try_cache_get(cache_key: str):
     """Best-effort cache read. A DB blip should never break analysis — fall
     through to the LLM if the lookup fails for any reason."""
@@ -494,7 +516,20 @@ def summarize_content(text: str, *, ctx: UsageContext | None = None) -> str:
 
 
 def analyze_image(b64: str, caption: str = "", *, ctx: UsageContext | None = None) -> str:
-    """Describe and extract key info from a base64-encoded JPEG image."""
+    """Describe and extract key info from a base64-encoded JPEG image.
+
+    Cached (since fix/cache-analyze-image) because the Telegram URL handler
+    appends image descriptions to the article text before calling `analyze()`.
+    Without this cache the inner LLM non-determinism propagates outward and
+    `analyze()`'s cache misses every time, even on identical articles.
+    """
+    cache_key = _cache_key_image(b64, caption)
+    cached = _try_cache_get(cache_key)
+    if cached is not None:
+        logger.info("image cache hit (key=%s...)", cache_key[:12])
+        _record_cache_hit(purpose="image", ctx=ctx)
+        return cached
+
     prompt = "Extract and describe all text and key information visible in this image."
     if caption:
         prompt += f" Context provided: {caption}"
@@ -517,7 +552,9 @@ def analyze_image(b64: str, caption: str = "", *, ctx: UsageContext | None = Non
             in_tok, out_tok = _anthropic_tokens(resp)
             _record_usage(purpose="image", input_tokens=in_tok, output_tokens=out_tok,
                           started_at=started, ctx=ctx)
-            return resp.content[0].text
+            out = resp.content[0].text
+            _try_cache_set(cache_key, "image", out)
+            return out
 
         resp = client.chat.completions.create(
             model=_MODEL,
@@ -532,7 +569,9 @@ def analyze_image(b64: str, caption: str = "", *, ctx: UsageContext | None = Non
         in_tok, out_tok = _openai_tokens(resp)
         _record_usage(purpose="image", input_tokens=in_tok, output_tokens=out_tok,
                       started_at=started, ctx=ctx)
-        return resp.choices[0].message.content
+        out = resp.choices[0].message.content
+        _try_cache_set(cache_key, "image", out)
+        return out
     except Exception as e:
         _record_usage(purpose="image", input_tokens=0, output_tokens=0,
                       started_at=started, ctx=ctx, status="error", error=str(e)[:200])

--- a/tests/test_llm_usage.py
+++ b/tests/test_llm_usage.py
@@ -256,6 +256,59 @@ class TestResultCache:
         assert result2 == "proper summary"
 
 
+class TestImageCache:
+    """analyze_image must cache too — its non-determinism is what breaks the
+    *analyze* cache on the Telegram URL path, which appends image
+    descriptions to the article text before calling analyze."""
+
+    def test_second_call_with_same_image_is_a_cache_hit(self, db, monkeypatch):
+        from bot import analyzer
+        monkeypatch.setattr(analyzer, "_PROVIDER", "anthropic")
+        monkeypatch.setattr(analyzer, "_MODEL", "claude-haiku-4-5-20251001")
+
+        fake = _FakeAnthropic(input_tokens=300, output_tokens=80, text="A photo of a cat.")
+        monkeypatch.setattr(analyzer, "_get_client", lambda: fake)
+
+        b64 = "ZmFrZS1pbWFnZS1ieXRlcw=="  # "fake-image-bytes"
+        first = analyzer.analyze_image(b64)
+        second = analyzer.analyze_image(b64)
+        assert first == second == "A photo of a cat."
+        rows = _all_llm_calls(db)
+        assert len(rows) == 1, f"expected 1 LLM call, got {len(rows)}"
+        with db._get_conn() as conn:
+            hits = conn.execute(
+                "SELECT purpose FROM llm_cache_hits"
+            ).fetchall()
+        assert [h["purpose"] for h in hits] == ["image"]
+
+    def test_different_image_bytes_dont_collide(self, db, monkeypatch):
+        from bot import analyzer
+        monkeypatch.setattr(analyzer, "_PROVIDER", "anthropic")
+        monkeypatch.setattr(analyzer, "_MODEL", "claude-haiku-4-5-20251001")
+
+        fake = _FakeAnthropic(input_tokens=100, output_tokens=20, text="desc")
+        monkeypatch.setattr(analyzer, "_get_client", lambda: fake)
+
+        analyzer.analyze_image("aaaa")
+        analyzer.analyze_image("bbbb")
+        # Two distinct images → no cache hit → two upstream calls.
+        assert len(_all_llm_calls(db)) == 2
+
+    def test_caption_is_part_of_the_key(self, db, monkeypatch):
+        """Same image bytes but different caption → different cache key.
+        Caption changes the prompt, so the model's output may differ."""
+        from bot import analyzer
+        monkeypatch.setattr(analyzer, "_PROVIDER", "anthropic")
+        monkeypatch.setattr(analyzer, "_MODEL", "claude-haiku-4-5-20251001")
+
+        fake = _FakeAnthropic(input_tokens=100, output_tokens=20, text="desc")
+        monkeypatch.setattr(analyzer, "_get_client", lambda: fake)
+
+        analyzer.analyze_image("samebytes", caption="cat")
+        analyzer.analyze_image("samebytes", caption="dog")
+        assert len(_all_llm_calls(db)) == 2
+
+
 class TestOpenAICapture:
     def test_analyze_reads_openai_usage(self, db, monkeypatch):
         from bot import analyzer


### PR DESCRIPTION
**Bug**: after #36 deployed, the user re-sent a Telegram post with the same URL — analyze still went to the LLM. Web hit cache, Telegram didn't.

## Root cause

\`bot/handlers.py:106\` (Telegram \`handle_text\`):

\`\`\`python
text = fetched["text"]
image_urls = fetched.get("image_urls") or []
if image_urls:
    text += await _describe_images(image_urls)   # ← appends LLM output
await _analyze_and_reply(update, user_id, text, ...)
\`\`\`

\`_describe_images\` calls \`analyze_image()\` on each inline image. **#36 deliberately scoped image caching out**, so each retry got fresh (slightly worded-different) descriptions appended, the combined \`text\` differed across calls, and the analyze cache key — which hashes \`text\` — missed every time. Each Telegram resend re-described every image AND re-analyzed the article.

Web doesn't hit this because \`/api/job\` and \`/api/try\` in \`bot/api.py\` only feed \`fetched["text"]\` into \`analyze()\` — no image descriptions appended. Same fetch (\`url_cache\` hit) → same text → same key → cache hit.

## Fix

Cache \`analyze_image()\` the same content-addressed way. Key = \`(provider, model, caption, base64 image bytes)\`. Same image + same caption → cached description → deterministic combined text → analyze cache hit.

The \`hit_rate\` denominator in \`/api/admin/cost-overview\` also gets \`image\` added to the cacheable-purposes list, so the dashboard metric stays honest.

## Tests (3 new, 188 total)

| Test | Pins |
|---|---|
| \`test_second_call_with_same_image_is_a_cache_hit\` | identical b64 → 1 LLM call, llm_cache_hits row with purpose='image' |
| \`test_different_image_bytes_dont_collide\` | different b64 → no false hits |
| \`test_caption_is_part_of_the_key\` | same b64 different caption → distinct cache keys (caption changes the prompt) |

## Verification post-merge

Re-send the same Telegram URL that didn't hit cache before. Expect:

1. First retry: fresh transcribe/describe/analyse (full cost).
2. Second retry: \`Fly logs\` shows \`image cache hit (key=...)\` for each image, \`analyze cache hit (key=...)\` and \`summary cache hit (key=...)\`. \`llm_calls\` count for that minute is 0.
3. Admin dashboard's Cache tile: hit count jumps; hit rate climbs.

\`\`\`bash
fly logs -a filter-fyi-backend --since 5m | grep -E "cache hit|cache miss"
fly ssh console -a filter-fyi-backend -C "sqlite3 /data/research.db \\"SELECT purpose, COUNT(*) FROM llm_cache_hits WHERE ts > datetime('now', '-1 hour') GROUP BY purpose\\""
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)