### PR TITLE
fix(telegram): suggestion briefs on demand via "try it" buttons (#49)

### DIFF
--- a/bot/application.py
+++ b/bot/application.py
@@ -2,7 +2,14 @@ import os
 import logging
 
 from telegram import Update
-from telegram.ext import Application, CommandHandler, MessageHandler, TypeHandler, filters
+from telegram.ext import (
+    Application,
+    CallbackQueryHandler,
+    CommandHandler,
+    MessageHandler,
+    TypeHandler,
+    filters,
+)
 
 from bot.commands import (
     cmd_delete,
@@ -21,6 +28,7 @@ from bot.handlers import (
     handle_text,
     handle_video,
     handle_voice,
+    on_try_callback,
 )
 
 logger = logging.getLogger(__name__)
@@ -71,6 +79,9 @@ def build_application(token: str) -> Application:
     app.add_handler(CommandHandler("search", cmd_search))
     app.add_handler(CommandHandler("delete", cmd_delete))
     app.add_handler(CommandHandler("profile", cmd_profile))
+
+    # "try it" suggestion buttons → send that suggestion's brief on demand
+    app.add_handler(CallbackQueryHandler(on_try_callback, pattern=r"^try:"))
 
     # Content ingestion
     app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handle_text))

--- a/bot/handlers.py
+++ b/bot/handlers.py
@@ -3,13 +3,13 @@ import logging
 import tempfile
 from pathlib import Path
 
-from telegram import Update
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
 from telegram.ext import ContextTypes
 
 from bot.agent_brief import build_actions
-from bot.analyzer import UsageContext, analyze, analyze_image, to_json_str
+from bot.analyzer import UsageContext, analyze, analyze_image, parse_stored, to_json_str
 from bot.config import MAX_CONTENT_CHARS
-from bot.db import get_or_create_user_by_telegram, get_user_profile, save_item
+from bot.db import get_item, get_or_create_user_by_telegram, get_user_profile, save_item
 from bot.fetch_errors import user_message as fetch_error_message
 from bot.formatting import format_agent_brief, format_analysis
 from bot.pipeline import PipelineError, analyze_url
@@ -19,31 +19,59 @@ from bot.transcriber import transcribe
 logger = logging.getLogger(__name__)
 
 
-async def _send_agent_briefs(
-    message,
-    analysis: dict,
-    user_id: int,
-    *,
-    source_text: str = "",
-    source_title: str = "",
-    source_url: str = "",
-) -> None:
-    """Send a copyable 'try this' brief per action, after the analysis.
+def _suggestions_keyboard(analysis: dict, item_id: int | None) -> InlineKeyboardMarkup | None:
+    """One '🔧 <title>' button per suggestion. Tapping sends that suggestion's
+    full copy-to-AI brief on demand — keeps the analysis reply short instead of
+    dumping every brief inline (issue #49). Needs a saved item_id to reference."""
+    suggestions = analysis.get("suggestions") or []
+    if not item_id or not suggestions:
+        return None
+    rows = []
+    for i, s in enumerate(suggestions):
+        title = (s.get("title") or f"Suggestion {i + 1}").strip()
+        effort = (s.get("effort") or "").strip()
+        label = f"🔧 {title}" + (f" · {effort}" if effort else "")
+        rows.append([InlineKeyboardButton(label[:60], callback_data=f"try:{item_id}:{i}")])
+    return InlineKeyboardMarkup(rows)
 
-    Sent as separate messages so each stays within Telegram's length limit and
-    each <pre> block is independently tap-to-copy.
-    """
+
+async def _reply_analysis(message, analysis: dict, item_id: int | None) -> None:
+    """Send the analysis with a 'try it' button per suggestion (brief on demand)."""
+    await message.reply_text(
+        format_analysis(analysis),
+        parse_mode="HTML",
+        reply_markup=_suggestions_keyboard(analysis, item_id),
+    )
+
+
+async def on_try_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle a 'try it' button tap: rebuild and send the one suggestion's brief."""
+    query = update.callback_query
+    if query is None:
+        return
+    await query.answer()
+    try:
+        _, item_id_s, index_s = (query.data or "").split(":")
+        item_id, index = int(item_id_s), int(index_s)
+    except ValueError:
+        return
+    user_id = get_or_create_user_by_telegram(update.effective_user.id)
+    row = get_item(item_id, user_id)
+    if not row:
+        await query.answer("That suggestion isn't available anymore.", show_alert=True)
+        return
+    analysis = parse_stored(row["analysis"]) or {}
     actions = build_actions(
         analysis,
         profile=get_user_profile(user_id) or "",
-        source_title=source_title,
-        source_url=source_url,
-        summary_excerpt=source_text,
+        source_url=row["source"] or "",
+        summary_excerpt=row["content"] or "",
     )
-    for action in actions:
-        block = format_agent_brief(action)
-        if block:
-            await message.reply_text(block, parse_mode="HTML")
+    if not (0 <= index < len(actions)):
+        return
+    block = format_agent_brief(actions[index])
+    if block:
+        await query.message.reply_text(block, parse_mode="HTML")
 
 
 async def _analyze_and_reply(
@@ -62,7 +90,7 @@ async def _analyze_and_reply(
         logger.exception("Analysis failed")
         await update.message.reply_text(f"Analysis failed: {e}\n\nThe content was not saved.")
         return
-    save_item(
+    item_id = save_item(
         user_id=user_id,
         source_type=source_type,
         source=source,
@@ -74,15 +102,7 @@ async def _analyze_and_reply(
         user_note=user_note,
         file_path=file_path,
     )
-    formatted = format_analysis(analysis)
-    await update.message.reply_text(formatted, parse_mode="HTML")
-    await _send_agent_briefs(
-        update.message,
-        analysis,
-        user_id,
-        source_text=store_content if store_content is not None else text,
-        source_title=source,
-    )
+    await _reply_analysis(update.message, analysis, item_id)
 
 
 # --- Text & URLs ---
@@ -120,15 +140,7 @@ async def handle_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
             except PipelineError as e:
                 await message.reply_text(fetch_error_message(e.fetched.get("reason"), url))
                 continue
-            await message.reply_text(format_analysis(result.analysis), parse_mode="HTML")
-            await _send_agent_briefs(
-                message,
-                result.analysis,
-                user_id,
-                source_text=result.summary,
-                source_title=result.title,
-                source_url=url,
-            )
+            await _reply_analysis(message, result.analysis, result.saved_id)
     else:
         await message.reply_text("Analyzing...")
         await _analyze_and_reply(update, user_id, text, source_type="note")

--- a/tests/test_telegram_suggestions.py
+++ b/tests/test_telegram_suggestions.py
@@ -1,0 +1,42 @@
+"""Telegram '🔧 try it' suggestion keyboard (issue #49).
+
+Instead of dumping every suggestion's full copy-to-AI brief inline, the analysis
+reply carries one button per suggestion; the brief is sent on demand when tapped.
+"""
+from __future__ import annotations
+
+
+_ANALYSIS = {
+    "verdict": "watch",
+    "suggestions": [
+        {"title": "Add a reranker", "detail": "…", "first_step": "…", "effort": "~2 hrs"},
+        {"title": "Build an eval harness", "detail": "…", "first_step": "…", "effort": "multi-week"},
+    ],
+}
+
+
+class TestSuggestionsKeyboard:
+    def test_one_button_per_suggestion_with_callback_data(self):
+        from bot.handlers import _suggestions_keyboard
+
+        kb = _suggestions_keyboard(_ANALYSIS, item_id=42)
+        rows = kb.inline_keyboard
+        assert len(rows) == 2
+        assert [b.callback_data for row in rows for b in row] == ["try:42:0", "try:42:1"]
+        first = rows[0][0]
+        assert "Add a reranker" in first.text
+        assert "~2 hrs" in first.text  # effort shown on the button
+
+    def test_none_without_item_id_or_suggestions(self):
+        from bot.handlers import _suggestions_keyboard
+
+        assert _suggestions_keyboard(_ANALYSIS, item_id=None) is None
+        assert _suggestions_keyboard({"suggestions": []}, item_id=1) is None
+        assert _suggestions_keyboard({}, item_id=1) is None
+
+    def test_button_label_is_truncated(self):
+        from bot.handlers import _suggestions_keyboard
+
+        long = {"suggestions": [{"title": "x" * 200, "effort": ""}]}
+        kb = _suggestions_keyboard(long, item_id=7)
+        assert len(kb.inline_keyboard[0][0].text) <= 60


### PR DESCRIPTION
Fixes #49.

After the 0–5 suggestions change, the Telegram reply dumped the **full copy-to-AI `<pre>` block for every suggestion** — enormous messages. Now the analysis reply stays short and the briefs come **on demand**.

## What changed
- The analysis reply shows the **verdict + suggestion one-liners** (unchanged `format_analysis`) plus an **inline keyboard: one `🔧 <title> · <effort>` button per suggestion**.
- Tapping a button sends **just that suggestion's brief** (the tap-to-copy `<pre>` block) as a reply. `callback_data` is `try:<item_id>:<index>`; `on_try_callback` rebuilds the brief from the saved item (analysis + stored summary + url) — no state to keep.
- Removed the old per-suggestion auto-send (`_send_agent_briefs`).
- Registered `CallbackQueryHandler(pattern=^try:)`. The webhook already routes updates through `process_update`, so callbacks work with no other wiring; the allowlist still applies.

## Verification
- `make test` → **219 passed** (new: keyboard builder — button count, `callback_data`, effort label, 60-char truncation, None when no item/suggestions).
- Callback happy-path checked by hand: tap → brief contains the suggestion + the new "What I want to do" wording + the stored summary + the URL; out-of-range index is a safe no-op.

No schema/deploy changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)