### PR TITLE
refactor: unify URL → analysis path across all entry points

### DIFF
--- a/bot/api.py
+++ b/bot/api.py
@@ -15,7 +15,15 @@ from fastapi import APIRouter, Depends, File, Form, Header, HTTPException, Uploa
 from fastapi.responses import FileResponse as FastAPIFileResponse
 from pydantic import BaseModel
 
-from bot.analyzer import UsageContext, analyze, analyze_image, summarize_content, to_json_str, to_plain_text
+from bot.analyzer import UsageContext, analyze, analyze_image, to_json_str, to_plain_text
+from bot.pipeline import (
+    ERR_ANALYZE_FAILED,
+    ERR_FETCH_FAILED,
+    ERR_NO_TEXT,
+    ERR_NO_TRANSCRIPT,
+    PipelineError,
+    analyze_url,
+)
 from bot.auth import require_token
 from bot.config import MAX_CONTENT_CHARS
 from bot.fetch_errors import user_message as fetch_error_message
@@ -39,7 +47,6 @@ from bot.db import (
     set_user_profile,
     upsert_user_by_email,
 )
-from bot.fetcher import fetch_url
 from bot.storage import full_path, save_file
 from bot.transcriber import transcribe
 
@@ -60,12 +67,6 @@ _job_steps: dict[str, str] = {}
 # giving the UI something to render. The full extracted text only ever exists
 # in-memory on this request.
 TRY_PREVIEW_CHARS = 2000
-
-# Source types where empty extracted text means "no transcript available"
-# rather than a generic extraction failure. Worker maps this to a friendly
-# "video transcripts coming with the full product" notice.
-_VIDEO_SOURCE_TYPES = {"youtube", "video"}
-
 
 # ---------------------------------------------------------------------------
 # Knowledge base
@@ -124,18 +125,16 @@ async def submit_url(
     user_note: str = Form(""),
     user_id: int = Depends(require_token),
 ):
-    fetched = await fetch_url(url)
-    if not fetched["text"].strip():
-        raise HTTPException(
-            status_code=422,
-            detail=fetch_error_message(fetched.get("reason"), url),
+    try:
+        result = await analyze_url(
+            url,
+            ctx=UsageContext(user_id=user_id),
+            save_for_user_id=user_id,
+            user_note=user_note,
         )
-    source_type = fetched.get("source_type") or "article"
-    ctx = UsageContext(user_id=user_id, source_type=source_type)
-    analysis = analyze(fetched["text"], ctx=ctx)
-    # Store a condensed summary, not a full copy of the fetched content.
-    save_item(user_id, "url", url, summarize_content(fetched["text"], ctx=ctx), to_json_str(analysis), user_note)
-    return {"analysis": to_plain_text(analysis), "analysis_data": analysis}
+    except PipelineError as e:
+        raise _pipeline_error_to_http(e, url)
+    return {"analysis": to_plain_text(result.analysis), "analysis_data": result.analysis}
 
 
 @router.post("/submit/file", status_code=201)
@@ -233,6 +232,26 @@ def _is_http_url(s: str) -> bool:
         return False
 
 
+def _pipeline_error_to_http(e: PipelineError, url: str) -> HTTPException:
+    """Translate a PipelineError into the JSON HTTPException shape every web
+    URL endpoint returns — kept centralised so the Worker contract stays
+    consistent across /api/try, /api/library/add, and /api/job results."""
+    reason = e.fetched.get("reason")
+    if e.code in (ERR_NO_TEXT, ERR_NO_TRANSCRIPT):
+        return HTTPException(
+            status_code=422,
+            detail={
+                "error": e.code,
+                "reason": reason,
+                "message": fetch_error_message(reason, url),
+            },
+        )
+    if e.code == ERR_FETCH_FAILED:
+        return HTTPException(status_code=502, detail={"error": "fetch-failed"})
+    # ERR_ANALYZE_FAILED and any unknown future code default to 502.
+    return HTTPException(status_code=502, detail={"error": e.code})
+
+
 @router.post("/try")
 async def try_url(req: TryRequest, _: None = Depends(_require_try_secret)):
     """One-shot analysis for anonymous web users.
@@ -246,58 +265,21 @@ async def try_url(req: TryRequest, _: None = Depends(_require_try_secret)):
         raise HTTPException(status_code=400, detail={"error": "invalid-url"})
 
     try:
-        fetched = await fetch_url(url)
-    except Exception as e:
-        logger.exception("fetch_url crashed for %s: %s", url, e)
-        raise HTTPException(status_code=502, detail={"error": "fetch-failed"})
-
-    text = (fetched.get("text") or "").strip()
-    source_type = fetched.get("source_type") or "article"
-
-    if not text:
-        # Distinguish video-with-no-transcript from generic extraction failure
-        # so the Worker can show the right message. `reason` + `message` carry
-        # the specific limitation (e.g. image_only_pdf, rate_limited).
-        reason = fetched.get("reason")
-        if source_type in _VIDEO_SOURCE_TYPES:
-            raise HTTPException(
-                status_code=422,
-                detail={
-                    "error": "no-transcript",
-                    "reason": reason,
-                    "message": fetch_error_message(reason, url),
-                },
-            )
-        raise HTTPException(
-            status_code=422,
-            detail={
-                "error": "extraction-failed",
-                "reason": reason,
-                "message": fetch_error_message(reason, url),
-            },
-        )
-
-    ctx = UsageContext(anon_id=req.anon_id, source_type=source_type)
-    try:
-        analysis = analyze(text, ctx=ctx)
-    except Exception as e:
-        logger.exception("analyze crashed for %s: %s", url, e)
-        raise HTTPException(status_code=502, detail={"error": "analyze-failed"})
+        result = await analyze_url(url, ctx=UsageContext(anon_id=req.anon_id))
+    except PipelineError as e:
+        raise _pipeline_error_to_http(e, url)
 
     # Worker contract: verdict at the top level, analysis dict has the other
     # five fields. analyzer.analyze() returns all six in one dict — split here.
+    analysis = result.analysis
     verdict = analysis.pop("verdict", "skim")
-
-    # The Worker stores content_preview in D1 (for claim-on-signup), so send the
-    # condensed summary rather than a verbatim slice of the source.
-    summary = summarize_content(text, ctx=ctx)
 
     return {
         "url": url,
-        "title": fetched.get("title") or url,
-        "source_type": source_type,
-        "image_urls": fetched.get("image_urls") or [],
-        "content_preview": summary[:TRY_PREVIEW_CHARS],
+        "title": result.title or url,
+        "source_type": result.source_type,
+        "image_urls": result.image_urls,
+        "content_preview": result.summary[:TRY_PREVIEW_CHARS],
         "verdict": verdict,
         "analysis": analysis,
     }
@@ -457,68 +439,24 @@ async def library_add(req: _LibraryAddRequest, _: None = Depends(_require_try_se
         raise HTTPException(status_code=400, detail={"error": "invalid-url"})
 
     try:
-        fetched = await fetch_url(url)
-    except Exception as e:
-        logger.exception("fetch_url crashed for %s: %s", url, e)
-        raise HTTPException(status_code=502, detail={"error": "fetch-failed"})
-
-    text = (fetched.get("text") or "").strip()
-    source_type = fetched.get("source_type") or "article"
-
-    if not text:
-        reason = fetched.get("reason")
-        if source_type in _VIDEO_SOURCE_TYPES:
-            raise HTTPException(
-                status_code=422,
-                detail={
-                    "error": "no-transcript",
-                    "reason": reason,
-                    "message": fetch_error_message(reason, url),
-                },
-            )
-        raise HTTPException(
-            status_code=422,
-            detail={
-                "error": "extraction-failed",
-                "reason": reason,
-                "message": fetch_error_message(reason, url),
-            },
+        result = await analyze_url(
+            url,
+            ctx=UsageContext(user_id=req.user_id),
+            save_for_user_id=req.user_id,
+            user_note=req.user_note,
         )
+    except PipelineError as e:
+        raise _pipeline_error_to_http(e, url)
 
-    ctx = UsageContext(user_id=req.user_id, source_type=source_type)
-    try:
-        analysis = analyze(text, ctx=ctx)
-    except Exception as e:
-        logger.exception("analyze crashed for %s: %s", url, e)
-        raise HTTPException(status_code=502, detail={"error": "analyze-failed"})
-
-    # Data minimisation: store a condensed, audience-neutral summary instead of
-    # a full copy of the fetched third-party content. The full text stays in
-    # memory only for this request; the summary is enough to re-derive verdicts
-    # later under a different profile.
-    summary = summarize_content(text, ctx=ctx)
-
-    save_item(
-        user_id=req.user_id,
-        source_type=source_type,
-        source=url,
-        content=summary,
-        analysis=to_json_str(analysis),
-        user_note=req.user_note,
-    )
-
-    # Fetch the row we just inserted so the Worker gets the canonical id.
-    rows = get_all_items(req.user_id)
-    new_id = rows[0]["id"] if rows else None
-
+    analysis = result.analysis
     verdict = analysis.pop("verdict", "skim")
     return {
-        "id": new_id,
+        "id": result.saved_id,
         "url": url,
-        "title": fetched.get("title") or url,
-        "source_type": source_type,
-        "image_urls": fetched.get("image_urls") or [],
-        "content_preview": summary[:TRY_PREVIEW_CHARS],
+        "title": result.title or url,
+        "source_type": result.source_type,
+        "image_urls": result.image_urls,
+        "content_preview": result.summary[:TRY_PREVIEW_CHARS],
         "verdict": verdict,
         "analysis": analysis,
     }
@@ -617,77 +555,48 @@ async def _run_job(
     user_note: str,
     anon_id: str | None = None,
 ) -> None:
-    """Background task: fetch → summarize → analyze(summary) → optionally save."""
+    """Background task: routes through the unified URL pipeline and stamps
+    progress steps for the polling UI. The pipeline does its own progression
+    (fetch → images → summary → analyze); we surface coarse steps here so
+    the browser has something to show — finer per-step progress would need
+    a callback API on the pipeline, parked as a follow-up."""
     try:
-        _job_steps[job_id] = "fetching"
+        ctx = UsageContext(user_id=user_id, anon_id=anon_id, job_id=job_id)
+
+        def _on_step(label: str) -> None:
+            _job_steps[job_id] = label
+
         try:
-            fetched = await fetch_url(url)
-        except Exception:
-            logger.exception("job %s: fetch_url crashed for %s", job_id, url)
-            set_job_error(job_id, "fetch-failed")
-            return
-
-        text = (fetched.get("text") or "").strip()
-        source_type = fetched.get("source_type") or "article"
-
-        if not text:
-            if source_type in _VIDEO_SOURCE_TYPES:
-                set_job_error(job_id, "no-transcript")
-            else:
-                set_job_error(job_id, "extraction-failed")
-            return
-
-        loop = asyncio.get_running_loop()
-        ctx = UsageContext(
-            user_id=user_id, anon_id=anon_id, job_id=job_id, source_type=source_type
-        )
-
-        # Summarise first — the summary is the canonical stored representation
-        # and the basis for the analysis verdict.
-        _job_steps[job_id] = "summarizing"
-        try:
-            summary = await loop.run_in_executor(None, lambda: summarize_content(text, ctx=ctx))
-        except Exception:
-            logger.exception("job %s: summarize_content crashed", job_id)
-            summary = text[:TRY_PREVIEW_CHARS]
-
-        _job_steps[job_id] = "analyzing"
-        try:
-            analysis = await loop.run_in_executor(None, lambda: analyze(summary, ctx=ctx))
-        except Exception:
-            logger.exception("job %s: analyze crashed", job_id)
-            set_job_error(job_id, "analyze-failed")
-            return
-
-        saved_id: int | None = None
-        if user_id is not None:
-            saved_id = save_item(
-                user_id=user_id,
-                source_type=source_type,
-                source=url,
-                content=summary,
-                analysis=to_json_str(analysis),
+            result = await analyze_url(
+                url,
+                ctx=ctx,
+                save_for_user_id=user_id,
                 user_note=user_note,
+                on_step=_on_step,
             )
+        except PipelineError as e:
+            set_job_error(job_id, e.code)
+            return
 
+        analysis = result.analysis
         verdict = analysis.pop("verdict", "skim")
         # `content` is the full stored brief, exposed so the result page can
         # show the basis for the verdict. `content_preview` is kept for the
         # Worker's D1 claim path, which stays on a 2k slice to bound row size.
-        result: dict = {
+        payload: dict = {
             "url": url,
-            "title": fetched.get("title") or url,
-            "source_type": source_type,
-            "image_urls": fetched.get("image_urls") or [],
-            "content": summary,
-            "content_preview": summary[:TRY_PREVIEW_CHARS],
+            "title": result.title or url,
+            "source_type": result.source_type,
+            "image_urls": result.image_urls,
+            "content": result.summary,
+            "content_preview": result.summary[:TRY_PREVIEW_CHARS],
             "verdict": verdict,
             "analysis": analysis,
         }
-        if saved_id is not None:
-            result["id"] = saved_id
+        if result.saved_id is not None:
+            payload["id"] = result.saved_id
 
-        set_job_done(job_id, result)
+        set_job_done(job_id, payload)
     except Exception:
         logger.exception("job %s: unexpected failure", job_id)
         set_job_error(job_id, "internal-error")

--- a/bot/handlers.py
+++ b/bot/handlers.py
@@ -3,39 +3,19 @@ import logging
 import tempfile
 from pathlib import Path
 
-import httpx
 from telegram import Update
 from telegram.ext import ContextTypes
 
-from bot.analyzer import analyze, analyze_image, summarize_content, to_json_str
+from bot.analyzer import UsageContext, analyze, analyze_image, to_json_str
 from bot.config import MAX_CONTENT_CHARS
 from bot.db import get_or_create_user_by_telegram, save_item
 from bot.fetch_errors import user_message as fetch_error_message
-from bot.fetcher import fetch_url
 from bot.formatting import format_analysis
+from bot.pipeline import PipelineError, analyze_url
 from bot.storage import save_file_from_path
 from bot.transcriber import transcribe
 
 logger = logging.getLogger(__name__)
-
-
-async def _describe_images(image_urls: list[str]) -> str:
-    """Download each image URL and return a combined description string."""
-    descriptions = []
-    async with httpx.AsyncClient(timeout=15, follow_redirects=True) as client:
-        for url in image_urls:
-            try:
-                resp = await client.get(url, headers={"User-Agent": "Mozilla/5.0"})
-                resp.raise_for_status()
-                b64 = base64.b64encode(resp.content).decode()
-                desc = analyze_image(b64)
-                descriptions.append(desc)
-            except Exception:
-                logger.exception(f"Failed to analyse image {url}")
-    if not descriptions:
-        return ""
-    joined = "\n\n".join(f"[Image {i+1}]: {d}" for i, d in enumerate(descriptions))
-    return f"\n\nIMAGE DESCRIPTIONS:\n{joined}"
 
 
 async def _analyze_and_reply(
@@ -94,23 +74,18 @@ async def handle_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
         user_note = " ".join(user_note.split()).strip()
 
         for url in urls:
-            await message.reply_text(f"Fetching {url} ...")
-            fetched = await fetch_url(url)
-            if not fetched["text"].strip():
-                await message.reply_text(fetch_error_message(fetched.get("reason"), url))
+            await message.reply_text(f"Fetching and analysing {url} ...")
+            try:
+                result = await analyze_url(
+                    url,
+                    ctx=UsageContext(user_id=user_id),
+                    save_for_user_id=user_id,
+                    user_note=user_note,
+                )
+            except PipelineError as e:
+                await message.reply_text(fetch_error_message(e.fetched.get("reason"), url))
                 continue
-            await message.reply_text("Analyzing...")
-            text = fetched["text"]
-            image_urls = fetched.get("image_urls") or []
-            if image_urls:
-                text += await _describe_images(image_urls)
-            await _analyze_and_reply(
-                update, user_id, text,
-                source_type="url", source=url, user_note=user_note,
-                file_path=fetched.get("file_path", ""),
-                # Store only a condensed summary of fetched third-party content.
-                store_content=summarize_content(text),
-            )
+            await message.reply_text(format_analysis(result.analysis), parse_mode="HTML")
     else:
         await message.reply_text("Analyzing...")
         await _analyze_and_reply(update, user_id, text, source_type="note")

--- a/bot/pipeline.py
+++ b/bot/pipeline.py
@@ -1,0 +1,219 @@
+"""Unified URL → analysis pipeline.
+
+Every URL-based entry point (web `/api/try`, `/api/job`, `/api/library/add`,
+`/submit/url`, and Telegram URL handler) routes through this module so they
+all share identical behavior:
+
+  1. Fetch the URL (cached in `url_cache` by exact URL).
+  2. For source types where inline images carry signal (articles, social
+     posts, etc.), describe each image with `analyze_image` and append the
+     descriptions to the text. Image analysis itself is content-addressed-
+     cached, so repeats are free.
+  3. Summarize the (text + image descriptions) into the canonical brief.
+  4. Analyze the summary — this bounds the analyze prompt size for long
+     content (transcripts, long PDFs) and keeps the cache key stable.
+  5. Optionally persist as an `items` row for signed-in users.
+
+Caller responsibilities: present the result (HTTP JSON, Telegram reply,
+async-job result blob) and translate `PipelineError` into the right
+status/UX for their surface.
+
+The module is the single source of truth for the URL pipeline. Diverging
+again (e.g. analyzing the raw text instead of the summary on some paths)
+will silently break the content-addressed cache, because the cache key
+hashes the exact input to `analyze` — see [[feedback_llm_chain_caching]].
+"""
+from __future__ import annotations
+
+import asyncio
+import base64
+import logging
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+import httpx
+
+from bot.analyzer import (
+    UsageContext,
+    analyze,
+    analyze_image,
+    summarize_content,
+    to_json_str,
+)
+from bot.db import save_item
+from bot.fetcher import fetch_url
+
+logger = logging.getLogger(__name__)
+
+# Which source types benefit from inline image descriptions appended to the
+# analyse input. Articles and social posts often have charts, screenshots, or
+# image-driven content that adds real signal. Video/audio already have the
+# transcript as the canonical content; their thumbnails/cards don't add
+# enough to justify the per-image LLM call. Default for `unknown` is on —
+# we'd rather pay for the extra context than miss it.
+_INCLUDE_IMAGES_BY_DEFAULT: frozenset[str] = frozenset({
+    "article", "social", "unknown",
+})
+
+
+# Caller-facing error codes — stable across HTTP and Telegram surfaces.
+ERR_FETCH_FAILED = "fetch-failed"            # network / timeout / connector error
+ERR_NO_TEXT = "extraction-failed"            # fetch ok but yielded empty text
+ERR_NO_TRANSCRIPT = "no-transcript"          # video-with-no-transcript variant of NO_TEXT
+ERR_ANALYZE_FAILED = "analyze-failed"        # LLM call failed mid-chain
+
+_VIDEO_SOURCE_TYPES: frozenset[str] = frozenset({"youtube", "video"})
+
+
+class PipelineError(Exception):
+    """Raised for any failure inside `analyze_url`. Carries an `error_code`
+    (one of `ERR_*` above) so callers can map it to their own status surface,
+    and `fetched` if the fetch succeeded but a later step failed — this lets
+    error responses include the title/source_type for nicer messages."""
+
+    def __init__(self, code: str, *, fetched: Optional[dict] = None, message: str = ""):
+        super().__init__(message or code)
+        self.code = code
+        self.fetched = fetched or {}
+
+
+@dataclass
+class PipelineResult:
+    fetched: dict
+    summary: str
+    analysis: dict
+    saved_id: int | None = None
+
+    @property
+    def source_type(self) -> str:
+        return self.fetched.get("source_type") or "article"
+
+    @property
+    def title(self) -> str:
+        return self.fetched.get("title") or ""
+
+    @property
+    def image_urls(self) -> list[str]:
+        return self.fetched.get("image_urls") or []
+
+
+async def analyze_url(
+    url: str,
+    *,
+    ctx: UsageContext,
+    save_for_user_id: int | None = None,
+    user_note: str = "",
+    include_images: bool | None = None,
+    on_step: Optional[Callable[[str], None]] = None,
+) -> PipelineResult:
+    """Run the full URL → analysis chain.
+
+    Raises `PipelineError` on any failure mode the caller should surface
+    (fetch failed, no extractable text, analyse crashed). Summarization
+    failures are absorbed by `summarize_content`'s own fallback — the
+    pipeline carries on with a truncated slice rather than failing the
+    whole request.
+
+    `include_images=None` (default) picks based on `source_type` — see
+    `_INCLUDE_IMAGES_BY_DEFAULT`. Pass `True`/`False` to override.
+
+    `on_step` is an optional sync callback invoked with stable labels
+    ("fetching" | "describing-images" | "summarizing" | "analyzing") so
+    callers like the async job runner can surface progress to the UI.
+    """
+    def _step(label: str) -> None:
+        if on_step is not None:
+            try:
+                on_step(label)
+            except Exception:
+                logger.exception("pipeline on_step callback raised; ignoring")
+
+    _step("fetching")
+    try:
+        fetched = await fetch_url(url)
+    except Exception as e:
+        logger.exception("pipeline: fetch_url crashed for %s", url)
+        raise PipelineError(ERR_FETCH_FAILED, message=str(e))
+
+    text = (fetched.get("text") or "").strip()
+    source_type = fetched.get("source_type") or "article"
+
+    if not text:
+        # Distinguish video-with-no-transcript from generic extraction
+        # failure so callers can surface the right UX.
+        code = ERR_NO_TRANSCRIPT if source_type in _VIDEO_SOURCE_TYPES else ERR_NO_TEXT
+        raise PipelineError(code, fetched=fetched)
+
+    # ctx may not have source_type set when the caller built it before
+    # fetching — fill it in here so downstream rows carry the right tag.
+    if not ctx.source_type:
+        ctx.source_type = source_type
+
+    # Inline image descriptions: append to text so they enter the summary
+    # (and therefore the analyze input) deterministically. analyze_image()
+    # is content-addressed-cached, so this is free on repeats.
+    if include_images is None:
+        include_images = source_type in _INCLUDE_IMAGES_BY_DEFAULT
+    if include_images:
+        image_urls = fetched.get("image_urls") or []
+        if image_urls:
+            _step("describing-images")
+            text = text + await _describe_images(image_urls, ctx=ctx)
+
+    # Summarise on a thread so we don't block the event loop on the LLM
+    # call. The async wrapper around a sync call mirrors what _run_job did.
+    _step("summarizing")
+    loop = asyncio.get_running_loop()
+    summary = await loop.run_in_executor(None, lambda: summarize_content(text, ctx=ctx))
+
+    _step("analyzing")
+    try:
+        analysis = await loop.run_in_executor(None, lambda: analyze(summary, ctx=ctx))
+    except Exception as e:
+        logger.exception("pipeline: analyze crashed for %s", url)
+        raise PipelineError(ERR_ANALYZE_FAILED, fetched=fetched, message=str(e))
+
+    saved_id: int | None = None
+    if save_for_user_id is not None:
+        saved_id = save_item(
+            user_id=save_for_user_id,
+            source_type=source_type,
+            source=url,
+            content=summary,
+            analysis=to_json_str(analysis),
+            user_note=user_note,
+        )
+
+    return PipelineResult(
+        fetched=fetched, summary=summary, analysis=analysis, saved_id=saved_id,
+    )
+
+
+async def _describe_images(image_urls: list[str], *, ctx: UsageContext) -> str:
+    """Download each image URL and return a combined description block.
+
+    Moved from `bot/handlers.py` and made cache-friendly: `analyze_image`
+    is content-addressed-cached, so repeated calls for the same image
+    bytes cost nothing. Per-image fetch failures are logged but never
+    propagate — a single broken image URL shouldn't kill the analysis.
+    """
+    descriptions: list[str] = []
+    async with httpx.AsyncClient(timeout=15, follow_redirects=True) as client:
+        for url in image_urls:
+            try:
+                resp = await client.get(url, headers={"User-Agent": "Mozilla/5.0"})
+                resp.raise_for_status()
+                b64 = base64.b64encode(resp.content).decode()
+                # analyze_image is sync; wrap in executor to keep the loop
+                # responsive when there are several images.
+                loop = asyncio.get_running_loop()
+                desc = await loop.run_in_executor(
+                    None, lambda: analyze_image(b64, ctx=ctx)
+                )
+                descriptions.append(desc)
+            except Exception:
+                logger.exception("describe_images: skipped %s", url)
+    if not descriptions:
+        return ""
+    joined = "\n\n".join(f"[Image {i+1}]: {d}" for i, d in enumerate(descriptions))
+    return f"\n\nIMAGE DESCRIPTIONS:\n{joined}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,12 +42,17 @@ def db():
 
 @pytest.fixture
 def client(monkeypatch):
-    """FastAPI TestClient with `analyze` and `fetch_url` mocked so we don't hit
-    the network or the LLM. Tests that need different mock behavior can
-    monkeypatch over these defaults."""
+    """FastAPI TestClient with the LLM + fetch path mocked.
+
+    Post the bot.pipeline refactor, `fetch_url`, `analyze`, and
+    `summarize_content` are no longer imported into bot.api — they live
+    inside bot.pipeline. Tests that need to override one of these should
+    patch `bot.pipeline.<name>` rather than `bot.api.<name>`.
+    """
     from fastapi import FastAPI
     from fastapi.testclient import TestClient
     import bot.api
+    import bot.pipeline
 
     async def fake_fetch_url(url):
         return {
@@ -71,9 +76,13 @@ def client(monkeypatch):
     def fake_summarize_content(text, **_kwargs):
         return "Neutral summary of the content."
 
-    monkeypatch.setattr(bot.api, "fetch_url", fake_fetch_url)
+    # Pipeline's external dependencies — replace the names as the pipeline
+    # module sees them.
+    monkeypatch.setattr(bot.pipeline, "fetch_url", fake_fetch_url)
+    monkeypatch.setattr(bot.pipeline, "analyze", fake_analyze)
+    monkeypatch.setattr(bot.pipeline, "summarize_content", fake_summarize_content)
+    # /submit/text still calls analyze directly in bot.api — patch there too.
     monkeypatch.setattr(bot.api, "analyze", fake_analyze)
-    monkeypatch.setattr(bot.api, "summarize_content", fake_summarize_content)
 
     app = FastAPI()
     app.include_router(bot.api.router)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -414,6 +414,7 @@ class TestJobFlow:
         # fetched text (the canonical-representation contract).
         import asyncio
         import bot.api
+        import bot.pipeline
 
         captured = {}
 
@@ -425,7 +426,9 @@ class TestJobFlow:
                 "verdict": "skim",
             }
 
-        monkeypatch.setattr(bot.api, "analyze", capture_analyze)
+        # Post-pipeline refactor: analyze + summarize_content live inside
+        # bot.pipeline, so that's the module to patch for run-time overrides.
+        monkeypatch.setattr(bot.pipeline, "analyze", capture_analyze)
         db.create_job("job-3")
         asyncio.run(bot.api._run_job("job-3", "https://example.com/x", None, ""))
         assert captured["text"] == "Neutral summary of the content."
@@ -433,11 +436,12 @@ class TestJobFlow:
     def test_run_job_no_text_sets_extraction_error(self, client, db, monkeypatch):
         import asyncio
         import bot.api
+        import bot.pipeline
 
         async def empty_fetch(url):
             return {"text": "", "title": url, "source_type": "article", "reason": "no_text"}
 
-        monkeypatch.setattr(bot.api, "fetch_url", empty_fetch)
+        monkeypatch.setattr(bot.pipeline, "fetch_url", empty_fetch)
         db.create_job("job-4")
         asyncio.run(bot.api._run_job("job-4", "https://example.com/x", None, ""))
         rec = db.get_job_record("job-4")
@@ -447,11 +451,12 @@ class TestJobFlow:
     def test_run_job_video_no_text_sets_no_transcript(self, client, db, monkeypatch):
         import asyncio
         import bot.api
+        import bot.pipeline
 
         async def empty_video_fetch(url):
             return {"text": "", "title": url, "source_type": "youtube", "reason": "no_transcript"}
 
-        monkeypatch.setattr(bot.api, "fetch_url", empty_video_fetch)
+        monkeypatch.setattr(bot.pipeline, "fetch_url", empty_video_fetch)
         db.create_job("job-5")
         asyncio.run(bot.api._run_job("job-5", "https://example.com/x", None, ""))
         rec = db.get_job_record("job-5")

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,230 @@
+"""Tests for bot/pipeline.py — the unified URL → analysis chain that every
+URL-based entry point goes through (web /api/try, /api/job, /api/library/add,
+/submit/url, and Telegram URL handler).
+
+The whole point of the pipeline is that the *same* input produces the *same*
+analyze() call regardless of which entry point. These tests pin that
+contract: same URL → same analyze input → cache hits work end-to-end."""
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+
+@pytest.fixture
+def pipeline(monkeypatch):
+    """Mock the pipeline's external dependencies with deterministic fakes.
+
+    Tests override these via further monkeypatch calls when they need to
+    exercise a specific edge case (empty text, video source_type, etc.)."""
+    import bot.pipeline
+
+    async def fake_fetch_url(url):
+        return {
+            "text": "Long article body about retrieval-augmented generation.",
+            "title": "RAG explained",
+            "source_type": "article",
+            "image_urls": [],
+        }
+
+    def fake_summarize_content(text, **_kwargs):
+        return f"SUMMARY({len(text)} chars)"
+
+    def fake_analyze(text, user_id=None, **_kwargs):
+        return {
+            "main_idea": text,  # echo the input so we can assert what was analyzed
+            "why_it_matters": "",
+            "category": "",
+            "quick_win": "",
+            "bigger_play": "",
+            "time_required": "",
+            "verdict": "watch",
+        }
+
+    monkeypatch.setattr(bot.pipeline, "fetch_url", fake_fetch_url)
+    monkeypatch.setattr(bot.pipeline, "summarize_content", fake_summarize_content)
+    monkeypatch.setattr(bot.pipeline, "analyze", fake_analyze)
+    return bot.pipeline
+
+
+class TestAnalyzeUrlBasics:
+    def test_returns_pipeline_result(self, pipeline):
+        from bot.analyzer import UsageContext
+        result = asyncio.run(pipeline.analyze_url(
+            "https://example.com/post", ctx=UsageContext()
+        ))
+        assert result.title == "RAG explained"
+        assert result.source_type == "article"
+        assert result.summary.startswith("SUMMARY(")
+        assert result.analysis["verdict"] == "watch"
+
+    def test_analyze_runs_on_summary_not_raw_text(self, pipeline):
+        """Canonical-representation contract: analyze sees the SUMMARY,
+        not the raw fetched text. This is what makes the cache key stable
+        for long content where the raw text varies slightly between fetches."""
+        from bot.analyzer import UsageContext
+        result = asyncio.run(pipeline.analyze_url(
+            "https://example.com/post", ctx=UsageContext()
+        ))
+        # fake_analyze echoes its input via main_idea
+        assert result.analysis["main_idea"].startswith("SUMMARY(")
+
+    def test_signed_in_save_persists_item(self, pipeline, db):
+        from bot.analyzer import UsageContext
+        uid = db.get_or_create_user_by_telegram(1)
+        result = asyncio.run(pipeline.analyze_url(
+            "https://example.com/post",
+            ctx=UsageContext(user_id=uid),
+            save_for_user_id=uid,
+            user_note="a note",
+        ))
+        assert result.saved_id is not None
+        rows = db.get_all_items(uid)
+        assert len(rows) == 1
+        assert rows[0]["source"] == "https://example.com/post"
+        assert rows[0]["source_type"] == "article"
+        assert rows[0]["user_note"] == "a note"
+
+    def test_anonymous_does_not_save(self, pipeline, db):
+        from bot.analyzer import UsageContext
+        result = asyncio.run(pipeline.analyze_url(
+            "https://example.com/post",
+            ctx=UsageContext(anon_id="anon-1"),
+        ))
+        assert result.saved_id is None
+
+
+class TestErrors:
+    def test_fetch_failure_raises_pipeline_error(self, pipeline, monkeypatch):
+        async def boom_fetch(url):
+            raise RuntimeError("network down")
+        monkeypatch.setattr(pipeline, "fetch_url", boom_fetch)
+
+        from bot.analyzer import UsageContext
+        with pytest.raises(pipeline.PipelineError) as exc_info:
+            asyncio.run(pipeline.analyze_url("x", ctx=UsageContext()))
+        assert exc_info.value.code == pipeline.ERR_FETCH_FAILED
+
+    def test_empty_text_for_article_raises_extraction_failed(
+        self, pipeline, monkeypatch
+    ):
+        async def empty_fetch(url):
+            return {"text": "", "title": url, "source_type": "article",
+                    "image_urls": [], "reason": "no_text"}
+        monkeypatch.setattr(pipeline, "fetch_url", empty_fetch)
+
+        from bot.analyzer import UsageContext
+        with pytest.raises(pipeline.PipelineError) as exc_info:
+            asyncio.run(pipeline.analyze_url("x", ctx=UsageContext()))
+        assert exc_info.value.code == pipeline.ERR_NO_TEXT
+        assert exc_info.value.fetched["reason"] == "no_text"
+
+    def test_empty_text_for_video_raises_no_transcript(
+        self, pipeline, monkeypatch
+    ):
+        async def empty_video(url):
+            return {"text": "", "title": url, "source_type": "youtube",
+                    "image_urls": [], "reason": "no_transcript"}
+        monkeypatch.setattr(pipeline, "fetch_url", empty_video)
+
+        from bot.analyzer import UsageContext
+        with pytest.raises(pipeline.PipelineError) as exc_info:
+            asyncio.run(pipeline.analyze_url("x", ctx=UsageContext()))
+        assert exc_info.value.code == pipeline.ERR_NO_TRANSCRIPT
+
+    def test_analyze_crash_raises_analyze_failed(self, pipeline, monkeypatch):
+        def boom(_text, **_kwargs):
+            raise RuntimeError("rate limited")
+        monkeypatch.setattr(pipeline, "analyze", boom)
+
+        from bot.analyzer import UsageContext
+        with pytest.raises(pipeline.PipelineError) as exc_info:
+            asyncio.run(pipeline.analyze_url("x", ctx=UsageContext()))
+        assert exc_info.value.code == pipeline.ERR_ANALYZE_FAILED
+        # fetched is attached so callers can include title in error UX
+        assert exc_info.value.fetched["title"] == "RAG explained"
+
+
+class TestImageStrategy:
+    """The image-description step is what made Telegram diverge before. Now
+    it's a per-source-type default with an explicit override. These tests
+    pin the matrix so changes are deliberate."""
+
+    @pytest.fixture
+    def with_images(self, pipeline, monkeypatch):
+        """Override fetch to return image_urls; capture analyze input to
+        verify image descriptions did/didn't end up there."""
+        async def fetch_with_images(url):
+            return {
+                "text": "Article body",
+                "title": "T",
+                "source_type": "article",
+                "image_urls": ["https://example.com/img1.jpg"],
+            }
+        monkeypatch.setattr(pipeline, "fetch_url", fetch_with_images)
+
+        captured: dict[str, Any] = {}
+
+        async def fake_describe(image_urls, *, ctx):
+            return "\n\nIMAGE DESCRIPTIONS:\n[Image 1]: a chart"
+
+        def capture_summarize(text, **_kw):
+            captured["summary_input"] = text
+            return f"SUMMARY({len(text)} chars)"
+
+        monkeypatch.setattr(pipeline, "_describe_images", fake_describe)
+        monkeypatch.setattr(pipeline, "summarize_content", capture_summarize)
+        return pipeline, captured
+
+    def test_article_includes_images_by_default(self, with_images):
+        pl, captured = with_images
+        from bot.analyzer import UsageContext
+        asyncio.run(pl.analyze_url("x", ctx=UsageContext()))
+        assert "IMAGE DESCRIPTIONS" in captured["summary_input"]
+
+    def test_youtube_excludes_images_by_default(self, with_images, monkeypatch):
+        pl, captured = with_images
+
+        async def fetch_youtube(url):
+            return {
+                "text": "Transcript here",
+                "title": "T",
+                "source_type": "youtube",
+                "image_urls": ["https://yt/thumbnail.jpg"],
+            }
+        monkeypatch.setattr(pl, "fetch_url", fetch_youtube)
+
+        from bot.analyzer import UsageContext
+        asyncio.run(pl.analyze_url("x", ctx=UsageContext()))
+        assert "IMAGE DESCRIPTIONS" not in captured["summary_input"]
+
+    def test_explicit_false_overrides_default(self, with_images):
+        pl, captured = with_images
+        from bot.analyzer import UsageContext
+        asyncio.run(pl.analyze_url("x", ctx=UsageContext(), include_images=False))
+        assert "IMAGE DESCRIPTIONS" not in captured["summary_input"]
+
+
+class TestProgressCallback:
+    def test_on_step_called_with_known_labels(self, pipeline):
+        steps: list[str] = []
+
+        from bot.analyzer import UsageContext
+        asyncio.run(pipeline.analyze_url(
+            "x", ctx=UsageContext(), on_step=steps.append,
+        ))
+        # Article with no images skips describing-images.
+        assert steps == ["fetching", "summarizing", "analyzing"]
+
+    def test_on_step_failure_does_not_break_pipeline(self, pipeline):
+        def bad_callback(_label):
+            raise RuntimeError("logger crashed")
+
+        from bot.analyzer import UsageContext
+        result = asyncio.run(pipeline.analyze_url(
+            "x", ctx=UsageContext(), on_step=bad_callback,
+        ))
+        assert result.analysis["verdict"] == "watch"  # ran to completion


### PR DESCRIPTION
Closes the structural drift that motivated #37. Five entry points → one pipeline → one analyse cache key for the same content, regardless of which surface the user came in through.

## Before (the drift)

| Caller | Analyzes | Images? |
|---|---|---|
| Telegram URL (handlers.py) | **raw text** | **describes + appends** |
| /submit/url (signed-in form) | raw text | no |
| /api/try (anon Worker) | raw text | no |
| /api/library/add (signed-in Worker) | raw text | no |
| /api/job \`_run_job\` (async) | **summary** | no |

Two independent dimensions of divergence. The image one is what made #37 necessary; the summary-vs-raw one would have bitten next.

## After

One service function — \`bot.pipeline.analyze_url\` — does the whole chain. Every caller is now 3-8 lines + presentation logic:

\`\`\`
fetch_url
  → maybe append per-image LLM descriptions  (per source_type)
  → summarize_content
  → analyze(summary)                          ← consistent across all surfaces
  → maybe save_item                            (if save_for_user_id given)
```

Per-source-type image strategy (\`_INCLUDE_IMAGES_BY_DEFAULT\`):

| source_type | Images appended | Why |
|---|---|---|
| \`article\` | ✅ | Screenshots, charts, code in images carry real signal |
| \`social\` | ✅ | Posts are often image-driven |
| \`unknown\` | ✅ | Prefer richer over thinner |
| \`youtube\` | ❌ | Transcript IS the content |
| \`video\` | ❌ | Same |

Override via \`include_images=True/False\` if a caller wants to.

Errors flow through a single \`PipelineError\` with stable codes (\`fetch-failed\`, \`extraction-failed\`, \`no-transcript\`, \`analyze-failed\`). \`bot/api.py\` gains a single \`_pipeline_error_to_http\` translator so all three URL HTTP endpoints return the same Worker contract shape.

## Behaviour changes (worth flagging on review)

1. **Web users now get image-aware analysis** for articles + social posts. Adds ~\$0.001-0.005 to the first scan of image-rich content; cache amortises repeats to \$0.
2. **All paths analyse the summary, not the raw text.** Bounds the analyze prompt token count for long content. Cache key becomes stable for long articles/transcripts that previously hit the truncation boundary differently between calls.
3. \`/api/library/add\` save path no longer does \`get_all_items(user_id)[0][\"id\"]\` to find the new row — it uses \`save_item\`'s returned rowid directly. Race-condition window closed.

## Tests (13 new, 198 total)

[tests/test_pipeline.py](tests/test_pipeline.py):

| Class | What it pins |
|---|---|
| \`TestAnalyzeUrlBasics\` | Result shape; **analyze sees the summary not raw text**; save vs no-save |
| \`TestErrors\` | All 4 \`PipelineError\` codes raise correctly; \`fetched\` attached for analyze-failed so UX can use the title |
| \`TestImageStrategy\` | Article-with-images appends to summary input; YouTube doesn't; \`include_images=False\` overrides |
| \`TestProgressCallback\` | \`on_step\` fires with stable labels; a callback that throws doesn't break the chain |

3 \`_run_job\` tests in \`tests/test_api.py\` updated to patch \`bot.pipeline.{analyze, fetch_url}\` since those names no longer live on \`bot.api\`. \`conftest.py\`'s \`client\` fixture follows the same pattern.

\`make test\` → **198 passed**.

## What's NOT in this PR

- Frontend changes — the API contract shape is unchanged (verdict + analysis + image_urls returned as before).
- Image cache (#37) stays exactly as-is and is now load-bearing: it's what keeps the per-source-type image strategy from doubling cost on every analysis.
- Prompt or schema tweaks. Pure plumbing refactor.

## Deploy considerations

- Worker contract unchanged. Frontend doesn't need to ship anything.
- Cost shape changes for image-rich articles on the web side — worth watching the Cost tile for a day or two after deploy. The Cache tile should show a corresponding bump in image hits as users re-scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)