### PR TITLE
feat(analysis): variable 0–5 suggestions[] (replaces quick_win/bigger_play)

### DIFF
--- a/bot/agent_brief.py
+++ b/bot/agent_brief.py
@@ -26,13 +26,6 @@ from __future__ import annotations
 SUMMARY_EXCERPT_CHARS = 1500
 PROFILE_CHARS = 600
 
-# Tiers we generate a brief for, in display order, with the label/why shown to
-# the user. `key` is the analysis field holding the action text; the third entry
-# is the field whose value becomes the action's "first move" (None = no step).
-_ACTION_TIERS = (
-    ("quick_win", "⚡ Quick win", "first_step"),
-    ("bigger_play", "🚀 Bigger play", None),
-)
 
 
 def _clip_sentence(text: str, limit: int) -> str:
@@ -126,22 +119,25 @@ def build_actions(
     source_url: str = "",
     summary_excerpt: str = "",
 ) -> list[dict]:
-    """Build the `actions` list (one entry per tier that has action text).
+    """Build the `actions` list — one entry per suggestion (0–5).
 
-    Each entry: {kind, label, text, brief, brief_link}. `brief` is the full
-    copy-paste version; `brief_link` is the concise version for "open in …" deep
-    links. Pure templating — no extra LLM calls.
+    Each entry: {index, title, detail, effort, brief, brief_link}. `brief` is the
+    full copy-paste version; `brief_link` is the concise version for "open in …"
+    deep links. Pure templating — no extra LLM calls. Returns [] when the
+    analysis has no suggestions (content with no follow-up worth the time).
     """
     grounded_in = (analysis.get("grounded_in") or "").strip()
     actions: list[dict] = []
-    for key, label, first_step_key in _ACTION_TIERS:
-        text = (analysis.get(key) or "").strip()
-        if not text:
+    for i, s in enumerate(analysis.get("suggestions") or []):
+        if not isinstance(s, dict):
             continue
-        first_step = (analysis.get(first_step_key) or "").strip() if first_step_key else ""
+        title = (s.get("title") or "").strip()
+        detail = (s.get("detail") or "").strip()
+        if not (title or detail):
+            continue
         kw = dict(
-            action=text,
-            first_step=first_step,
+            action=detail or title,
+            first_step=(s.get("first_step") or "").strip(),
             grounded_in=grounded_in,
             profile=profile,
             source_title=source_title,
@@ -149,9 +145,10 @@ def build_actions(
             summary_excerpt=summary_excerpt,
         )
         actions.append({
-            "kind": key,
-            "label": label,
-            "text": text,
+            "index": i,
+            "title": title or "Try this",
+            "detail": detail,
+            "effort": (s.get("effort") or "").strip(),
             "brief": build_agent_brief(**kw, variant="full"),
             "brief_link": build_agent_brief(**kw, variant="link"),
         })

--- a/bot/analyzer.py
+++ b/bot/analyzer.py
@@ -149,21 +149,26 @@ def _get_client():
     return _client
 
 
+# Scalar (string) analysis fields. The actionable follow-ups live in a separate
+# `suggestions` array (0–5 items) handled alongside these — see SUGGESTION_FIELDS.
 ANALYSIS_FIELDS = (
     "main_idea",
     "why_it_matters",
     "grounded_in",
     "category",
-    "quick_win",
-    "first_step",
-    "bigger_play",
     "time_required",
     "verdict",
 )
 
-# Older stored items used a single `suggested_experiment`. Kept as a constant so
-# renderers can fall back to it; new analyses populate quick_win + bigger_play.
+# Each suggestion is a self-contained next step. 0–5 per analysis; an empty list
+# is valid and expected when the content has no follow-up worth the reader's time.
+SUGGESTION_FIELDS = ("title", "detail", "first_step", "effort")
+MAX_SUGGESTIONS = 5
+
+# Legacy fields from before the suggestions[] migration. Kept so _normalize can
+# synthesize suggestions from older cached/stored analyses for uniform rendering.
 LEGACY_EXPERIMENT_FIELD = "suggested_experiment"
+_LEGACY_ACTION_FIELDS = ("quick_win", "bigger_play", "first_step", "suggested_experiment")
 
 VERDICTS = ("watch", "skim", "skip")
 
@@ -191,31 +196,43 @@ _TOOL_SCHEMA = {
             "type": "string",
             "description": "Short topic tag (kebab-case), e.g. 'ai-engineering', 'productivity', 'crypto-trading'.",
         },
-        "quick_win": {
-            "type": "string",
+        "suggestions": {
+            "type": "array",
+            "maxItems": MAX_SUGGESTIONS,
             "description": (
-                "A concrete, scoped action this person can finish in 30–90 minutes "
-                "THIS WEEKEND — low activation energy, no setup marathon. Specific to "
-                "their situation, not generic advice. Phrase it as an imperative "
-                "instruction ('Add X to your Y…'), not a suggestion to consider."
+                "0 to 5 concrete next steps the reader could take, ordered best-first "
+                "and varied in ambition (a 30-minute quick win through a multi-week "
+                "project). Each must be specific to this person and genuinely worth "
+                "their time. QUALITY OVER QUANTITY: return an EMPTY array if the "
+                "content is purely informational/news with no follow-up worth doing — "
+                "never invent busywork. We always respect the reader's time."
             ),
-        },
-        "first_step": {
-            "type": "string",
-            "description": (
-                "The single most concrete first move for the quick win — a specific, "
-                "do-able action (e.g. the exact command to run, the file or page to "
-                "open, the search to make, or the first thing to write). Imperative, "
-                "no preamble, and no meta-advice about using AI/assistants."
-            ),
-        },
-        "bigger_play": {
-            "type": "string",
-            "description": (
-                "A more ambitious multi-session/multi-week project for when they're "
-                "ready to commit — the deeper arc that builds real capability. Make "
-                "the difference from the quick win clear."
-            ),
+            "items": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string",
+                        "description": "A 3–6 word imperative label, e.g. 'Add a reranker'.",
+                    },
+                    "detail": {
+                        "type": "string",
+                        "description": "One sentence: what to do and why it pays off, specific to this person.",
+                    },
+                    "first_step": {
+                        "type": "string",
+                        "description": (
+                            "The single most concrete first move — the exact command to run, "
+                            "file/page to open, or first thing to write. Imperative, no preamble, "
+                            "no meta-advice about using AI/assistants."
+                        ),
+                    },
+                    "effort": {
+                        "type": "string",
+                        "description": "Rough commitment, e.g. '~30 min', '~2 hrs', 'a weekend', 'multi-week'.",
+                    },
+                },
+                "required": list(SUGGESTION_FIELDS),
+            },
         },
         "time_required": {
             "type": "string",
@@ -227,7 +244,7 @@ _TOOL_SCHEMA = {
             "description": "How worth the user's time: 'watch' (engage fully), 'skim' (worth a quick look), 'skip' (not for them).",
         },
     },
-    "required": list(ANALYSIS_FIELDS),
+    "required": list(ANALYSIS_FIELDS) + ["suggestions"],
 }
 
 _ANTHROPIC_TOOL = {
@@ -254,22 +271,22 @@ _PROMPT = """You are my personal AI research analyst.
 {profile_block}
 Analyze the following content and produce a structured analysis covering the required fields. Be concrete and specific to this person — `why_it_matters` should speak to their situation, not give generic advice.
 
-The actions are the point of this analysis — make them the strongest part:
-- `grounded_in`: name the one specific claim/result/quote/section in this content the actions build on, so they're traceable to the source.
-- `quick_win`: an imperative action they can finish in 30–90 minutes this weekend (low activation energy).
-- `first_step`: the single most concrete first move for the quick win — a specific, do-able action (a command, a file/page to open, a thing to write), not meta-advice about using AI.
-- `bigger_play`: the more ambitious multi-week arc for when they're ready to commit.
-Make the difference between quick_win and bigger_play obvious; don't just restate one as the other. Every action must be concrete and specific to this person — never generic advice.
+The suggestions are the point of this analysis — make them the strongest part:
+- `grounded_in`: name the one specific claim/result/quote/section in this content the suggestions build on, so they're traceable to the source.
+- `suggestions`: 0 to 5 concrete next steps, ordered best-first, varied in ambition (a 30-minute quick win through a multi-week project). Each has a short `title`, a one-sentence `detail`, a concrete `first_step`, and an `effort` estimate. Every one must be specific to this person and genuinely worth their time — never generic advice.
+  QUALITY OVER QUANTITY. Do not pad to hit a number. If the content is purely informational or news with no follow-up genuinely worth the reader's time, return an EMPTY `suggestions` array — we always respect the reader's time.
 
 CONTENT:
 {text}"""
 
 _OPENAI_JSON_SUFFIX = (
-    "\n\nRespond with a single JSON object containing exactly these keys: "
+    "\n\nRespond with a single JSON object containing these keys: "
     + ", ".join(ANALYSIS_FIELDS)
-    + ". 'verdict' must be one of: "
+    + ", suggestions. 'verdict' must be one of: "
     + ", ".join(VERDICTS)
-    + "."
+    + ". 'suggestions' is an array of 0 to 5 objects, each with: "
+    + ", ".join(SUGGESTION_FIELDS)
+    + " (return [] if there's no follow-up worth the reader's time)."
 )
 
 
@@ -281,12 +298,54 @@ def _load_profile(user_id: int | None) -> str:
 
 
 def _normalize(raw: dict) -> dict:
-    """Coerce LLM output into our exact schema (string fields, verdict in allowed set)."""
+    """Coerce LLM output into our schema: scalar string fields + a suggestions list.
+
+    Also upgrades legacy analyses (cached or stored before the suggestions[]
+    migration) by synthesizing suggestions from their quick_win/bigger_play
+    fields, so every downstream renderer can rely on `suggestions`.
+    """
     out = {k: str(raw.get(k, "")).strip() for k in ANALYSIS_FIELDS}
     if out["verdict"].lower() not in VERDICTS:
         out["verdict"] = "skim"
     else:
         out["verdict"] = out["verdict"].lower()
+    out["suggestions"] = _normalize_suggestions(raw)
+    return out
+
+
+def _normalize_suggestions(raw: dict) -> list[dict]:
+    raw_list = raw.get("suggestions")
+    if isinstance(raw_list, list):
+        items: list[dict] = []
+        for s in raw_list[:MAX_SUGGESTIONS]:
+            if not isinstance(s, dict):
+                continue
+            item = {k: str(s.get(k, "")).strip() for k in SUGGESTION_FIELDS}
+            if item["title"] or item["detail"]:  # drop empty rows
+                items.append(item)
+        return items
+    return _legacy_suggestions(raw)
+
+
+def _legacy_suggestions(raw: dict) -> list[dict]:
+    """Build suggestions[] from the old quick_win/bigger_play/suggested_experiment
+    fields, so analyses produced before the migration still render as boxes."""
+    out: list[dict] = []
+    quick_win = str(raw.get("quick_win", "")).strip()
+    if quick_win:
+        out.append({
+            "title": "Quick win",
+            "detail": quick_win,
+            "first_step": str(raw.get("first_step", "")).strip(),
+            "effort": "a weekend",
+        })
+    bigger_play = str(raw.get("bigger_play", "")).strip()
+    if bigger_play:
+        out.append({"title": "Bigger play", "detail": bigger_play, "first_step": "", "effort": "multi-week"})
+    if not out:
+        legacy = str(raw.get(LEGACY_EXPERIMENT_FIELD, "")).strip()
+        if legacy:
+            out.append({"title": "Try this", "detail": legacy, "first_step": "", "effort": ""})
     return out
 
 
@@ -427,7 +486,7 @@ def analyze(text: str, user_id: int | None = None, *, ctx: UsageContext | None =
         if _PROVIDER == "anthropic":
             resp = client.messages.create(
                 model=model,
-                max_tokens=1024,
+                max_tokens=2048,  # room for up to 5 suggestions + scalar fields
                 tools=[_ANTHROPIC_TOOL],
                 tool_choice={"type": "tool", "name": "record_analysis"},
                 messages=[{"role": "user", "content": prompt}],
@@ -736,4 +795,16 @@ def to_plain_text(analysis: dict) -> str:
         if not value:
             continue
         lines.append(f"{_LEGACY_FIELD_LABELS[key]}: {value}")
+    suggestions = analysis.get("suggestions") or []
+    if suggestions:
+        parts = ["Suggestions:"]
+        for s in suggestions:
+            title = (s.get("title") or "").strip()
+            detail = (s.get("detail") or "").strip()
+            effort = (s.get("effort") or "").strip()
+            parts.append(f"- {title}" + (f" ({effort})" if effort else "") + (f": {detail}" if detail else ""))
+            first_step = (s.get("first_step") or "").strip()
+            if first_step:
+                parts.append(f"  First step: {first_step}")
+        lines.append("\n".join(parts))
     return "\n\n".join(lines)

--- a/bot/formatting.py
+++ b/bot/formatting.py
@@ -36,12 +36,14 @@ def format_agent_brief(action: dict) -> str:
     The brief sits in a <pre> block so Telegram offers tap-to-copy — the user
     pastes it straight into whatever assistant they use (ChatGPT, Claude, …).
     """
-    label = (action.get("label") or "Action").strip()
+    title = (action.get("title") or action.get("label") or "Action").strip()
+    effort = (action.get("effort") or "").strip()
     brief = (action.get("brief") or "").strip()
     if not brief:
         return ""
+    head = html.escape(title) + (f" · {html.escape(effort)}" if effort else "")
     return (
-        f"📋 <b>{html.escape(label)} — try this</b>\n"
+        f"📋 <b>{head} — try this</b>\n"
         f"<i>tap to copy, then paste into ChatGPT, Claude, Cursor, Codex…</i>\n"
         f"<pre>{html.escape(brief)}</pre>"
     )
@@ -73,6 +75,20 @@ def _format_dict(analysis: dict) -> str:
         label = _FIELD_LABELS.get(key, key)
         prefix = f"{emoji} " if emoji else ""
         parts.append(f"{prefix}<b>{html.escape(label)}</b>\n{html.escape(value)}")
+
+    suggestions = analysis.get("suggestions")
+    if isinstance(suggestions, list) and suggestions:
+        block = ["🎯 <b>Suggestions</b>"]
+        for s in suggestions:
+            title = html.escape((s.get("title") or "").strip())
+            detail = html.escape((s.get("detail") or "").strip())
+            effort = html.escape((s.get("effort") or "").strip())
+            head = f"• <b>{title}</b>" + (f" — <i>{effort}</i>" if effort else "")
+            block.append(head + (f"\n{detail}" if detail else ""))
+        parts.append("\n".join(block))
+    elif isinstance(suggestions, list):
+        # Explicitly no follow-up — we value the reader's time, so say so.
+        parts.append("🎯 <b>No action needed</b>\nNothing here is worth a special follow-up — this one's just to stay informed.")
     return "\n\n".join(parts)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,9 +68,20 @@ def client(monkeypatch):
             "why_it_matters": "Practical AI pattern.",
             "grounded_in": "They show a 12-point eval lift from reranking retrieved chunks.",
             "category": "ai-engineering",
-            "quick_win": "Wire up a 20-doc RAG demo this afternoon.",
-            "first_step": "Create rag_demo.py and load 20 markdown files into a vector store.",
-            "bigger_play": "Build an evaluated RAG pipeline over your own corpus.",
+            "suggestions": [
+                {
+                    "title": "Wire up a RAG demo",
+                    "detail": "Stand up a 20-doc retrieval demo this afternoon to feel the pattern.",
+                    "first_step": "Create rag_demo.py and load 20 markdown files into a vector store.",
+                    "effort": "~2 hrs",
+                },
+                {
+                    "title": "Add a reranker",
+                    "detail": "Wrap the retriever with a cross-encoder reranker and measure the lift.",
+                    "first_step": "pip install sentence-transformers and rerank the top 50 hits.",
+                    "effort": "a weekend",
+                },
+            ],
             "time_required": "10 min read",
             "verdict": "watch",
         }

--- a/tests/test_agent_brief.py
+++ b/tests/test_agent_brief.py
@@ -15,29 +15,45 @@ _ANALYSIS = {
     "why_it_matters": "Practical AI pattern.",
     "grounded_in": "They show a 12-point eval lift from reranking retrieved chunks.",
     "category": "ai-engineering",
-    "quick_win": "Add a reranker to your existing RAG demo.",
-    "first_step": "Open rag_demo.py and wrap the retriever call with a reranker.",
-    "bigger_play": "Build an evaluated RAG pipeline over your own corpus.",
+    "suggestions": [
+        {
+            "title": "Add a reranker",
+            "detail": "Add a reranker to your existing RAG demo.",
+            "first_step": "Open rag_demo.py and wrap the retriever call with a reranker.",
+            "effort": "~2 hrs",
+        },
+        {
+            "title": "Build an eval harness",
+            "detail": "Build an evaluated RAG pipeline over your own corpus.",
+            "first_step": "Collect 50 query/answer pairs into eval.jsonl.",
+            "effort": "multi-week",
+        },
+    ],
     "time_required": "10 min read",
     "verdict": "watch",
 }
 
 
 class TestBuildActions:
-    def test_builds_one_action_per_tier_with_both_briefs(self):
+    def test_builds_one_action_per_suggestion_with_both_briefs(self):
         actions = agent_brief.build_actions(_ANALYSIS)
-        assert [a["kind"] for a in actions] == ["quick_win", "bigger_play"]
-        assert all(a["text"] for a in actions)
+        assert [a["index"] for a in actions] == [0, 1]
+        assert [a["title"] for a in actions] == ["Add a reranker", "Build an eval harness"]
+        assert [a["effort"] for a in actions] == ["~2 hrs", "multi-week"]
         assert all(a["brief"] for a in actions)
         assert all(a["brief_link"] for a in actions)
 
-    def test_skips_tiers_without_text(self):
-        analysis = dict(_ANALYSIS, bigger_play="")
+    def test_skips_empty_suggestion_rows(self):
+        analysis = dict(_ANALYSIS, suggestions=[
+            {"title": "", "detail": "", "first_step": "", "effort": ""},
+            _ANALYSIS["suggestions"][0],
+        ])
         actions = agent_brief.build_actions(analysis)
-        assert [a["kind"] for a in actions] == ["quick_win"]
+        assert [a["title"] for a in actions] == ["Add a reranker"]
 
-    def test_empty_analysis_yields_no_actions(self):
+    def test_no_suggestions_yields_no_actions(self):
         assert agent_brief.build_actions({}) == []
+        assert agent_brief.build_actions({"suggestions": []}) == []
 
 
 class TestBuildAgentBrief:

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -33,44 +33,58 @@ class TestSummarizeContent:
         assert small < large
 
 
-class TestNormalizeTwoModeExperiment:
-    def test_keeps_quick_win_and_bigger_play(self):
+class TestNormalizeSuggestions:
+    def test_keeps_and_clamps_suggestions(self):
+        from bot import analyzer
+
+        raw_suggestions = [
+            {"title": f"S{i}", "detail": f"do {i}", "first_step": f"step {i}", "effort": "~1 hr"}
+            for i in range(8)  # over the cap
+        ]
+        out = analyzer._normalize({
+            "main_idea": "x", "why_it_matters": "y", "grounded_in": "g", "category": "c",
+            "suggestions": raw_suggestions, "time_required": "10 min", "verdict": "watch",
+        })
+        assert len(out["suggestions"]) == analyzer.MAX_SUGGESTIONS  # clamped to 5
+        assert out["suggestions"][0] == {"title": "S0", "detail": "do 0", "first_step": "step 0", "effort": "~1 hr"}
+        assert set(out["suggestions"][0].keys()) == set(analyzer.SUGGESTION_FIELDS)
+
+    def test_empty_suggestions_is_valid(self):
+        from bot import analyzer
+
+        out = analyzer._normalize({"verdict": "skip", "suggestions": []})
+        assert out["suggestions"] == []  # 0 actions is a legitimate result
+
+    def test_drops_empty_suggestion_rows(self):
+        from bot import analyzer
+
+        out = analyzer._normalize({"verdict": "watch", "suggestions": [
+            {"title": "", "detail": "", "first_step": "x", "effort": "y"},  # dropped
+            {"title": "Keep", "detail": "real", "first_step": "", "effort": ""},
+        ]})
+        assert [s["title"] for s in out["suggestions"]] == ["Keep"]
+
+    def test_legacy_quick_win_synthesized_into_suggestions(self):
         from bot import analyzer
 
         out = analyzer._normalize({
-            "main_idea": "x", "why_it_matters": "y", "category": "c",
-            "quick_win": "do this in an hour", "bigger_play": "the multi-week arc",
-            "time_required": "10 min", "verdict": "watch",
+            "main_idea": "x", "verdict": "watch",
+            "quick_win": "do this in an hour", "first_step": "open file",
+            "bigger_play": "the multi-week arc",
         })
-        assert out["quick_win"] == "do this in an hour"
-        assert out["bigger_play"] == "the multi-week arc"
-        assert "suggested_experiment" not in out  # old field dropped from new schema
-        assert set(out.keys()) == set(analyzer.ANALYSIS_FIELDS)
-
-    def test_missing_fields_default_to_empty(self):
-        from bot import analyzer
-
-        out = analyzer._normalize({"verdict": "skip"})
-        assert out["quick_win"] == ""
-        assert out["bigger_play"] == ""
-        assert out["verdict"] == "skip"
+        titles = [s["title"] for s in out["suggestions"]]
+        assert titles == ["Quick win", "Bigger play"]
+        assert out["suggestions"][0]["detail"] == "do this in an hour"
+        assert out["suggestions"][0]["first_step"] == "open file"
 
 
 class TestActionSchema:
-    def test_grounding_and_first_step_in_schema(self):
+    def test_scalar_fields_and_suggestions_in_schema(self):
         from bot import analyzer
 
-        for field in ("grounded_in", "first_step"):
-            assert field in analyzer.ANALYSIS_FIELDS
-            assert field in analyzer._TOOL_SCHEMA["properties"]
-            assert field in analyzer._TOOL_SCHEMA["required"]
-
-    def test_normalize_round_trips_new_fields(self):
-        from bot import analyzer
-
-        out = analyzer._normalize({
-            "grounded_in": "the key claim", "first_step": "open the file",
-            "quick_win": "do x", "verdict": "watch",
-        })
-        assert out["grounded_in"] == "the key claim"
-        assert out["first_step"] == "open the file"
+        assert "grounded_in" in analyzer.ANALYSIS_FIELDS
+        assert "quick_win" not in analyzer.ANALYSIS_FIELDS  # moved into suggestions[]
+        assert "suggestions" in analyzer._TOOL_SCHEMA["properties"]
+        assert "suggestions" in analyzer._TOOL_SCHEMA["required"]
+        item = analyzer._TOOL_SCHEMA["properties"]["suggestions"]["items"]
+        assert set(item["required"]) == set(analyzer.SUGGESTION_FIELDS)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -90,10 +90,10 @@ class TestLibraryAdd:
         assert body["verdict"] == "watch"
         assert body["id"] is not None
         assert "main_idea" in body["analysis"]
-        # Agent-handoff actions: one per tier, each with a paste-able brief.
-        kinds = [a["kind"] for a in body["actions"]]
-        assert kinds == ["quick_win", "bigger_play"]
-        assert all(a["brief"] for a in body["actions"])
+        # Agent-handoff actions: one per suggestion, each with a paste-able brief.
+        actions = body["actions"]
+        assert [a["index"] for a in actions] == [0, 1]
+        assert all(a["title"] and a["brief"] and a["brief_link"] for a in actions)
 
     def test_rejects_invalid_url(self, client, auth_headers):
         uid = self._make_user(client, auth_headers)


### PR DESCRIPTION
Replaces the fixed two-tier **quick_win/bigger_play** with a variable **`suggestions`** array (0–5), each `{title, detail, first_step, effort}`. The model decides how many genuinely useful next steps exist and returns an **empty array** for content with no follow-up worth the reader's time (pure news, etc.) — we never pad. This is the backend for the new 0–5 suggestion-box UI.

## Changes
- **analyzer**: `ANALYSIS_FIELDS` is now scalar-only; new `SUGGESTION_FIELDS` + a `maxItems: 5` array in the tool schema. Prompt rewritten — *"quality over quantity; return [] if no follow-up is worth the reader's time."* `max_tokens` 1024→2048 (room for 5 suggestions).
- **`_normalize`**: clamps to 5, drops empty rows, and **upgrades legacy analyses** (cached/stored `quick_win`/`bigger_play`/`suggested_experiment`) into `suggestions[]`, so every downstream renderer relies on one shape.
- **`build_actions`**: one action per suggestion → `{index, title, detail, effort, brief, brief_link}`.
- **`to_plain_text` + Telegram `format_analysis`**: render the suggestions list, with an explicit **"No action needed — just stay informed"** note when empty (we value the reader's time).
- Prompt + schema change **auto-invalidates the analyze cache**.

## Tests
Reworked: normalize clamp/empty/legacy-synthesis, `build_actions` over suggestions, `/library/add` actions shape. `make test` → **216 passed**. Telegram render eyeballed for both the with-suggestions and zero-suggestions cases.

## Pairs with
The frontend PR (suggestion-box UI + interaction signals) — coming next. Frontend degrades gracefully via legacy synthesis if deployed out of order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)