### PR TITLE
fix(youtube): use any-language transcript instead of forcing English

### DIFF
--- a/bot/fetcher.py
+++ b/bot/fetcher.py
@@ -105,15 +105,26 @@ def _youtube_transcript(url: str) -> dict:
     thumb = _youtube_thumbnail(video_id)
     try:
         api = YouTubeTranscriptApi()
-        fetched = api.fetch(video_id)
-        text = " ".join(snippet.text for snippet in fetched)
-        title = _youtube_oembed_title(url) or f"YouTube video ({video_id})"
-        return {
-            "text": f"{title}\n\nTranscript:\n{text}"[:MAX_CONTENT_CHARS],
-            "title": title,
-            "source_type": "youtube",
-            "image_urls": [thumb],
-        }
+        # Enumerate every available transcript instead of forcing 'en'. Prefer
+        # manually-created over auto-generated, but DON'T translate — keep the
+        # source language so the LLM summarises in the speaker's tongue. The
+        # previous `api.fetch(video_id)` defaulted to English and silently
+        # dropped to yt-dlp for every non-English-captioned video.
+        transcripts = list(api.list(video_id))
+        manual = next((t for t in transcripts if not t.is_generated), None)
+        generated = next((t for t in transcripts if t.is_generated), None)
+        transcript = manual or generated
+        if transcript is not None:
+            fetched = transcript.fetch()
+            text = " ".join(snippet.text for snippet in fetched)
+            title = _youtube_oembed_title(url) or f"YouTube video ({video_id})"
+            return {
+                "text": f"{title}\n\nTranscript:\n{text}"[:MAX_CONTENT_CHARS],
+                "title": title,
+                "source_type": "youtube",
+                "image_urls": [thumb],
+                "language": transcript.language_code,
+            }
     except Exception:
         logger.info(f"No transcript for {video_id}, falling back to yt-dlp")
 
@@ -291,10 +302,19 @@ def _yt_dlp_extract(url: str) -> dict:
     uploader = info.get("uploader") or info.get("channel") or ""
     description = info.get("description") or ""
     duration = int(info.get("duration") or 0)
+    language = info.get("language") or ""
     source_type = "youtube" if "vimeo" not in url and "youtube" in url else "video"
 
-    # Pass 2: best-effort subtitle download. A 429 here drops us back to the
-    # description; it does NOT take the whole extract down with it.
+    # Pass 2: best-effort subtitle download. Prefer the video's detected
+    # language so non-English videos don't degrade to description-only, then
+    # fall through to common English variants for back-compat. A 429 here
+    # drops us back to the description; it does NOT take the whole extract
+    # down with it.
+    lang_pref: list[str] = []
+    for lang in (language, "en", "en-US", "en-GB"):
+        if lang and lang not in lang_pref:
+            lang_pref.append(lang)
+
     subtitle_text = ""
     try:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -304,7 +324,7 @@ def _yt_dlp_extract(url: str) -> dict:
                 "ignore_no_formats_error": True,
                 "writesubtitles": True,
                 "writeautomaticsub": True,
-                "subtitleslangs": ["en", "en-US", "en-GB"],
+                "subtitleslangs": lang_pref,
                 "subtitlesformat": "vtt",
                 "paths": {"home": tmpdir},
                 "outtmpl": os.path.join("%(id)s", "%(id)s.%(ext)s"),
@@ -346,6 +366,7 @@ def _yt_dlp_extract(url: str) -> dict:
         "source_type": source_type,
         "has_transcript": bool(subtitle_text),
         "duration": duration,
+        "language": language,
     }
 
 

--- a/scripts/debug_transcript.py
+++ b/scripts/debug_transcript.py
@@ -26,7 +26,10 @@ logger = logging.getLogger("debug.transcript")
 
 
 def _raw_youtube_transcript_len(url: str) -> int | None:
-    """Pre-truncation raw transcript length, or None if not YouTube / unavailable."""
+    """Pre-truncation raw transcript length, or None if not YouTube / unavailable.
+
+    Mirrors `_youtube_transcript`'s language-agnostic selection so it works for
+    non-English videos too — preferring manual over auto-generated."""
     from bot.fetcher import _YT_PATTERNS
 
     match = _YT_PATTERNS.search(url)
@@ -37,7 +40,13 @@ def _raw_youtube_transcript_len(url: str) -> int | None:
         from youtube_transcript_api import YouTubeTranscriptApi
 
         api = YouTubeTranscriptApi()
-        fetched = api.fetch(video_id)
+        transcripts = list(api.list(video_id))
+        manual = next((t for t in transcripts if not t.is_generated), None)
+        generated = next((t for t in transcripts if t.is_generated), None)
+        transcript = manual or generated
+        if transcript is None:
+            return None
+        fetched = transcript.fetch()
         return sum(len(s.text) + 1 for s in fetched)  # +1 mirrors the " ".join
     except Exception as e:
         logger.warning("raw transcript fetch failed: %s", e)
@@ -64,6 +73,8 @@ def main() -> int:
     print(f"source_type:  {fetched.get('source_type')}")
     print(f"title:        {fetched.get('title')}")
     print(f"image_urls:   {len(fetched.get('image_urls') or [])}")
+    if fetched.get("language"):
+        print(f"language:     {fetched['language']}")
     if fetched.get("reason"):
         print(f"reason:       {fetched['reason']}")
 

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -18,14 +18,21 @@ VIDEO_ID = "dQw4w9WgXcQ"
 
 
 class TestYouTubeFallbackChain:
+    def _mock_transcript(self, *, language_code: str = "en", is_generated: bool = False, snippets=("hello", "world")):
+        """Build a Transcript-shaped mock whose `.fetch()` yields snippets with `.text`."""
+        t = MagicMock()
+        t.language_code = language_code
+        t.is_generated = is_generated
+        t.fetch.return_value = [MagicMock(text=s) for s in snippets]
+        return t
+
     def test_uses_transcript_api_when_available(self):
         from bot import fetcher
 
         with patch("youtube_transcript_api.YouTubeTranscriptApi") as TranscriptApi, \
              patch.object(fetcher, "_youtube_oembed_title", return_value="Real Title"):
-            TranscriptApi.return_value.fetch.return_value = [
-                MagicMock(text="hello"),
-                MagicMock(text="world"),
+            TranscriptApi.return_value.list.return_value = [
+                self._mock_transcript(snippets=("hello", "world")),
             ]
             result = fetcher._youtube_transcript(YOUTUBE_URL)
 
@@ -34,13 +41,45 @@ class TestYouTubeFallbackChain:
         assert any("ytimg.com" in u for u in result.get("image_urls", []))
         # Real video title surfaces instead of the "YouTube video (<id>)" placeholder.
         assert result["title"] == "Real Title"
+        assert result["language"] == "en"
+
+    def test_prefers_manual_over_auto_generated_transcript(self):
+        """When both manual and auto-generated transcripts exist, the manually
+        created one wins — it's usually higher fidelity (real captions vs. ASR)."""
+        from bot import fetcher
+
+        manual = self._mock_transcript(language_code="de", is_generated=False, snippets=("manual",))
+        auto = self._mock_transcript(language_code="en", is_generated=True, snippets=("auto",))
+        with patch("youtube_transcript_api.YouTubeTranscriptApi") as TranscriptApi, \
+             patch.object(fetcher, "_youtube_oembed_title", return_value="t"):
+            # Order shouldn't matter — manual is selected regardless.
+            TranscriptApi.return_value.list.return_value = [auto, manual]
+            result = fetcher._youtube_transcript(YOUTUBE_URL)
+
+        assert "manual" in result["text"]
+        assert "auto" not in result["text"]
+        assert result["language"] == "de"
+
+    def test_uses_non_english_auto_generated_when_thats_all_there_is(self):
+        """A German-only auto-generated transcript should be picked up (regression
+        for the English-default behaviour that silently dropped non-en videos)."""
+        from bot import fetcher
+
+        de_auto = self._mock_transcript(language_code="de", is_generated=True, snippets=("guten", "tag"))
+        with patch("youtube_transcript_api.YouTubeTranscriptApi") as TranscriptApi, \
+             patch.object(fetcher, "_youtube_oembed_title", return_value="t"):
+            TranscriptApi.return_value.list.return_value = [de_auto]
+            result = fetcher._youtube_transcript(YOUTUBE_URL)
+
+        assert "guten tag" in result["text"]
+        assert result["language"] == "de"
 
     def test_transcript_api_title_falls_back_to_placeholder(self):
         from bot import fetcher
 
         with patch("youtube_transcript_api.YouTubeTranscriptApi") as TranscriptApi, \
              patch.object(fetcher, "_youtube_oembed_title", return_value=None):
-            TranscriptApi.return_value.fetch.return_value = [MagicMock(text="hi")]
+            TranscriptApi.return_value.list.return_value = [self._mock_transcript(snippets=("hi",))]
             result = fetcher._youtube_transcript(YOUTUBE_URL)
 
         assert result["title"] == f"YouTube video ({VIDEO_ID})"
@@ -51,7 +90,7 @@ class TestYouTubeFallbackChain:
         with patch("youtube_transcript_api.YouTubeTranscriptApi") as TranscriptApi, \
              patch.object(fetcher, "_yt_dlp_extract") as extract, \
              patch.object(fetcher, "_yt_dlp_transcribe") as transcribe:
-            TranscriptApi.return_value.fetch.side_effect = Exception("blocked")
+            TranscriptApi.return_value.list.side_effect = Exception("blocked")
             extract.return_value = {
                 "text": "Title\nBy: ch\n\nTranscript:\nsubs body",
                 "title": "Title",
@@ -72,7 +111,7 @@ class TestYouTubeFallbackChain:
         with patch("youtube_transcript_api.YouTubeTranscriptApi") as TranscriptApi, \
              patch.object(fetcher, "_yt_dlp_extract") as extract, \
              patch.object(fetcher, "_yt_dlp_transcribe") as transcribe:
-            TranscriptApi.return_value.fetch.side_effect = Exception("blocked")
+            TranscriptApi.return_value.list.side_effect = Exception("blocked")
             extract.return_value = {
                 "text": "Title\nBy: ch\n\nshort description",
                 "title": "Title",
@@ -98,7 +137,7 @@ class TestYouTubeFallbackChain:
         with patch("youtube_transcript_api.YouTubeTranscriptApi") as TranscriptApi, \
              patch.object(fetcher, "_yt_dlp_extract") as extract, \
              patch.object(fetcher, "_yt_dlp_transcribe") as transcribe:
-            TranscriptApi.return_value.fetch.side_effect = Exception("blocked")
+            TranscriptApi.return_value.list.side_effect = Exception("blocked")
             extract.return_value = {
                 "text": "Title\nBy: ch\n\nlong description",
                 "title": "Title",
@@ -118,7 +157,7 @@ class TestYouTubeFallbackChain:
         with patch("youtube_transcript_api.YouTubeTranscriptApi") as TranscriptApi, \
              patch.object(fetcher, "_yt_dlp_extract") as extract, \
              patch.object(fetcher, "_yt_dlp_transcribe") as transcribe:
-            TranscriptApi.return_value.fetch.side_effect = Exception("blocked")
+            TranscriptApi.return_value.list.side_effect = Exception("blocked")
             extract.return_value = {
                 "text": "Title\nBy: ch\n\ndescription text",
                 "title": "Title",
@@ -142,7 +181,7 @@ class TestYouTubeFallbackChain:
         with patch("youtube_transcript_api.YouTubeTranscriptApi") as TranscriptApi, \
              patch.object(fetcher, "_yt_dlp_extract") as extract, \
              patch.object(fetcher, "_yt_dlp_transcribe") as transcribe:
-            TranscriptApi.return_value.fetch.side_effect = Exception("blocked")
+            TranscriptApi.return_value.list.side_effect = Exception("blocked")
             extract.return_value = {
                 "text": "",
                 "title": YOUTUBE_URL,


### PR DESCRIPTION
## Summary

The YouTube fetcher was hardcoded to English-only at two points, which silently degraded non-English videos to a description-only response. This PR fixes both, keeps the source language (no translation), and surfaces the picked-up language in the fetched dict.

## The bug

`bot/fetcher.py:_youtube_transcript` was calling `api.fetch(video_id)` with no language argument — the youtube-transcript-api library defaults to `'en'`, so any non-English-captioned video raised. It then fell through to `_yt_dlp_extract`, whose subtitle pass requested `subtitleslangs=["en", "en-US", "en-GB"]` only — also failed. For videos longer than 180s the Whisper fallback skipped, and the user got `reason: video_too_long_for_whisper` plus 3-4k chars of YouTube description (affiliate links, timestamps, disclaimer).

**Repro:** `https://www.youtube.com/watch?v=fEhvFf5oxM0` (German market podcast, German auto-generated captions only).

| | before | after |
|---|---:|---:|
| fetched text chars | ~3,654 (description-only) | **~16,266 (German transcript)** |
| `reason` flag | `video_too_long_for_whisper` | _(unset — success)_ |
| `language` | _(absent)_ | `de` |

## Changes

- **`_youtube_transcript`**: switched from `api.fetch(video_id)` to `api.list(video_id)`, enumerate transcripts, prefer manually-created over auto-generated, pick the first available. No translation — keep the speaker's language so the LLM summarises in the same tongue.
- **`_yt_dlp_extract`**: use `info.get(\"language\")` from the metadata pass as the primary subtitle language preference, with the previous English variants as fallback.
- Both code paths now return `language` in the fetched dict so downstream surfaces (the debug script, future analyze prompts, persisted item rows if you want to add a column later) can see the detected language.
- `scripts/debug_transcript.py`'s pre-truncation-length helper was using the same English-only API and emitting a spurious WARNING for non-en videos — aligned with the new selection logic and the script now also prints `language: <code>` in the FETCH block.

## Why no translation

`youtube-transcript-api` does support translating any transcript to a target language, but:

1. Claude handles multilingual content natively — both the summary prompt and the analyze prompt work in any language. A user reading a German podcast presumably wants a German brief, not a re-translated-into-English one.
2. Translation loses speaker voice and adds a translation-quality dependency on the captions provider's machine translation.
3. Adding it later behind a flag is trivial; ripping out a baked-in translation later is harder.

## Tests

- New: `test_prefers_manual_over_auto_generated_transcript` — regression for the selection order.
- New: `test_uses_non_english_auto_generated_when_thats_all_there_is` — direct regression for the German-only case.
- Existing 6 tests in the fallback chain rewired to the `.list()`-based mock pattern.
- Full suite: **203 passing** locally.

## Test plan

- [ ] `python -m scripts.debug_transcript 'https://www.youtube.com/watch?v=fEhvFf5oxM0'` returns ~16k chars and shows `language: de`.
- [ ] An English-captioned video (e.g. `-HppUFVl-Ak`) still picks up its English transcript with `language: en`.
- [ ] A multi-language video with both manual and auto-generated transcripts picks the manual one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)