### PR TITLE
Don't gate user-initiated fetches on robots.txt

### DIFF
--- a/bot/fetch_errors.py
+++ b/bot/fetch_errors.py
@@ -23,7 +23,6 @@ VIDEO_UNAVAILABLE = "video_unavailable"
 JS_REQUIRED = "js_required"
 PAYWALLED = "paywalled"
 BLOCKED_URL = "blocked_url"
-BLOCKED_BY_ROBOTS = "blocked_by_robots"
 
 
 _USER_MESSAGES: dict[str, str] = {
@@ -83,11 +82,6 @@ _USER_MESSAGES: dict[str, str] = {
     BLOCKED_URL: (
         "That URL can't be fetched — only public web addresses are supported. "
         "Private, local, or internal-network addresses are blocked."
-    ),
-    BLOCKED_BY_ROBOTS: (
-        "This site's robots.txt asks automated tools not to fetch this page, so "
-        "we didn't. If you can open it yourself, paste the text directly and "
-        "I'll analyse it."
     ),
 }
 

--- a/bot/fetcher.py
+++ b/bot/fetcher.py
@@ -1,7 +1,6 @@
 import asyncio
 import logging
 import re
-import urllib.robotparser
 from functools import lru_cache
 from pathlib import Path
 from urllib.parse import urlparse
@@ -16,46 +15,6 @@ from bot.ssrf import BlockedURLError, assert_public_url
 logger = logging.getLogger(__name__)
 
 _YT_PATTERNS = re.compile(r"(?:v=|youtu\.be/)([a-zA-Z0-9_-]{11})")
-
-# Crawler token we present to robots.txt. We honour an explicit Disallow for
-# this agent (or `*`) on the generic article/blog path only — platform
-# fetchers (YouTube/X/Vimeo) use their own endpoints, not generic crawling.
-_ROBOTS_UA = "filter-fyi"
-
-
-@lru_cache(maxsize=512)
-def _robots_parser_for(scheme: str, netloc: str) -> urllib.robotparser.RobotFileParser | None:
-    """Fetch and parse a host's robots.txt. Cached per host for the process.
-
-    Returns None when robots.txt is absent/unreadable (→ treat as allowed).
-    """
-    robots_url = f"{scheme}://{netloc}/robots.txt"
-    try:
-        resp = requests.get(robots_url, timeout=10, headers={"User-Agent": _ROBOTS_UA})
-    except Exception as e:
-        logger.info("robots.txt fetch failed for %s (allowing): %s", netloc, e)
-        return None
-    if resp.status_code >= 400:
-        return None  # no robots.txt → nothing disallowed
-    rp = urllib.robotparser.RobotFileParser()
-    rp.parse(resp.text.splitlines())
-    return rp
-
-
-def _robots_allows(url: str) -> bool:
-    """True unless the site's robots.txt explicitly disallows our agent.
-
-    Fail-open: if robots.txt is missing or unreadable, allow the (single,
-    user-initiated) fetch rather than blocking the user.
-    """
-    parsed = urlparse(url)
-    rp = _robots_parser_for(parsed.scheme, parsed.netloc)
-    if rp is None:
-        return True
-    try:
-        return rp.can_fetch(_ROBOTS_UA, url)
-    except Exception:
-        return True
 
 
 def _youtube_thumbnail(video_id: str) -> str:
@@ -714,10 +673,10 @@ async def _fetch_url_uncached(url: str) -> dict:
     if urlparse(url).path.lower().endswith(".pdf"):
         return await _pdf_fetch(url)
 
-    # Generic article/blog fetch: honour robots.txt for this path only. (The
-    # platform fetchers above use their own endpoints, not generic crawling.)
-    loop = asyncio.get_running_loop()
-    if not await loop.run_in_executor(None, _robots_allows, url):
-        logger.info("robots.txt disallows %s", url)
-        return {"text": "", "title": url, "source_type": "article", "reason": fetch_errors.BLOCKED_BY_ROBOTS}
+    # Generic article/blog fetch. We deliberately do NOT consult robots.txt
+    # here: every fetch is a single, user-initiated request for a page the
+    # person already intends to read — a user agent acting on their behalf,
+    # not a crawler indexing the site. (Same distinction Google draws for its
+    # user-triggered fetchers.) SSRF guard, rate limits and summary-only
+    # retention still apply.
     return await _generic_fetch(url)

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -287,35 +287,30 @@ class TestUrlCacheLayer:
 
 
 class TestRobots:
-    """Generic article/blog fetches honour robots.txt; fail open when absent."""
+    """robots.txt is deliberately NOT consulted: a generic fetch is a single
+    user-initiated request (a user agent acting for the person), not crawling.
+    The page is fetched regardless of what robots.txt would say."""
 
-    def test_allows_when_no_robots(self, monkeypatch):
-        from bot import fetcher
-        monkeypatch.setattr(fetcher, "_robots_parser_for", lambda scheme, netloc: None)
-        assert fetcher._robots_allows("https://example.com/post") is True
-
-    def test_blocks_when_disallowed(self, monkeypatch):
-        from bot import fetcher
-
-        class _RP:
-            def can_fetch(self, ua, url):
-                return False
-
-        monkeypatch.setattr(fetcher, "_robots_parser_for", lambda scheme, netloc: _RP())
-        assert fetcher._robots_allows("https://example.com/post") is False
-
-    def test_generic_path_short_circuits_when_disallowed(self, monkeypatch):
+    def test_generic_path_does_not_consult_robots(self, monkeypatch):
         from bot import fetcher
 
         monkeypatch.setattr(fetcher, "assert_public_url", lambda u: None)  # skip DNS
-        monkeypatch.setattr(fetcher, "_robots_allows", lambda u: False)
         called = {"generic": False}
 
-        async def _no_generic(u):
+        async def _generic(u):
             called["generic"] = True
-            return {"text": "should not happen"}
+            return {"text": "article body", "title": "T", "source_type": "article"}
 
-        monkeypatch.setattr(fetcher, "_generic_fetch", _no_generic)
+        monkeypatch.setattr(fetcher, "_generic_fetch", _generic)
         result = asyncio.run(fetcher._fetch_url_uncached("https://example.com/post"))
-        assert result["reason"] == fetcher.fetch_errors.BLOCKED_BY_ROBOTS
-        assert called["generic"] is False, "must not fetch a disallowed page"
+        assert called["generic"] is True, "user-initiated fetch must proceed"
+        assert result["text"] == "article body"
+        assert "reason" not in result
+
+    def test_robots_machinery_is_gone(self):
+        """No leftover robots gate that a future change could re-wire."""
+        from bot import fetch_errors, fetcher
+
+        assert not hasattr(fetcher, "_robots_allows")
+        assert not hasattr(fetcher, "_robots_parser_for")
+        assert not hasattr(fetch_errors, "BLOCKED_BY_ROBOTS")


### PR DESCRIPTION
## What

A submitted link is a single, **user-initiated** request for a page the person already intends to read — a user agent acting on their behalf, not a crawler indexing the site. (Same distinction Google draws for its [user-triggered fetchers](https://developers.google.com/search/docs/crawling-indexing/google-common-crawlers#user-triggered-fetchers), which ignore robots.txt.) robots.txt targets automated crawling, so honouring it here blocked legitimate user requests — e.g. Springer articles under a blanket `Disallow: *` — with a dead-end error and no recourse.

This removes the robots.txt gate from the generic article/blog fetch and deletes the now-dead `BLOCKED_BY_ROBOTS` reason code.

## Reverses an intentional decision

The gate was added deliberately in `7ed0183` ("Compliance: respect robots.txt") as pre-launch copyright/GDPR hardening. This PR walks that back per a product decision: we analyse **on behalf of the user**, not by scraping. SSRF guard, rate limits, and summary-only retention are all unchanged — those were the substantive protections; robots.txt was the over-broad one.

## ⚠️ Must land with the frontend PR

The public terms & privacy copy claimed "we respect robots.txt". That claim is removed in **johannespietsch/filter.fyi#38** — the two must ship together so the published policy matches behaviour.

## Tests

Replaced the robots allow/block tests with one proving the generic path fetches regardless of robots.txt, plus a guard that the machinery stays gone. **215 pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
