### PR TITLE
feat: tiered video transcription caps via Groq hosted Whisper

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ TELEGRAM_TOKEN=your-telegram-bot-token
 ANTHROPIC_API_KEY=your-anthropic-key
 OPENAI_API_KEY=your-openai-key
 
+# Optional -- hosted transcription for captionless videos (Groq
+# whisper-large-v3-turbo). Required to transcribe long videos (anon 30 min /
+# signed-in 2 h caps); without it the bot falls back to a local faster-whisper
+# CPU model that only keeps up with short clips.
+GROQ_API_KEY=your-groq-key
+
 # Optional -- set for production webhook mode
 WEBHOOK_URL=https://your-domain.com
 

--- a/README.md
+++ b/README.md
@@ -66,10 +66,11 @@ TELEGRAM_TOKEN=your-telegram-bot-token
 ANTHROPIC_API_KEY=your-anthropic-key
 OPENAI_API_KEY=your-openai-key
 
-# Optional -- hosted transcription for captionless videos (Groq
-# whisper-large-v3-turbo). Required to transcribe long videos (anon 30 min /
-# signed-in 2 h caps); without it the bot falls back to a local faster-whisper
-# CPU model that only keeps up with short clips.
+# Optional -- hosted transcription for captionless videos. Required to
+# transcribe long videos (anon 30 min / signed-in 2 h caps); without it the bot
+# falls back to a local faster-whisper CPU model that only keeps up with short
+# clips. Provider preference: GROQ_API_KEY (whisper-large-v3-turbo, ~$0.04/h)
+# first, else the OPENAI_API_KEY above is reused (whisper-1, ~$0.36/h).
 GROQ_API_KEY=your-groq-key
 
 # Optional -- set for production webhook mode

--- a/bot/api.py
+++ b/bot/api.py
@@ -27,7 +27,6 @@ from bot.pipeline import (
 )
 from bot.auth import require_token
 from bot.config import MAX_CONTENT_CHARS
-from bot.fetcher import WHISPER_MAX_DURATION_SYNC_S
 from bot.fetch_errors import user_message as fetch_error_message
 from bot.db import (
     FEEDBACK_SIGNALS,
@@ -162,7 +161,6 @@ async def submit_url(
             ctx=UsageContext(user_id=user_id),
             save_for_user_id=user_id,
             user_note=user_note,
-            max_whisper_duration=WHISPER_MAX_DURATION_SYNC_S,
         )
     except PipelineError as e:
         raise _pipeline_error_to_http(e, url)
@@ -313,11 +311,7 @@ async def try_url(req: TryRequest, _: None = Depends(_require_try_secret)):
         raise HTTPException(status_code=400, detail={"error": "invalid-url"})
 
     try:
-        result = await analyze_url(
-            url,
-            ctx=UsageContext(anon_id=req.anon_id),
-            max_whisper_duration=WHISPER_MAX_DURATION_SYNC_S,
-        )
+        result = await analyze_url(url, ctx=UsageContext(anon_id=req.anon_id))
     except PipelineError as e:
         raise _pipeline_error_to_http(e, url)
 
@@ -503,7 +497,6 @@ async def library_add(req: _LibraryAddRequest, _: None = Depends(_require_try_se
             ctx=UsageContext(user_id=req.user_id),
             save_for_user_id=req.user_id,
             user_note=req.user_note,
-            max_whisper_duration=WHISPER_MAX_DURATION_SYNC_S,
         )
     except PipelineError as e:
         raise _pipeline_error_to_http(e, url)

--- a/bot/api.py
+++ b/bot/api.py
@@ -27,6 +27,7 @@ from bot.pipeline import (
 )
 from bot.auth import require_token
 from bot.config import MAX_CONTENT_CHARS
+from bot.fetcher import WHISPER_MAX_DURATION_SYNC_S
 from bot.fetch_errors import user_message as fetch_error_message
 from bot.db import (
     FEEDBACK_SIGNALS,
@@ -161,6 +162,7 @@ async def submit_url(
             ctx=UsageContext(user_id=user_id),
             save_for_user_id=user_id,
             user_note=user_note,
+            max_whisper_duration=WHISPER_MAX_DURATION_SYNC_S,
         )
     except PipelineError as e:
         raise _pipeline_error_to_http(e, url)
@@ -311,7 +313,11 @@ async def try_url(req: TryRequest, _: None = Depends(_require_try_secret)):
         raise HTTPException(status_code=400, detail={"error": "invalid-url"})
 
     try:
-        result = await analyze_url(url, ctx=UsageContext(anon_id=req.anon_id))
+        result = await analyze_url(
+            url,
+            ctx=UsageContext(anon_id=req.anon_id),
+            max_whisper_duration=WHISPER_MAX_DURATION_SYNC_S,
+        )
     except PipelineError as e:
         raise _pipeline_error_to_http(e, url)
 
@@ -497,6 +503,7 @@ async def library_add(req: _LibraryAddRequest, _: None = Depends(_require_try_se
             ctx=UsageContext(user_id=req.user_id),
             save_for_user_id=req.user_id,
             user_note=req.user_note,
+            max_whisper_duration=WHISPER_MAX_DURATION_SYNC_S,
         )
     except PipelineError as e:
         raise _pipeline_error_to_http(e, url)

--- a/bot/fetch_errors.py
+++ b/bot/fetch_errors.py
@@ -31,8 +31,9 @@ _USER_MESSAGES: dict[str, str] = {
         "to analyse. Try sharing a video with captions enabled."
     ),
     VIDEO_TOO_LONG_FOR_WHISPER: (
-        "This video has no subtitles and is too long for automatic transcription. "
-        "Try a shorter video (under 3 minutes) or one with captions."
+        "This video has no subtitles and is too long for us to transcribe "
+        "automatically. Try a video with captions, or a shorter one. Signing in "
+        "raises the length limit."
     ),
     WHISPER_FAILED: (
         "Couldn't transcribe this video's audio. The source may be blocking "

--- a/bot/fetcher.py
+++ b/bot/fetcher.py
@@ -47,11 +47,22 @@ def _youtube_oembed_title(url: str) -> str | None:
         return None
 
 
-# Whisper fallback is only attempted for videos short enough that the
-# audio download + transcription has a real chance of completing within the
-# Worker's 25 s timeout on `/api/try` / `/api/library/add`. Long videos fall
-# back to title + uploader + description.
-_WHISPER_FALLBACK_MAX_DURATION_S = 180
+# Per-tier ceilings on how long a captionless video may be before we attempt
+# audio download + transcription (Groq, see bot.transcriber). Hosted
+# transcription is fast enough that the real cost is the audio download, so
+# these are policy/cost levers rather than compute limits.
+WHISPER_MAX_DURATION_ANON_S = 30 * 60        # 30 min — anonymous web tries
+WHISPER_MAX_DURATION_SIGNED_IN_S = 2 * 60 * 60  # 2 h — signed-in users
+# Synchronous HTTP endpoints (`/api/try`, `/api/library/add`) are bound by the
+# Worker's ~25 s timeout: even with fast hosted transcription, the audio
+# download for a long video blows that budget. They pass this lower cap
+# explicitly; the async job path and Telegram use the full per-tier cap.
+WHISPER_MAX_DURATION_SYNC_S = 8 * 60         # 8 min
+
+
+def whisper_cap_for(*, signed_in: bool) -> int:
+    """Default per-tier transcription duration ceiling (seconds)."""
+    return WHISPER_MAX_DURATION_SIGNED_IN_S if signed_in else WHISPER_MAX_DURATION_ANON_S
 
 
 def _lang_base(code: str) -> str:
@@ -89,7 +100,7 @@ def _select_transcript(transcripts: list):
     return english_manual or (manuals[0] if manuals else None) or generated
 
 
-def _youtube_transcript(url: str) -> dict:
+def _youtube_transcript(url: str, max_whisper_duration: int = WHISPER_MAX_DURATION_ANON_S) -> dict:
     from youtube_transcript_api import YouTubeTranscriptApi
 
     match = _YT_PATTERNS.search(url)
@@ -132,10 +143,10 @@ def _youtube_transcript(url: str) -> dict:
         return extract
 
     duration = extract.get("duration") or 0
-    if duration and duration <= _WHISPER_FALLBACK_MAX_DURATION_S:
+    if duration and duration <= max_whisper_duration:
         logger.info(
             f"YouTube {video_id}: no subtitles, trying audio + Whisper "
-            f"(duration {duration}s)"
+            f"(duration {duration}s, cap {max_whisper_duration}s)"
         )
         whisper = _yt_dlp_transcribe(url)
         if whisper.get("text"):
@@ -145,7 +156,7 @@ def _youtube_transcript(url: str) -> dict:
         logger.info(f"YouTube {video_id}: Whisper fallback also failed, returning description")
         # Description-only answer: still useful, but mark the limitation.
         extract["reason"] = fetch_errors.WHISPER_FAILED
-    elif duration > _WHISPER_FALLBACK_MAX_DURATION_S:
+    elif duration > max_whisper_duration:
         extract["reason"] = fetch_errors.VIDEO_TOO_LONG_FOR_WHISPER
     else:
         extract["reason"] = fetch_errors.NO_TRANSCRIPT
@@ -649,11 +660,20 @@ def _domain_matches(domain: str, *targets: str) -> bool:
     return any(domain == t or domain.endswith(f".{t}") for t in targets)
 
 
-async def fetch_url(url: str) -> dict:
+async def fetch_url(
+    url: str, *, max_whisper_duration: int = WHISPER_MAX_DURATION_ANON_S
+) -> dict:
     """Public entry point. Wraps `_fetch_url_uncached` with a per-URL cache so
     repeat submissions, retries, and concurrent fetches of the same URL don't
     each hit upstream. Failed fetches (empty `text`) are NOT cached so the
-    next attempt is fresh."""
+    next attempt is fresh.
+
+    `max_whisper_duration` is the captionless-video transcription ceiling for
+    this caller's tier (see `whisper_cap_for`). It only changes *whether* we
+    transcribe, never the transcript itself, so the cache stays keyed by URL —
+    except the one tier-dependent degraded outcome (`video_too_long_for_whisper`)
+    which we never cache, so a stricter tier can't poison a more generous one.
+    """
     from bot.db import get_cached_fetch, set_cached_fetch
 
     cached = get_cached_fetch(url)
@@ -661,9 +681,13 @@ async def fetch_url(url: str) -> dict:
         logger.info(f"url_cache hit for {url}")
         return cached
 
-    result = await _fetch_url_uncached(url)
+    result = await _fetch_url_uncached(url, max_whisper_duration=max_whisper_duration)
 
-    if (result.get("text") or "").strip():
+    cacheable = (
+        (result.get("text") or "").strip()
+        and result.get("reason") != fetch_errors.VIDEO_TOO_LONG_FOR_WHISPER
+    )
+    if cacheable:
         try:
             set_cached_fetch(url, result)
         except Exception as e:
@@ -804,7 +828,9 @@ async def _academic_fetch(url: str, doi: str) -> dict | None:
     return None
 
 
-async def _fetch_url_uncached(url: str) -> dict:
+async def _fetch_url_uncached(
+    url: str, *, max_whisper_duration: int = WHISPER_MAX_DURATION_ANON_S
+) -> dict:
     """The actual routing logic — keep this as the only place that knows the
     source-specific fetchers. `fetch_url` is the cache layer in front."""
     # SSRF guard: refuse anything that resolves to a non-public address before
@@ -820,7 +846,9 @@ async def _fetch_url_uncached(url: str) -> dict:
 
     if _domain_matches(domain, "youtube.com", "youtu.be"):
         loop = asyncio.get_running_loop()
-        return await loop.run_in_executor(None, _youtube_transcript, url)
+        return await loop.run_in_executor(
+            None, _youtube_transcript, url, max_whisper_duration
+        )
 
     if _domain_matches(domain, "streamyard.com"):
         return await _streamyard_fetch(url)
@@ -829,6 +857,11 @@ async def _fetch_url_uncached(url: str) -> dict:
         loop = asyncio.get_running_loop()
         result = await loop.run_in_executor(None, _yt_dlp_extract, url)
         if result["text"].strip():
+            return result
+        duration = result.get("duration") or 0
+        if duration and duration > max_whisper_duration:
+            logger.info(f"Vimeo {url}: {duration}s exceeds cap {max_whisper_duration}s")
+            result["reason"] = fetch_errors.VIDEO_TOO_LONG_FOR_WHISPER
             return result
         logger.info(f"No subtitles for {url}, falling back to Whisper transcription")
         return await loop.run_in_executor(None, _yt_dlp_transcribe, url)

--- a/bot/fetcher.py
+++ b/bot/fetcher.py
@@ -50,14 +50,11 @@ def _youtube_oembed_title(url: str) -> str | None:
 # Per-tier ceilings on how long a captionless video may be before we attempt
 # audio download + transcription (Groq, see bot.transcriber). Hosted
 # transcription is fast enough that the real cost is the audio download, so
-# these are policy/cost levers rather than compute limits.
+# these are policy/cost levers rather than compute limits. Every web request
+# runs through the async job path (`/api/job`), which has no Worker-side
+# analysis timeout, so both tiers use their full cap everywhere.
 WHISPER_MAX_DURATION_ANON_S = 30 * 60        # 30 min — anonymous web tries
 WHISPER_MAX_DURATION_SIGNED_IN_S = 2 * 60 * 60  # 2 h — signed-in users
-# Synchronous HTTP endpoints (`/api/try`, `/api/library/add`) are bound by the
-# Worker's ~25 s timeout: even with fast hosted transcription, the audio
-# download for a long video blows that budget. They pass this lower cap
-# explicitly; the async job path and Telegram use the full per-tier cap.
-WHISPER_MAX_DURATION_SYNC_S = 8 * 60         # 8 min
 
 
 def whisper_cap_for(*, signed_in: bool) -> int:

--- a/bot/pipeline.py
+++ b/bot/pipeline.py
@@ -41,7 +41,7 @@ from bot.analyzer import (
     to_json_str,
 )
 from bot.db import save_item
-from bot.fetcher import fetch_url
+from bot.fetcher import fetch_url, whisper_cap_for
 
 logger = logging.getLogger(__name__)
 
@@ -112,6 +112,7 @@ async def analyze_url(
     save_for_user_id: int | None = None,
     user_note: str = "",
     include_images: bool | None = None,
+    max_whisper_duration: int | None = None,
     on_step: Optional[Callable[[str], None]] = None,
 ) -> PipelineResult:
     """Run the full URL → analysis chain.
@@ -125,6 +126,10 @@ async def analyze_url(
     `include_images=None` (default) picks based on `source_type` — see
     `_INCLUDE_IMAGES_BY_DEFAULT`. Pass `True`/`False` to override.
 
+    `max_whisper_duration=None` (default) derives the captionless-video
+    transcription ceiling from the caller's tier (signed-in → 2 h, anon →
+    30 min). Time-bound sync endpoints pass a lower explicit cap.
+
     `on_step` is an optional sync callback invoked with stable labels
     ("fetching" | "describing-images" | "summarizing" | "analyzing") so
     callers like the async job runner can surface progress to the UI.
@@ -136,9 +141,12 @@ async def analyze_url(
             except Exception:
                 logger.exception("pipeline on_step callback raised; ignoring")
 
+    if max_whisper_duration is None:
+        max_whisper_duration = whisper_cap_for(signed_in=ctx.user_id is not None)
+
     _step("fetching")
     try:
-        fetched = await fetch_url(url)
+        fetched = await fetch_url(url, max_whisper_duration=max_whisper_duration)
     except Exception as e:
         logger.exception("pipeline: fetch_url crashed for %s", url)
         raise PipelineError(ERR_FETCH_FAILED, message=str(e))

--- a/bot/pipeline.py
+++ b/bot/pipeline.py
@@ -64,6 +64,14 @@ ERR_ANALYZE_FAILED = "analyze-failed"        # LLM call failed mid-chain
 
 _VIDEO_SOURCE_TYPES: frozenset[str] = frozenset({"youtube", "video"})
 
+# A degraded fetch (no transcript, too long for Whisper, etc.) flags itself
+# with `reason` but may still carry a thin fallback — e.g. a captionless video
+# with an empty description leaves just "Title\nBy: Channel" (~50 chars).
+# Below this, there's no real content to analyse, so we surface the `reason`
+# instead of fabricating an analysis from a title-only stub. Only applied when
+# `reason` is set, so successful (unflagged) fetches are never gated.
+_MIN_ANALYZABLE_CHARS = 200
+
 
 class PipelineError(Exception):
     """Raised for any failure inside `analyze_url`. Carries an `error_code`
@@ -137,8 +145,13 @@ async def analyze_url(
 
     text = (fetched.get("text") or "").strip()
     source_type = fetched.get("source_type") or "article"
+    reason = fetched.get("reason")
 
-    if not text:
+    # Bail before analysing when there's nothing usable: either no text at all,
+    # or a degraded fetch (`reason` set) whose fallback is just a title-only
+    # stub. Both surface the fetch `reason` to the caller rather than running
+    # the analyser on a thin snippet — see _MIN_ANALYZABLE_CHARS.
+    if not text or (reason and len(text) < _MIN_ANALYZABLE_CHARS):
         # Distinguish video-with-no-transcript from generic extraction
         # failure so callers can surface the right UX.
         code = ERR_NO_TRANSCRIPT if source_type in _VIDEO_SOURCE_TYPES else ERR_NO_TEXT

--- a/bot/pipeline.py
+++ b/bot/pipeline.py
@@ -128,7 +128,8 @@ async def analyze_url(
 
     `max_whisper_duration=None` (default) derives the captionless-video
     transcription ceiling from the caller's tier (signed-in → 2 h, anon →
-    30 min). Time-bound sync endpoints pass a lower explicit cap.
+    30 min). Every web request runs through the async job path, so the full
+    tier cap applies; the override exists only for tests / future callers.
 
     `on_step` is an optional sync callback invoked with stable labels
     ("fetching" | "describing-images" | "summarizing" | "analyzing") so

--- a/bot/transcriber.py
+++ b/bot/transcriber.py
@@ -8,24 +8,40 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
-# Hosted transcription (Groq's whisper-large-v3-turbo) is the primary path:
-# it transcribes hours of audio in seconds, which is what makes the longer
-# per-tier video caps feasible on our small box. When GROQ_API_KEY is unset
-# (local dev / tests) we fall back to self-hosted faster-whisper, which is
-# fine for the short clips that path still handles.
+# Hosted transcription is the primary path: it transcribes hours of audio in
+# seconds, which is what makes the longer per-tier video caps feasible on our
+# small box. Both providers speak the OpenAI audio API, so the only difference
+# is base_url + model. Preference: Groq first (whisper-large-v3-turbo is far
+# cheaper — ~$0.04/h vs OpenAI whisper-1's $0.36/h — and faster), then OpenAI,
+# then self-hosted faster-whisper for local dev / tests (short clips only).
 _GROQ_KEY = os.getenv("GROQ_API_KEY")
-_GROQ_BASE_URL = "https://api.groq.com/openai/v1"
-_GROQ_MODEL = "whisper-large-v3-turbo"
+_OPENAI_KEY = os.getenv("OPENAI_API_KEY")
 
-# Groq caps upload size (25 MB free tier). We always transcode to 16 kHz mono
-# Opus first — Whisper resamples to 16 kHz internally anyway, and Opus at a low
-# bitrate keeps even a 2-hour show well under the limit (~15 MB) with no
-# meaningful accuracy loss on speech.
+if _GROQ_KEY:
+    _PROVIDER = "groq"
+    _HOSTED_KEY = _GROQ_KEY
+    _HOSTED_BASE_URL = "https://api.groq.com/openai/v1"
+    _HOSTED_MODEL = "whisper-large-v3-turbo"
+elif _OPENAI_KEY:
+    _PROVIDER = "openai"
+    _HOSTED_KEY = _OPENAI_KEY
+    _HOSTED_BASE_URL = None  # default OpenAI endpoint
+    _HOSTED_MODEL = "whisper-1"
+else:
+    _PROVIDER = "local"
+    _HOSTED_KEY = None
+    _HOSTED_BASE_URL = None
+    _HOSTED_MODEL = None
+
+# Both Groq and OpenAI cap audio uploads at 25 MB. We always transcode to
+# 16 kHz mono Opus first — Whisper resamples to 16 kHz internally anyway, and
+# Opus at a low bitrate keeps even a 2-hour show well under the limit (~15 MB)
+# with no meaningful accuracy loss on speech.
 _UPLOAD_TARGET_HZ = 16_000
 _UPLOAD_OPUS_BITRATE = "16k"
 
 _model = None
-_groq_client = None
+_hosted_client = None
 
 
 def _get_model():
@@ -37,16 +53,16 @@ def _get_model():
     return _model
 
 
-def _get_groq_client():
-    global _groq_client
-    if _groq_client is None:
+def _get_hosted_client():
+    global _hosted_client
+    if _hosted_client is None:
         from openai import OpenAI  # Groq exposes an OpenAI-compatible API
-        _groq_client = OpenAI(api_key=_GROQ_KEY, base_url=_GROQ_BASE_URL)
-    return _groq_client
+        _hosted_client = OpenAI(api_key=_HOSTED_KEY, base_url=_HOSTED_BASE_URL)
+    return _hosted_client
 
 
 def _compress_for_upload(file_path: str) -> str:
-    """Transcode to 16 kHz mono Opus so even long audio fits Groq's size cap.
+    """Transcode to 16 kHz mono Opus so even long audio fits the 25 MB cap.
 
     Returns a path to a new temp file on success, or the original path when
     ffmpeg is unavailable / the transcode fails (caller still tries to upload
@@ -75,13 +91,13 @@ def _compress_for_upload(file_path: str) -> str:
         return file_path
 
 
-def _transcribe_groq(file_path: str) -> str:
-    client = _get_groq_client()
+def _transcribe_hosted(file_path: str) -> str:
+    client = _get_hosted_client()
     upload_path = _compress_for_upload(file_path)
     try:
         with open(upload_path, "rb") as f:
             resp = client.audio.transcriptions.create(
-                model=_GROQ_MODEL,
+                model=_HOSTED_MODEL,
                 file=f,
                 response_format="text",
             )
@@ -105,14 +121,14 @@ def _transcribe_local(file_path: str) -> str:
 def _transcribe_sync(file_path: str) -> str:
     """Transcribe an audio/video file to text.
 
-    Uses Groq when GROQ_API_KEY is set (the only path that can keep up with
-    the longer per-tier video caps); a Groq failure raises so the caller
-    surfaces WHISPER_FAILED rather than silently dropping to the local CPU
-    model, which can't realistically finish a long file on our box. Without a
-    key we use the local model (dev / tests; short clips only).
+    Uses the hosted provider (Groq, else OpenAI) when a key is set — the only
+    path that can keep up with the longer per-tier video caps. A hosted failure
+    raises so the caller surfaces WHISPER_FAILED rather than silently dropping
+    to the local CPU model, which can't realistically finish a long file on our
+    box. Without a key we use the local model (dev / tests; short clips only).
     """
-    if _GROQ_KEY:
-        return _transcribe_groq(file_path)
+    if _PROVIDER != "local":
+        return _transcribe_hosted(file_path)
     return _transcribe_local(file_path)
 
 

--- a/bot/transcriber.py
+++ b/bot/transcriber.py
@@ -1,9 +1,31 @@
 import asyncio
 import logging
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
+# Hosted transcription (Groq's whisper-large-v3-turbo) is the primary path:
+# it transcribes hours of audio in seconds, which is what makes the longer
+# per-tier video caps feasible on our small box. When GROQ_API_KEY is unset
+# (local dev / tests) we fall back to self-hosted faster-whisper, which is
+# fine for the short clips that path still handles.
+_GROQ_KEY = os.getenv("GROQ_API_KEY")
+_GROQ_BASE_URL = "https://api.groq.com/openai/v1"
+_GROQ_MODEL = "whisper-large-v3-turbo"
+
+# Groq caps upload size (25 MB free tier). We always transcode to 16 kHz mono
+# Opus first — Whisper resamples to 16 kHz internally anyway, and Opus at a low
+# bitrate keeps even a 2-hour show well under the limit (~15 MB) with no
+# meaningful accuracy loss on speech.
+_UPLOAD_TARGET_HZ = 16_000
+_UPLOAD_OPUS_BITRATE = "16k"
+
 _model = None
+_groq_client = None
 
 
 def _get_model():
@@ -15,12 +37,83 @@ def _get_model():
     return _model
 
 
-def _transcribe_sync(file_path: str) -> str:
+def _get_groq_client():
+    global _groq_client
+    if _groq_client is None:
+        from openai import OpenAI  # Groq exposes an OpenAI-compatible API
+        _groq_client = OpenAI(api_key=_GROQ_KEY, base_url=_GROQ_BASE_URL)
+    return _groq_client
+
+
+def _compress_for_upload(file_path: str) -> str:
+    """Transcode to 16 kHz mono Opus so even long audio fits Groq's size cap.
+
+    Returns a path to a new temp file on success, or the original path when
+    ffmpeg is unavailable / the transcode fails (caller still tries to upload
+    — short clips are usually under the limit as-is).
+    """
+    if not shutil.which("ffmpeg"):
+        logger.warning("ffmpeg not found — uploading original audio without compression")
+        return file_path
+    out_path = tempfile.NamedTemporaryFile(suffix=".ogg", delete=False).name
+    try:
+        subprocess.run(
+            [
+                "ffmpeg", "-y", "-i", file_path,
+                "-ac", "1", "-ar", str(_UPLOAD_TARGET_HZ),
+                "-c:a", "libopus", "-b:a", _UPLOAD_OPUS_BITRATE,
+                out_path,
+            ],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        return out_path
+    except Exception as e:
+        logger.warning("Audio compression failed (%s); uploading original", e)
+        Path(out_path).unlink(missing_ok=True)
+        return file_path
+
+
+def _transcribe_groq(file_path: str) -> str:
+    client = _get_groq_client()
+    upload_path = _compress_for_upload(file_path)
+    try:
+        with open(upload_path, "rb") as f:
+            resp = client.audio.transcriptions.create(
+                model=_GROQ_MODEL,
+                file=f,
+                response_format="text",
+            )
+        # response_format="text" yields a plain string; be defensive in case
+        # the SDK returns an object with a `.text` attribute instead.
+        text = resp if isinstance(resp, str) else getattr(resp, "text", "")
+        return (text or "").strip()
+    finally:
+        if upload_path != file_path:
+            Path(upload_path).unlink(missing_ok=True)
+
+
+def _transcribe_local(file_path: str) -> str:
     model = _get_model()
     segments, info = model.transcribe(file_path, beam_size=5)
     text = " ".join(s.text for s in segments).strip()
     logger.info(f"Transcribed {file_path} ({info.language}, {info.duration:.1f}s)")
     return text
+
+
+def _transcribe_sync(file_path: str) -> str:
+    """Transcribe an audio/video file to text.
+
+    Uses Groq when GROQ_API_KEY is set (the only path that can keep up with
+    the longer per-tier video caps); a Groq failure raises so the caller
+    surfaces WHISPER_FAILED rather than silently dropping to the local CPU
+    model, which can't realistically finish a long file on our box. Without a
+    key we use the local model (dev / tests; short clips only).
+    """
+    if _GROQ_KEY:
+        return _transcribe_groq(file_path)
+    return _transcribe_local(file_path)
 
 
 async def transcribe(file_path: str) -> str:

--- a/scripts/debug_transcript.py
+++ b/scripts/debug_transcript.py
@@ -63,8 +63,14 @@ def main() -> int:
     parser.add_argument("url")
     args = parser.parse_args()
 
+    from bot.fetcher import WHISPER_MAX_DURATION_SIGNED_IN_S
+
     raw_len = _raw_youtube_transcript_len(args.url)
-    fetched = asyncio.run(fetch_url(args.url))
+    # Debug at the most generous (signed-in) cap so the script reflects the
+    # full transcription capability, not the stricter anonymous default.
+    fetched = asyncio.run(
+        fetch_url(args.url, max_whisper_duration=WHISPER_MAX_DURATION_SIGNED_IN_S)
+    )
 
     text = fetched.get("text") or ""
     print()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,7 +54,7 @@ def client(monkeypatch):
     import bot.api
     import bot.pipeline
 
-    async def fake_fetch_url(url):
+    async def fake_fetch_url(url, **kwargs):
         return {
             "text": "Sample article body about retrieval-augmented generation.",
             "title": "Hello RAG",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -442,7 +442,7 @@ class TestJobFlow:
         import bot.api
         import bot.pipeline
 
-        async def empty_fetch(url):
+        async def empty_fetch(url, **kwargs):
             return {"text": "", "title": url, "source_type": "article", "reason": "no_text"}
 
         monkeypatch.setattr(bot.pipeline, "fetch_url", empty_fetch)
@@ -462,7 +462,7 @@ class TestJobFlow:
         import bot.pipeline
         from bot import fetch_errors
 
-        async def paywalled_fetch(url):
+        async def paywalled_fetch(url, **kwargs):
             return {"text": "", "title": url, "source_type": "article", "reason": fetch_errors.PAYWALLED}
 
         monkeypatch.setattr(bot.pipeline, "fetch_url", paywalled_fetch)
@@ -489,7 +489,7 @@ class TestJobFlow:
         import bot.api
         import bot.pipeline
 
-        async def empty_video_fetch(url):
+        async def empty_video_fetch(url, **kwargs):
             return {"text": "", "title": url, "source_type": "youtube", "reason": "no_transcript"}
 
         monkeypatch.setattr(bot.pipeline, "fetch_url", empty_video_fetch)

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -181,9 +181,9 @@ class TestYouTubeFallbackChain:
                 "duration": 1200,  # 20 min
             }
 
-            # Explicit 8-min cap (the sync-endpoint ceiling) → 20 min is over it.
+            # Explicit 10-min cap → the 20-min video is over it.
             result = fetcher._youtube_transcript(
-                YOUTUBE_URL, max_whisper_duration=fetcher.WHISPER_MAX_DURATION_SYNC_S
+                YOUTUBE_URL, max_whisper_duration=10 * 60
             )
 
         transcribe.assert_not_called()

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -166,7 +166,32 @@ class TestYouTubeFallbackChain:
         assert "spoken words" in result["text"]
         assert result["source_type"] == "youtube"  # corrected back to youtube
 
-    def test_skips_whisper_for_long_video(self):
+    def test_skips_whisper_when_duration_exceeds_cap(self):
+        from bot import fetcher, fetch_errors
+
+        with patch("youtube_transcript_api.YouTubeTranscriptApi") as TranscriptApi, \
+             patch.object(fetcher, "_yt_dlp_extract") as extract, \
+             patch.object(fetcher, "_yt_dlp_transcribe") as transcribe:
+            TranscriptApi.return_value.list.side_effect = Exception("blocked")
+            extract.return_value = {
+                "text": "Title\nBy: ch\n\nlong description",
+                "title": "Title",
+                "source_type": "youtube",
+                "has_transcript": False,
+                "duration": 1200,  # 20 min
+            }
+
+            # Explicit 8-min cap (the sync-endpoint ceiling) → 20 min is over it.
+            result = fetcher._youtube_transcript(
+                YOUTUBE_URL, max_whisper_duration=fetcher.WHISPER_MAX_DURATION_SYNC_S
+            )
+
+        transcribe.assert_not_called()
+        assert "long description" in result["text"]
+        assert result["reason"] == fetch_errors.VIDEO_TOO_LONG_FOR_WHISPER
+
+    def test_transcribes_long_video_under_signed_in_cap(self):
+        """20 min is within the 2-hour signed-in cap → Whisper is attempted."""
         from bot import fetcher
 
         with patch("youtube_transcript_api.YouTubeTranscriptApi") as TranscriptApi, \
@@ -178,13 +203,20 @@ class TestYouTubeFallbackChain:
                 "title": "Title",
                 "source_type": "youtube",
                 "has_transcript": False,
-                "duration": 1200,  # 20 min — would time out
+                "duration": 1200,
+            }
+            transcribe.return_value = {
+                "text": "Title\nBy: ch\n\nTranscript:\nspoken words",
+                "title": "Title",
+                "source_type": "video",
             }
 
-            result = fetcher._youtube_transcript(YOUTUBE_URL)
+            result = fetcher._youtube_transcript(
+                YOUTUBE_URL, max_whisper_duration=fetcher.WHISPER_MAX_DURATION_SIGNED_IN_S
+            )
 
-        transcribe.assert_not_called()
-        assert "long description" in result["text"]
+        transcribe.assert_called_once()
+        assert "spoken words" in result["text"]
 
     def test_returns_description_when_whisper_fallback_fails(self):
         from bot import fetcher
@@ -302,13 +334,31 @@ class TestUrlCacheLayer:
 
         assert inner.call_count == 2, "failed fetch shouldn't poison the cache"
 
+    def test_too_long_for_whisper_is_not_cached(self):
+        """The one tier-dependent degraded outcome must not be cached, or a
+        stricter (anon) tier would poison a more generous (signed-in) one."""
+        from bot import fetcher, fetch_errors
+
+        with patch.object(fetcher, "_fetch_url_uncached", new_callable=AsyncMock) as inner:
+            inner.return_value = {
+                "text": "Title\nBy: ch",  # title-only stub
+                "title": "Title",
+                "source_type": "youtube",
+                "reason": fetch_errors.VIDEO_TOO_LONG_FOR_WHISPER,
+            }
+
+            asyncio.run(fetcher.fetch_url("https://youtube.com/watch?v=zzzzzzzzzzz"))
+            asyncio.run(fetcher.fetch_url("https://youtube.com/watch?v=zzzzzzzzzzz"))
+
+        assert inner.call_count == 2, "too-long result must not be cached"
+
     def test_different_urls_get_separate_entries(self):
         from bot import fetcher
 
         with patch.object(fetcher, "_fetch_url_uncached", new_callable=AsyncMock) as inner:
-            def by_url(url):
+            def by_url(url, **kwargs):
                 return {"text": f"body for {url}", "title": "", "source_type": "article"}
-            inner.side_effect = lambda u: by_url(u)
+            inner.side_effect = lambda u, **kw: by_url(u, **kw)
 
             asyncio.run(fetcher.fetch_url("https://example.com/a"))
             asyncio.run(fetcher.fetch_url("https://example.com/b"))

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -135,6 +135,38 @@ class TestErrors:
             asyncio.run(pipeline.analyze_url("x", ctx=UsageContext()))
         assert exc_info.value.code == pipeline.ERR_NO_TRANSCRIPT
 
+    def test_thin_stub_with_reason_for_video_raises_no_transcript(
+        self, pipeline, monkeypatch
+    ):
+        # Captionless video, too long for Whisper, empty description: the
+        # fetcher returns a title-only stub *plus* a reason. We must surface
+        # the reason, not analyse the stub.
+        async def thin_video(url):
+            return {"text": "Real Boom? Fake Money?\nBy: THE JACK MALLERS SHOW",
+                    "title": "Real Boom? Fake Money?", "source_type": "youtube",
+                    "image_urls": [], "reason": "video_too_long_for_whisper"}
+        monkeypatch.setattr(pipeline, "fetch_url", thin_video)
+
+        from bot.analyzer import UsageContext
+        with pytest.raises(pipeline.PipelineError) as exc_info:
+            asyncio.run(pipeline.analyze_url("x", ctx=UsageContext()))
+        assert exc_info.value.code == pipeline.ERR_NO_TRANSCRIPT
+        assert exc_info.value.fetched["reason"] == "video_too_long_for_whisper"
+
+    def test_short_description_without_reason_still_analyses(
+        self, pipeline, monkeypatch
+    ):
+        # A successful (unflagged) fetch with short text must NOT be gated —
+        # only degraded fetches carrying a `reason` are subject to the floor.
+        async def short_ok(url):
+            return {"text": "A short but real article.", "title": "t",
+                    "source_type": "article", "image_urls": []}
+        monkeypatch.setattr(pipeline, "fetch_url", short_ok)
+
+        from bot.analyzer import UsageContext
+        result = asyncio.run(pipeline.analyze_url("x", ctx=UsageContext()))
+        assert result.analysis is not None
+
     def test_analyze_crash_raises_analyze_failed(self, pipeline, monkeypatch):
         def boom(_text, **_kwargs):
             raise RuntimeError("rate limited")

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -22,7 +22,7 @@ def pipeline(monkeypatch):
     exercise a specific edge case (empty text, video source_type, etc.)."""
     import bot.pipeline
 
-    async def fake_fetch_url(url):
+    async def fake_fetch_url(url, **kwargs):
         return {
             "text": "Long article body about retrieval-augmented generation.",
             "title": "RAG explained",
@@ -99,7 +99,7 @@ class TestAnalyzeUrlBasics:
 
 class TestErrors:
     def test_fetch_failure_raises_pipeline_error(self, pipeline, monkeypatch):
-        async def boom_fetch(url):
+        async def boom_fetch(url, **kwargs):
             raise RuntimeError("network down")
         monkeypatch.setattr(pipeline, "fetch_url", boom_fetch)
 
@@ -111,7 +111,7 @@ class TestErrors:
     def test_empty_text_for_article_raises_extraction_failed(
         self, pipeline, monkeypatch
     ):
-        async def empty_fetch(url):
+        async def empty_fetch(url, **kwargs):
             return {"text": "", "title": url, "source_type": "article",
                     "image_urls": [], "reason": "no_text"}
         monkeypatch.setattr(pipeline, "fetch_url", empty_fetch)
@@ -125,7 +125,7 @@ class TestErrors:
     def test_empty_text_for_video_raises_no_transcript(
         self, pipeline, monkeypatch
     ):
-        async def empty_video(url):
+        async def empty_video(url, **kwargs):
             return {"text": "", "title": url, "source_type": "youtube",
                     "image_urls": [], "reason": "no_transcript"}
         monkeypatch.setattr(pipeline, "fetch_url", empty_video)
@@ -141,7 +141,7 @@ class TestErrors:
         # Captionless video, too long for Whisper, empty description: the
         # fetcher returns a title-only stub *plus* a reason. We must surface
         # the reason, not analyse the stub.
-        async def thin_video(url):
+        async def thin_video(url, **kwargs):
             return {"text": "Real Boom? Fake Money?\nBy: THE JACK MALLERS SHOW",
                     "title": "Real Boom? Fake Money?", "source_type": "youtube",
                     "image_urls": [], "reason": "video_too_long_for_whisper"}
@@ -158,7 +158,7 @@ class TestErrors:
     ):
         # A successful (unflagged) fetch with short text must NOT be gated —
         # only degraded fetches carrying a `reason` are subject to the floor.
-        async def short_ok(url):
+        async def short_ok(url, **kwargs):
             return {"text": "A short but real article.", "title": "t",
                     "source_type": "article", "image_urls": []}
         monkeypatch.setattr(pipeline, "fetch_url", short_ok)
@@ -189,7 +189,7 @@ class TestImageStrategy:
     def with_images(self, pipeline, monkeypatch):
         """Override fetch to return image_urls; capture analyze input to
         verify image descriptions did/didn't end up there."""
-        async def fetch_with_images(url):
+        async def fetch_with_images(url, **kwargs):
             return {
                 "text": "Article body",
                 "title": "T",
@@ -220,7 +220,7 @@ class TestImageStrategy:
     def test_youtube_excludes_images_by_default(self, with_images, monkeypatch):
         pl, captured = with_images
 
-        async def fetch_youtube(url):
+        async def fetch_youtube(url, **kwargs):
             return {
                 "text": "Transcript here",
                 "title": "T",

--- a/tests/test_transcriber.py
+++ b/tests/test_transcriber.py
@@ -1,0 +1,65 @@
+"""Tests for bot/transcriber.py — the Groq-vs-local routing.
+
+Network is never hit: we mock the Groq client and the local model and assert
+which one `_transcribe_sync` picks based on whether GROQ_API_KEY is set.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from bot import transcriber
+
+
+def test_routes_to_groq_when_key_set():
+    with patch.object(transcriber, "_GROQ_KEY", "gsk-test"), \
+         patch.object(transcriber, "_transcribe_groq", return_value="groq text") as groq, \
+         patch.object(transcriber, "_transcribe_local") as local:
+        out = transcriber._transcribe_sync("/tmp/audio.mp3")
+
+    assert out == "groq text"
+    groq.assert_called_once_with("/tmp/audio.mp3")
+    local.assert_not_called()
+
+
+def test_groq_failure_propagates_not_silently_local():
+    # A long file can't realistically finish on the local CPU model, so a Groq
+    # failure must raise (→ caller surfaces WHISPER_FAILED), never fall back.
+    with patch.object(transcriber, "_GROQ_KEY", "gsk-test"), \
+         patch.object(transcriber, "_transcribe_groq", side_effect=RuntimeError("boom")), \
+         patch.object(transcriber, "_transcribe_local") as local:
+        try:
+            transcriber._transcribe_sync("/tmp/audio.mp3")
+            assert False, "expected RuntimeError to propagate"
+        except RuntimeError:
+            pass
+    local.assert_not_called()
+
+
+def test_routes_to_local_when_no_key():
+    with patch.object(transcriber, "_GROQ_KEY", None), \
+         patch.object(transcriber, "_transcribe_local", return_value="local text") as local, \
+         patch.object(transcriber, "_transcribe_groq") as groq:
+        out = transcriber._transcribe_sync("/tmp/audio.mp3")
+
+    assert out == "local text"
+    local.assert_called_once_with("/tmp/audio.mp3")
+    groq.assert_not_called()
+
+
+def test_groq_upload_compresses_and_cleans_up(tmp_path):
+    src = tmp_path / "audio.mp3"
+    src.write_bytes(b"fake-audio")
+    compressed = tmp_path / "small.ogg"
+    compressed.write_bytes(b"opus")
+
+    fake_client = MagicMock()
+    fake_client.audio.transcriptions.create.return_value = "transcribed"
+
+    with patch.object(transcriber, "_get_groq_client", return_value=fake_client), \
+         patch.object(transcriber, "_compress_for_upload", return_value=str(compressed)):
+        out = transcriber._transcribe_groq(str(src))
+
+    assert out == "transcribed"
+    # The compressed temp upload is removed; the original is left to its caller.
+    assert not compressed.exists()
+    assert src.exists()

--- a/tests/test_transcriber.py
+++ b/tests/test_transcriber.py
@@ -1,7 +1,8 @@
-"""Tests for bot/transcriber.py — the Groq-vs-local routing.
+"""Tests for bot/transcriber.py — the hosted-vs-local routing.
 
-Network is never hit: we mock the Groq client and the local model and assert
-which one `_transcribe_sync` picks based on whether GROQ_API_KEY is set.
+Network is never hit: we mock the hosted client and the local model and assert
+which one `_transcribe_sync` picks based on the resolved provider (Groq /
+OpenAI when a key is set, else local faster-whisper).
 """
 from __future__ import annotations
 
@@ -10,22 +11,23 @@ from unittest.mock import MagicMock, patch
 from bot import transcriber
 
 
-def test_routes_to_groq_when_key_set():
-    with patch.object(transcriber, "_GROQ_KEY", "gsk-test"), \
-         patch.object(transcriber, "_transcribe_groq", return_value="groq text") as groq, \
+def test_routes_to_hosted_when_provider_set():
+    with patch.object(transcriber, "_PROVIDER", "groq"), \
+         patch.object(transcriber, "_transcribe_hosted", return_value="hosted text") as hosted, \
          patch.object(transcriber, "_transcribe_local") as local:
         out = transcriber._transcribe_sync("/tmp/audio.mp3")
 
-    assert out == "groq text"
-    groq.assert_called_once_with("/tmp/audio.mp3")
+    assert out == "hosted text"
+    hosted.assert_called_once_with("/tmp/audio.mp3")
     local.assert_not_called()
 
 
-def test_groq_failure_propagates_not_silently_local():
-    # A long file can't realistically finish on the local CPU model, so a Groq
-    # failure must raise (→ caller surfaces WHISPER_FAILED), never fall back.
-    with patch.object(transcriber, "_GROQ_KEY", "gsk-test"), \
-         patch.object(transcriber, "_transcribe_groq", side_effect=RuntimeError("boom")), \
+def test_hosted_failure_propagates_not_silently_local():
+    # A long file can't realistically finish on the local CPU model, so a
+    # hosted failure must raise (→ caller surfaces WHISPER_FAILED), never fall
+    # back.
+    with patch.object(transcriber, "_PROVIDER", "openai"), \
+         patch.object(transcriber, "_transcribe_hosted", side_effect=RuntimeError("boom")), \
          patch.object(transcriber, "_transcribe_local") as local:
         try:
             transcriber._transcribe_sync("/tmp/audio.mp3")
@@ -35,18 +37,18 @@ def test_groq_failure_propagates_not_silently_local():
     local.assert_not_called()
 
 
-def test_routes_to_local_when_no_key():
-    with patch.object(transcriber, "_GROQ_KEY", None), \
+def test_routes_to_local_when_no_provider():
+    with patch.object(transcriber, "_PROVIDER", "local"), \
          patch.object(transcriber, "_transcribe_local", return_value="local text") as local, \
-         patch.object(transcriber, "_transcribe_groq") as groq:
+         patch.object(transcriber, "_transcribe_hosted") as hosted:
         out = transcriber._transcribe_sync("/tmp/audio.mp3")
 
     assert out == "local text"
     local.assert_called_once_with("/tmp/audio.mp3")
-    groq.assert_not_called()
+    hosted.assert_not_called()
 
 
-def test_groq_upload_compresses_and_cleans_up(tmp_path):
+def test_hosted_upload_compresses_and_cleans_up(tmp_path):
     src = tmp_path / "audio.mp3"
     src.write_bytes(b"fake-audio")
     compressed = tmp_path / "small.ogg"
@@ -55,9 +57,9 @@ def test_groq_upload_compresses_and_cleans_up(tmp_path):
     fake_client = MagicMock()
     fake_client.audio.transcriptions.create.return_value = "transcribed"
 
-    with patch.object(transcriber, "_get_groq_client", return_value=fake_client), \
+    with patch.object(transcriber, "_get_hosted_client", return_value=fake_client), \
          patch.object(transcriber, "_compress_for_upload", return_value=str(compressed)):
-        out = transcriber._transcribe_groq(str(src))
+        out = transcriber._transcribe_hosted(str(src))
 
     assert out == "transcribed"
     # The compressed temp upload is removed; the original is left to its caller.


### PR DESCRIPTION
## Context
A user reported `https://www.youtube.com/watch?v=8LbZjzW4r1w` returning a near-empty analysis. Two distinct problems:

1. The pipeline analysed a 48-char **title-only stub** instead of surfacing the "no transcript" message.
2. The captionless-video Whisper ceiling was **3 minutes** — far too short for real YouTube content.

## Changes

**`fix(pipeline)`** — bail before analysing when a degraded fetch (`reason` set) carries less than `_MIN_ANALYZABLE_CHARS` of fallback text, so callers render the friendly fetch-error message instead of a thin fabricated analysis. Gated on `reason`, so successful fetches (incl. short articles) are untouched.

**`feat(transcription)`** — move transcription to hosted Whisper and raise the cap per tier:

| Tier | Cap |
|------|-----|
| Anonymous | 30 min |
| Signed-in | 2 h |

Every web request runs through the async `/api/job` path (verified in the frontend Worker — both anon and signed-in POST to `/api/job`; nothing calls `/api/try` or `/api/library/add`), which has no Worker-side analysis timeout. So the full per-tier cap applies uniformly — no special sync-endpoint cap. The cap is threaded `pipeline → fetch_url → _youtube_transcript`, derived from `ctx.user_id`. `video_too_long_for_whisper` results are not cached, so a stricter tier can't poison a more generous one.

**Provider selection** — both Groq and OpenAI speak the OpenAI audio API. Preference: `GROQ_API_KEY` (whisper-large-v3-turbo, ~$0.04/h, fastest) → `OPENAI_API_KEY` (whisper-1, ~$0.36/h) → local faster-whisper for short clips. Audio is transcoded to 16 kHz mono Opus to stay under the 25 MB upload limit. A hosted failure surfaces `WHISPER_FAILED` rather than silently dropping to the local CPU model, which can't finish a long file.

## Deploy note
Set `GROQ_API_KEY` (or rely on an existing `OPENAI_API_KEY`) as a Fly secret before this helps in prod. Without either, prod stays on local faster-whisper (long videos hit `WHISPER_FAILED`).

## Tests
227 pass, incl. new coverage for the tier gate, cache-skip, and hosted/local routing (`tests/test_transcriber.py`).

## Follow-ups
- #52 — cap yt-dlp audio download size/format on the 1 GB box.
- "Unlimited / pro" tier deferred until a real `tier`/`plan` column exists; `whisper_cap_for()` is the single extension point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)