### PR TITLE
feat(summary): preserve source language + anchor relative dates

### DIFF
--- a/bot/analyzer.py
+++ b/bot/analyzer.py
@@ -460,6 +460,15 @@ sponsor segments, and verbatim padding.
 and only short phrases (under ~25 words) where exact wording matters.
 - Scale length to the source: a short article stays short; a long, dense, \
 multi-topic source should yield a long, thoroughly sectioned brief.
+- Write the brief in the SAME language as the source content. If the source mixes \
+languages, use the dominant one. Do not translate.
+- Anchor every relative time expression ("this year", "last week", "a few months \
+ago", "recently") to the source date shown below — NOT to your own training \
+cutoff. If the source itself states an absolute date, preserve that exact date. \
+Do not invent specific years that the source left vague.
+
+SOURCE METADATA:
+- Published: {published_at}
 
 CONTENT:
 {text}"""
@@ -472,6 +481,18 @@ SUMMARY_MAX_CHARS = 100_000
 # SUMMARY_MAX_CHARS at the model's average chars/token, and well under the
 # Haiku 4.5 64k hard limit. Scaled per source below.
 _SUMMARY_MAX_OUTPUT_TOKENS = 32_000
+
+
+def _published_at_for_prompt(published_at: str | None) -> str:
+    """Render the SOURCE METADATA Published line. Falls back to today tagged
+    as a best estimate when the caller doesn't have a real date — this still
+    anchors the model to the right year, which is what fixed the Haiku date
+    hallucinations (e.g. Haiku writing "October 2023" for a transcript that
+    said "Oktober 2025")."""
+    if published_at and published_at.strip():
+        return published_at.strip()
+    from datetime import date
+    return f"{date.today().isoformat()} (today; actual publication date unknown)"
 
 
 def _summary_output_tokens(text: str) -> int:
@@ -487,23 +508,38 @@ def _summary_output_tokens(text: str) -> int:
     return max(512, min(_SUMMARY_MAX_OUTPUT_TOKENS, approx_input_tokens))
 
 
-def summarize_content(text: str, *, ctx: UsageContext | None = None) -> str:
+def summarize_content(
+    text: str,
+    *,
+    ctx: UsageContext | None = None,
+    published_at: str | None = None,
+) -> str:
     """Distil source content into a faithful, length-scaled structured brief.
 
     Stored instead of the full fetched text: rich enough to re-derive verdicts
     under a different profile and to power retrieval/chat, but a derived brief
     rather than a verbatim copy. Falls back to a truncated slice if the model
     call fails, so persistence never breaks on an LLM hiccup.
+
+    `published_at` is the source's publication date (ISO YYYY-MM-DD), used to
+    anchor relative time expressions ("this year") so the model doesn't fill
+    them in from its own training cutoff. If unknown, today's date is passed
+    in tagged as a best-estimate fallback — still better than letting the
+    model default to its training year, which is what produced the date
+    hallucinations seen on non-English transcripts.
     """
     text = (text or "").strip()
     if not text:
         return ""
 
     model = _resolve_model("summary", ctx)
+    published_at_str = _published_at_for_prompt(published_at)
 
     # Cache: keyed by (provider, model, prompt template, content). Anon and
     # signed-in callers land on different models so their results are
-    # partitioned naturally by the cache key.
+    # partitioned naturally by the cache key. published_at is deliberately
+    # NOT part of the key — a per-day fallback would otherwise blow the cache
+    # daily for any source without a real publication date.
     cache_key = _cache_key_summary(text, model)
     cached = _try_cache_get(cache_key)
     if cached is not None:
@@ -511,7 +547,7 @@ def summarize_content(text: str, *, ctx: UsageContext | None = None) -> str:
         _record_cache_hit(purpose="summary", ctx=ctx)
         return cached[:SUMMARY_MAX_CHARS]
 
-    prompt = _SUMMARY_PROMPT.format(text=text)
+    prompt = _SUMMARY_PROMPT.format(text=text, published_at=published_at_str)
     max_tokens = _summary_output_tokens(text)
     started = time.monotonic()
     try:

--- a/bot/fetcher.py
+++ b/bot/fetcher.py
@@ -303,6 +303,14 @@ def _yt_dlp_extract(url: str) -> dict:
     description = info.get("description") or ""
     duration = int(info.get("duration") or 0)
     language = info.get("language") or ""
+    # yt-dlp returns YYYYMMDD as a string; normalise to ISO so it flows
+    # cleanly into prompts and (later) into stored item rows.
+    upload_date_raw = info.get("upload_date") or ""
+    published_at = (
+        f"{upload_date_raw[:4]}-{upload_date_raw[4:6]}-{upload_date_raw[6:8]}"
+        if len(upload_date_raw) == 8 and upload_date_raw.isdigit()
+        else ""
+    )
     source_type = "youtube" if "vimeo" not in url and "youtube" in url else "video"
 
     # Pass 2: best-effort subtitle download. Prefer the video's detected
@@ -367,6 +375,7 @@ def _yt_dlp_extract(url: str) -> dict:
         "has_transcript": bool(subtitle_text),
         "duration": duration,
         "language": language,
+        "published_at": published_at,
     }
 
 

--- a/bot/pipeline.py
+++ b/bot/pipeline.py
@@ -162,9 +162,16 @@ async def analyze_url(
 
     # Summarise on a thread so we don't block the event loop on the LLM
     # call. The async wrapper around a sync call mirrors what _run_job did.
+    # `published_at` (when available from yt-dlp) anchors the model's
+    # interpretation of relative dates in the source — without it, models
+    # silently default to their training-cutoff year.
     _step("summarizing")
+    published_at = fetched.get("published_at") or ""
     loop = asyncio.get_running_loop()
-    summary = await loop.run_in_executor(None, lambda: summarize_content(text, ctx=ctx))
+    summary = await loop.run_in_executor(
+        None,
+        lambda: summarize_content(text, ctx=ctx, published_at=published_at),
+    )
 
     _step("analyzing")
     try:

--- a/scripts/debug_summary.py
+++ b/scripts/debug_summary.py
@@ -85,10 +85,13 @@ def main() -> int:
     print(f"mode:           {'anon' if args.anon else 'signed-in (user_id=1)'}")
     print(f"resolved model: {resolved_model}")
 
+    published_at = fetched.get("published_at") or ""
     print()
     print("=== FETCH ===")
     print(f"source_type:        {fetched.get('source_type')}")
     print(f"title:              {fetched.get('title')}")
+    print(f"language:           {fetched.get('language') or '(unknown)'}")
+    print(f"published_at:       {published_at or '(unknown — will fall back to today)'}")
     print(f"fetched text chars: {len(text):,}  (MAX_CONTENT_CHARS={MAX_CONTENT_CHARS:,})")
     if len(text) >= MAX_CONTENT_CHARS:
         print(f"*** input was TRUNCATED at MAX_CONTENT_CHARS before summarization ***")
@@ -99,7 +102,7 @@ def main() -> int:
     print(f"_SUMMARY_MAX_OUTPUT_TOKENS:{_SUMMARY_MAX_OUTPUT_TOKENS:>7,}  (hard ceiling)")
     print(f"requested max_tokens:     {requested_max_tokens:,}  (scaled: ~input_chars // 4, 1:1 with input tokens)")
 
-    summary = summarize_content(text, ctx=ctx)
+    summary = summarize_content(text, ctx=ctx, published_at=published_at)
 
     # Estimate output tokens used to detect a max_tokens-shaped cutoff. The
     # char cap (SUMMARY_MAX_CHARS) and the token cap (requested max_tokens)

--- a/scripts/debug_transcript.py
+++ b/scripts/debug_transcript.py
@@ -75,6 +75,8 @@ def main() -> int:
     print(f"image_urls:   {len(fetched.get('image_urls') or [])}")
     if fetched.get("language"):
         print(f"language:     {fetched['language']}")
+    if fetched.get("published_at"):
+        print(f"published_at: {fetched['published_at']}")
     if fetched.get("reason"):
         print(f"reason:       {fetched['reason']}")
 


### PR DESCRIPTION
## Summary

Two related summary-step fidelity fixes, both surfaced by the German-podcast comparison done after #41 merged:

1. **Language preservation.** Haiku was silently translating German transcripts to English because the prompt is in English and the rules said nothing about output language. That undoes #41 (multilang fetcher) at the next step of the chain.
2. **Date anchoring.** Both Haiku and Sonnet were filling in relative time expressions ("diesen Jahres", "in diesem Jahr") with their *training-cutoff* year — Haiku → 2024, Sonnet → 2025 — instead of the source's actual recording date. Haiku even rewrote *absolute* dates the speaker stated outright (transcript: "Oktober 2025" → Haiku: "October 2023").

## Mechanism

- `_SUMMARY_PROMPT` gains two new rules and a `SOURCE METADATA` block above CONTENT:
  - Write the brief in the same language as the source. Don't translate.
  - Anchor every relative time expression to the SOURCE METADATA Published date — not your own training cutoff. Preserve absolute dates verbatim. Don't invent specifics the source left vague.
- `summarize_content(text, *, ctx, published_at=None)` — new optional kwarg, threaded through the format string.
- `_published_at_for_prompt(published_at)` — falls back to today's date tagged as a best estimate when the caller doesn't have a real date. Still anchors the model to the current year, which is what fixed Haiku's year drift.
- `bot.fetcher._yt_dlp_extract` returns `published_at` (ISO `YYYY-MM-DD`) from yt-dlp's `upload_date` field.
- `bot.pipeline.analyze_url` reads `published_at` from the fetched dict and passes it into `summarize_content`.
- Debug scripts surface `published_at` so the anchor is visible.
- `published_at` is **not** part of the summary cache key — a per-day fallback would otherwise blow the cache daily for any source without a real publication date. The prompt template hash already invalidates all old summaries thanks to the new SOURCE METADATA section.

## Verification — German repro (`fEhvFf5oxM0`)

Anon (Haiku), `--no-cache`:

| | before | after |
|---|---|---|
| Output language | en (translated) | **de** ✅ |
| "größter Rückgang seit Oktober 2025" | "October 2023" ❌ | **"Oktober 2025"** ✅ |
| "14 Senkung ... in diesem Jahr" | "14 rate cuts in 2024" ❌ | **"14 Zinsensenkungen ... im Jahr 2026"** ✅ |
| "20. Feb. diesen Jahres" | "February 20, 2024" ❌ | **"20. Februar 2026"** ✅ |

Signed-in (Sonnet) re-checked — no regression; language stays German, "Oktober 2025" preserved, and Sonnet now surfaces `Veröffentlicht: 2026-06-06` from the SOURCE METADATA block.

## Why not put `published_at` in the cache key?

When the caller has no real date we fall back to `date.today()`. If `published_at` were part of the cache key, every URL without a known publication date would miss the cache daily — destroying the value of the content-addressed cache. The risk in *not* including it is small: per URL, the publication date is stable, so the same input maps to the same cached output deterministically.

## Tests

All 203 tests pass. The prompt change naturally invalidates every existing summary cache row (good — they were potentially wrong).

## Test plan

- [ ] `python -m scripts.debug_summary 'https://www.youtube.com/watch?v=fEhvFf5oxM0' --anon --no-cache` — summary in German, dates match the transcript's "Oktober 2025" etc.
- [ ] Same URL without `--anon` (signed-in Sonnet) — still German, dates anchored.
- [ ] An English source still produces an English brief.
- [ ] yt-dlp-fetched videos (no transcript_api hit) show a real `published_at` from `upload_date` rather than the today-fallback.

## Follow-ups not in this PR

- The youtube-transcript-api success path doesn't surface upload date without an extra round-trip; today's date is a usable proxy for recent uploads but not for historical content. Worth a separate ticket if we want exact dates everywhere.
- Sonnet drifted "14 → 4" on one numeric mention in one re-run — run-to-run variance, not caused by this change. If it persists, worth a "preserve numbers exactly" rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)