### PR TITLE
chore(actions): reword "do this with your AI" → "try this"

### DIFF
--- a/bot/agent_brief.py
+++ b/bot/agent_brief.py
@@ -1,9 +1,9 @@
-"""Build agent-agnostic 'do this with AI' handoff briefs from an analysis.
+"""Build agent-agnostic 'try this' handoff briefs from an analysis.
 
 The brief is a self-contained, paste-anywhere instruction the user drops into
-their own AI assistant (ChatGPT, Claude, Cursor, Codex, Gemini — we don't name
-one). filter.fyi finds the signal and hands it off; the user's own AI does the
-work, so this adds no inference cost on our side — the brief is pure templating
+their assistant of choice (ChatGPT, Claude, Cursor, Codex, Gemini — we don't name
+one). filter.fyi finds the signal and hands it off; the user's own assistant does
+the work, so this adds no inference cost on our side — the brief is pure templating
 over fields the analysis already produced.
 
 Security: source-derived text (the grounded claim + a summary excerpt) is wrapped
@@ -44,7 +44,8 @@ def build_agent_brief(
 ) -> str:
     """Render one agent-agnostic handoff brief.
 
-    Returns a plain-text block the user can paste into any AI assistant. Empty
+    Returns a plain-text block the user can paste into their assistant of choice
+    (ChatGPT, Claude, Cursor, Codex, …). Empty
     `action` yields an empty string (nothing to hand off).
     """
     action = (action or "").strip()

--- a/bot/formatting.py
+++ b/bot/formatting.py
@@ -34,15 +34,15 @@ def format_agent_brief(action: dict) -> str:
     """Render one handoff action as a Telegram-HTML message with a copyable block.
 
     The brief sits in a <pre> block so Telegram offers tap-to-copy — the user
-    pastes it straight into whatever AI assistant they use.
+    pastes it straight into whatever assistant they use (ChatGPT, Claude, …).
     """
     label = (action.get("label") or "Action").strip()
     brief = (action.get("brief") or "").strip()
     if not brief:
         return ""
     return (
-        f"📋 <b>{html.escape(label)} — do this with your AI</b>\n"
-        f"<i>tap to copy, paste into ChatGPT / Claude / Cursor / Codex…</i>\n"
+        f"📋 <b>{html.escape(label)} — try this</b>\n"
+        f"<i>tap to copy, then paste into ChatGPT, Claude, Cursor, Codex…</i>\n"
         f"<pre>{html.escape(brief)}</pre>"
     )
 

--- a/bot/handlers.py
+++ b/bot/handlers.py
@@ -28,7 +28,7 @@ async def _send_agent_briefs(
     source_title: str = "",
     source_url: str = "",
 ) -> None:
-    """Send a copyable 'do this with your AI' brief per action, after the analysis.
+    """Send a copyable 'try this' brief per action, after the analysis.
 
     Sent as separate messages so each stays within Telegram's length limit and
     each <pre> block is independently tap-to-copy.


### PR DESCRIPTION
Follow-up to #44 (merged). Aligns the Telegram handoff wording with the frontend pivot (filter.fyi#29) away from the word **"AI"** — which ages like "internet company" — toward a tool-agnostic **"try this"**.

- `formatting.py`: the user-facing Telegram brief header now reads `<label> — try this`; the hint drops "do this with your AI" and just names tools (`paste into ChatGPT, Claude, Cursor, Codex…`).
- `handlers.py` / `agent_brief.py`: docstrings/comments updated to match.

No behaviour change. `make test` → 213 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)