### PR TITLE
Surface the specific fetch-failure message on async jobs

### DIFF
--- a/bot/api.py
+++ b/bot/api.py
@@ -635,7 +635,7 @@ async def _run_job(
                 on_step=_on_step,
             )
         except PipelineError as e:
-            set_job_error(job_id, e.code)
+            set_job_error(job_id, e.code, fetch_error_message(e.fetched.get("reason"), url))
             return
 
         analysis = result.analysis
@@ -684,7 +684,7 @@ async def get_job_status(job_id: str, _: None = Depends(_require_try_secret)):
             result = None
         return {"status": "done", "result": result}
     if job["status"] == "error":
-        return {"status": "error", "error": job["error"]}
+        return {"status": "error", "error": job["error"], "message": job["message"]}
     return {"status": "pending", "step": _job_steps.get(job_id, "fetching")}
 
 

--- a/bot/db.py
+++ b/bot/db.py
@@ -148,6 +148,7 @@ CREATE TABLE IF NOT EXISTS jobs (
     status     TEXT NOT NULL DEFAULT 'pending',
     result     TEXT NOT NULL DEFAULT '',
     error      TEXT NOT NULL DEFAULT '',
+    message    TEXT NOT NULL DEFAULT '',
     created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%S', 'now')),
     updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%S', 'now'))
 )"""
@@ -265,6 +266,14 @@ def _has_table(conn: sqlite3.Connection, name: str) -> bool:
     return row is not None
 
 
+def _ensure_column(conn: sqlite3.Connection, table: str, column: str, ddl: str) -> None:
+    """Idempotently add a column to an existing table (CREATE TABLE IF NOT
+    EXISTS won't alter a table that already exists on the Fly disk)."""
+    cols = {r["name"] for r in conn.execute(f"PRAGMA table_info({table})")}
+    if column not in cols:
+        conn.execute(f"ALTER TABLE {table} ADD COLUMN {ddl}")
+
+
 def _migrate_from_profiles(conn: sqlite3.Connection) -> None:
     """One-time migration: profiles + items(user_id TEXT) -> users + items(user_id INT).
 
@@ -331,6 +340,9 @@ def _init() -> None:
         conn.execute(_CREATE_ERROR_LOG_SQL)
         conn.execute(_CREATE_FEEDBACK_SQL)
         conn.execute(_CREATE_JOBS_SQL)
+        # Added after jobs shipped: carries the user-facing failure message so
+        # the Worker can show *why* a job failed instead of a generic string.
+        _ensure_column(conn, "jobs", "message", "message TEXT NOT NULL DEFAULT ''")
         conn.execute(_CREATE_LLM_CALLS_SQL)
         conn.execute(_CREATE_ANALYZE_TRACES_SQL)
         conn.execute(_CREATE_PROCESSED_UPDATES_SQL)
@@ -731,18 +743,20 @@ def set_job_done(job_id: str, result: dict) -> None:
         )
 
 
-def set_job_error(job_id: str, error: str) -> None:
+def set_job_error(job_id: str, error: str, message: str = "") -> None:
+    """Mark a job failed. `error` is the machine code (the Worker may key on
+    it); `message` is the user-facing explanation surfaced in the browser."""
     with _get_conn() as conn:
         conn.execute(
-            "UPDATE jobs SET status = 'error', error = ?, updated_at = ? WHERE id = ?",
-            (error, _utcnow_iso(), job_id),
+            "UPDATE jobs SET status = 'error', error = ?, message = ?, updated_at = ? WHERE id = ?",
+            (error, message, _utcnow_iso(), job_id),
         )
 
 
 def get_job_record(job_id: str) -> sqlite3.Row | None:
     with _get_conn() as conn:
         return conn.execute(
-            "SELECT id, status, result, error FROM jobs WHERE id = ?",
+            "SELECT id, status, result, error, message FROM jobs WHERE id = ?",
             (job_id,),
         ).fetchone()
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -451,6 +451,38 @@ class TestJobFlow:
         rec = db.get_job_record("job-4")
         assert rec["status"] == "error"
         assert rec["error"] == "extraction-failed"
+        # A user-facing explanation is persisted alongside the code so the
+        # Worker can show *why* it failed, not just a generic line.
+        assert rec["message"]
+
+    def test_run_job_persists_specific_reason_message(self, client, db, monkeypatch):
+        """A known fetch reason (e.g. paywall) surfaces its friendly message."""
+        import asyncio
+        import bot.api
+        import bot.pipeline
+        from bot import fetch_errors
+
+        async def paywalled_fetch(url):
+            return {"text": "", "title": url, "source_type": "article", "reason": fetch_errors.PAYWALLED}
+
+        monkeypatch.setattr(bot.pipeline, "fetch_url", paywalled_fetch)
+        db.create_job("job-pw")
+        asyncio.run(bot.api._run_job("job-pw", "https://example.com/x", None, ""))
+        rec = db.get_job_record("job-pw")
+        assert rec["status"] == "error"
+        assert rec["message"] == fetch_errors.user_message(fetch_errors.PAYWALLED, "https://example.com/x")
+        assert "paywall" in rec["message"].lower()
+
+    def test_get_job_status_returns_error_message(self, client, db):
+        """The poll endpoint exposes the persisted message to the Worker."""
+        db.create_job("job-st")
+        db.set_job_error("job-st", "extraction-failed", "This looks paywalled.")
+        resp = client.get("/api/job/job-st", headers={"x-filter-fyi-secret": "test-secret"})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "error"
+        assert body["error"] == "extraction-failed"
+        assert body["message"] == "This looks paywalled."
 
     def test_run_job_video_no_text_sets_no_transcript(self, client, db, monkeypatch):
         import asyncio

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -111,6 +111,43 @@ class TestMigration:
         names = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
         assert {"users", "items", "link_codes"}.issubset(names)
 
+    def test_init_adds_jobs_message_column_to_old_db(self, monkeypatch):
+        """A jobs table predating the `message` column gets it via _ensure_column."""
+        data_dir = os.environ["DATA_DIR"]
+        c = sqlite3.connect(os.path.join(data_dir, "research.db"))
+        c.executescript(
+            """
+            CREATE TABLE jobs (
+                id TEXT PRIMARY KEY,
+                status TEXT NOT NULL DEFAULT 'pending',
+                result TEXT NOT NULL DEFAULT '',
+                error TEXT NOT NULL DEFAULT '',
+                created_at TEXT,
+                updated_at TEXT
+            );
+            INSERT INTO jobs (id, status, error) VALUES ('old', 'error', 'extraction-failed');
+            """
+        )
+        c.commit()
+        c.close()
+
+        import bot.db as db
+
+        cols = {r["name"] for r in db._get_conn().execute("PRAGMA table_info(jobs)")}
+        assert "message" in cols
+        # The pre-existing row survives and defaults to an empty message.
+        rec = db.get_job_record("old")
+        assert rec["error"] == "extraction-failed"
+        assert rec["message"] == ""
+
+    def test_set_job_error_roundtrips_message(self, db):
+        db.create_job("j1")
+        db.set_job_error("j1", "extraction-failed", "This looks paywalled.")
+        rec = db.get_job_record("j1")
+        assert rec["status"] == "error"
+        assert rec["error"] == "extraction-failed"
+        assert rec["message"] == "This looks paywalled."
+
 
 # ---------------------------------------------------------------------------
 # User helpers


### PR DESCRIPTION
## The bug

A user reported submitting a URL and getting **"something went wrong — The summarizer had a problem. Try a different URL?"** instead of a specific explanation.

Root cause: the anon + signed-in flows run analysis as an **async job** (`POST /api/job` → poll `GET /api/job/:id`), but the reason-specific friendly message (paywall, JS-wall, fetch failure, …) was only ever computed on the **synchronous** `/api/try` path, which those flows don't use.

- `_run_job` stored only the coarse pipeline code: `set_job_error(job_id, e.code)`.
- The poll endpoint returned just that code.
- So the Worker fell through to its hardcoded generic line — exactly the string the user saw.

## Fix

- `jobs`: add a `message` column. Idempotent `_ensure_column` migration for the existing Fly DB; included in `CREATE TABLE` for fresh installs.
- `set_job_error(job_id, error, message="")` persists the user-facing message alongside the machine code.
- `_run_job` computes `fetch_error_message(reason, url)` on `PipelineError`.
- `GET /api/job/:id` returns `message` in the error body.

## Pairs with frontend

The Worker must read this through instead of hardcoding — **johannespietsch/filter.fyi#39**. Backend is backward-compatible (extra field), so ordering isn't strict, but the user-visible fix only lands once both ship.

## Tests

Column migration on a pre-`message` `jobs` table, set/get roundtrip, a specific reason (paywall) surfacing its message end-to-end through `_run_job`, and the poll endpoint exposing it. **219 pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
