### PR TITLE
feat(debug): default debug scripts to signed-in path; add --anon flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,13 +159,15 @@ Example list output:
 
 ### Debugging the pipeline
 
-Three scripts walk the URL → analysis chain step by step and surface the internal length limits that bound each stage. Use them to see exactly where a piece of content is being truncated (`MAX_CONTENT_CHARS` on the fetched text, requested `max_tokens` on the summary call, `SUMMARY_MAX_CHARS` on the stored brief).
+Three scripts walk the URL → analysis chain step by step and surface the internal length limits that bound each stage. Use them to see exactly where a piece of content is being truncated (`MAX_CONTENT_CHARS` on the fetched text, requested `max_tokens` on the summary call, `SUMMARY_MAX_CHARS` on the stored brief) and which model the dispatch resolves to.
 
 ```bash
-python -m scripts.debug_transcript <url>                       # fetched text + char limits
-python -m scripts.debug_summary <url> [--no-cache]             # + summary, with token-cap fill ratio
-python -m scripts.debug_verdict <url> [--profile PROFILE.md]   # + verdict; defaults to anon DEFAULT_PROFILE
+python -m scripts.debug_transcript <url>                          # fetched text + char limits
+python -m scripts.debug_summary <url> [--anon] [--no-cache]       # + summary, with token-cap fill ratio
+python -m scripts.debug_verdict <url> [--anon] [--profile PROFILE.md]  # + verdict; profile defaults to DEFAULT_PROFILE
 ```
+
+`debug_summary` and `debug_verdict` default to the **signed-in path** (`ctx.user_id=1` → Sonnet 4.6 on summary + analyze), matching what a real signed-in user sees. Pass `--anon` to simulate the anonymous `/api/try` caller (Haiku throughout).
 
 `--no-cache` on `debug_summary` bypasses the content-addressed cache so you see a fresh LLM call after changing prompts or token caps (the cache key doesn't include `max_tokens`, so a stale truncated summary would otherwise be returned).
 

--- a/scripts/debug_summary.py
+++ b/scripts/debug_summary.py
@@ -8,11 +8,16 @@ Surfaces the limits applied at this stage:
   - bot.analyzer._summary_output_tokens(text) — actual max_tokens requested,
     scaled to the input length.
 
+By default runs as a signed-in user (ctx.user_id=1) so the model dispatch
+picks Sonnet 4.6 — same code path real signed-in users hit. Pass `--anon`
+to simulate an anonymous /api/try caller (Haiku 4.5).
+
 Hits the same content-addressed cache as the production pipeline; a "cache hit"
 log line means no LLM call was made.
 
 Run:
-    python -m scripts.debug_summary <url>
+    python -m scripts.debug_summary <url>            # signed-in path (default)
+    python -m scripts.debug_summary <url> --anon     # anon /api/try path
 """
 from __future__ import annotations
 
@@ -44,6 +49,13 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("url")
     parser.add_argument(
+        "--anon",
+        action="store_true",
+        help="Simulate the anonymous /api/try caller (no user_id in ctx). "
+        "Default is signed-in (ctx.user_id=1) so the dispatch picks the "
+        "premium model.",
+    )
+    parser.add_argument(
         "--no-cache",
         action="store_true",
         help="Force a fresh LLM call (the summary cache key doesn't include "
@@ -62,6 +74,16 @@ def main() -> int:
         return 1
 
     requested_max_tokens = _summary_output_tokens(text)
+    ctx = UsageContext(
+        user_id=None if args.anon else 1,
+        source_type=fetched.get("source_type") or "",
+    )
+    resolved_model = analyzer._resolve_model("summary", ctx)
+
+    print()
+    print("=== TIER ===")
+    print(f"mode:           {'anon' if args.anon else 'signed-in (user_id=1)'}")
+    print(f"resolved model: {resolved_model}")
 
     print()
     print("=== FETCH ===")
@@ -77,7 +99,6 @@ def main() -> int:
     print(f"_SUMMARY_MAX_OUTPUT_TOKENS:{_SUMMARY_MAX_OUTPUT_TOKENS:>7,}  (hard ceiling)")
     print(f"requested max_tokens:     {requested_max_tokens:,}  (scaled: ~input_chars // 4, 1:1 with input tokens)")
 
-    ctx = UsageContext(source_type=fetched.get("source_type") or "")
     summary = summarize_content(text, ctx=ctx)
 
     # Estimate output tokens used to detect a max_tokens-shaped cutoff. The

--- a/scripts/debug_verdict.py
+++ b/scripts/debug_verdict.py
@@ -1,16 +1,19 @@
 """Debug step 3: fetch + summarize + analyze a URL — the full pipeline ending in a verdict.
 
-Uses the real `bot.pipeline.analyze_url`, so this is exactly what `/api/try`
-runs for an anonymous user (no `save_for_user_id`).
+Uses the real `bot.pipeline.analyze_url`. By default runs as a signed-in
+user (ctx.user_id=1) so the dispatch picks Sonnet 4.6 for summary +
+analyze — same code path real signed-in users hit. Pass `--anon` to
+simulate the anonymous /api/try caller (Haiku 4.5 throughout).
 
 Surfaces all limits along the chain:
   - bot.config.MAX_CONTENT_CHARS    (fetched text cap)
   - bot.analyzer.SUMMARY_MAX_CHARS  (summary cap — analyze() runs on the summary, not the raw text)
-  - profile text (DEFAULT_PROFILE for anon, or the file passed via --profile)
+  - profile text (DEFAULT_PROFILE if --profile not given; --profile reads from a file)
 
 Run:
-    python -m scripts.debug_verdict <url>                       # anon → DEFAULT_PROFILE
-    python -m scripts.debug_verdict <url> --profile PROFILE.md  # use a custom profile file
+    python -m scripts.debug_verdict <url>                       # signed-in path (default)
+    python -m scripts.debug_verdict <url> --anon                # anon /api/try path
+    python -m scripts.debug_verdict <url> --profile PROFILE.md  # signed-in with a custom profile
 """
 from __future__ import annotations
 
@@ -38,29 +41,44 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("url")
     parser.add_argument(
+        "--anon",
+        action="store_true",
+        help="Simulate the anonymous /api/try caller (no user_id in ctx). "
+        "Default is signed-in (ctx.user_id=1) so the dispatch picks the "
+        "premium model.",
+    )
+    parser.add_argument(
         "--profile",
-        help="Path to a profile file (e.g. PROFILE.md). Omit to use DEFAULT_PROFILE (anon).",
+        help="Path to a profile file (e.g. PROFILE.md). Omit to use DEFAULT_PROFILE.",
     )
     args = parser.parse_args()
 
-    # Resolve which profile the analyzer will use. We monkey-patch
-    # _load_profile so analyze() picks up the supplied file without needing a
-    # signed-in user_id, mirroring the anon path otherwise.
+    # Resolve which profile the analyzer will use. We always monkey-patch
+    # _load_profile so analyze() picks up the configured text without
+    # touching the real DB — independent of the tier flag.
     if args.profile:
         profile_text = Path(args.profile).read_text(encoding="utf-8").strip()
         profile_source = f"file: {args.profile}"
-        analyzer._load_profile = lambda user_id=None: profile_text  # type: ignore[assignment]
     else:
         profile_text = DEFAULT_PROFILE
-        profile_source = "DEFAULT_PROFILE (anon)"
+        profile_source = "DEFAULT_PROFILE"
+    analyzer._load_profile = lambda user_id=None: profile_text  # type: ignore[assignment]
+
+    ctx = UsageContext(user_id=None if args.anon else 1)
+    resolved_summary_model = analyzer._resolve_model("summary", ctx)
+    resolved_analyze_model = analyzer._resolve_model("analyze", ctx)
+
+    print()
+    print("=== TIER ===")
+    print(f"mode:           {'anon' if args.anon else 'signed-in (user_id=1)'}")
+    print(f"summary model:  {resolved_summary_model}")
+    print(f"analyze model:  {resolved_analyze_model}")
 
     print()
     print("=== PROFILE ===")
     print(f"source: {profile_source}")
     print(f"chars:  {len(profile_text):,}")
     print(profile_text)
-
-    ctx = UsageContext()  # anon: no user_id / anon_id / job_id
 
     def on_step(label: str) -> None:
         logger.info("pipeline step: %s", label)


### PR DESCRIPTION
## Summary

Defaults `scripts/debug_summary` and `scripts/debug_verdict` to the **signed-in** code path (`ctx.user_id=1` → Sonnet 4.6 on summary + analyze) so running either script exercises what a real signed-in user sees. Pass `--anon` to simulate the anonymous `/api/try` caller (Haiku throughout).

Follow-up to #39 — that PR landed the per-tier dispatch but the debug scripts still ran as anon by default, so they didn't exercise the Sonnet path.

## What changed

- `--anon` flag added to `debug_summary.py` and `debug_verdict.py`.
- Both scripts print a `=== TIER ===` block showing the mode and the resolved model(s), so the dispatch choice is visible without grepping logs.
- `debug_verdict.py` now always monkey-patches `_load_profile` (was only doing it when `--profile` was given). Needed because the signed-in default passes a `user_id` that would otherwise trigger a real DB lookup.
- `debug_transcript.py` untouched — it doesn't touch any LLM, so the tier doesn't apply.
- README's "Debugging the pipeline" subsection updated with the new flag matrix.

## Usage

```bash
python -m scripts.debug_summary  <url>           # signed-in → Sonnet 4.6
python -m scripts.debug_summary  <url> --anon    # anon      → Haiku 4.5
python -m scripts.debug_verdict  <url>           # signed-in → Sonnet 4.6 (summary + analyze)
python -m scripts.debug_verdict  <url> --anon    # anon      → Haiku 4.5
```

## Test plan

- [ ] `python -m scripts.debug_summary <url>` — `=== TIER ===` shows `signed-in (user_id=1)` and `resolved model: claude-sonnet-4-6`.
- [ ] `python -m scripts.debug_summary <url> --anon` — `=== TIER ===` shows `anon` and `resolved model: claude-haiku-4-5-20251001`.
- [ ] `python -m scripts.debug_verdict <url>` — both `summary model` and `analyze model` show Sonnet.
- [ ] `python -m scripts.debug_verdict <url> --anon` — both show Haiku.
- [ ] Full pytest suite still passes (verified locally: 201/201).

🤖 Generated with [Claude Code](https://claude.com/claude-code)