### PR TITLE
Recover walled academic articles via DOI → Crossref/Unpaywall

### DIFF
--- a/bot/config.py
+++ b/bot/config.py
@@ -1,4 +1,11 @@
+import os
+
 # Model and context limits
 # claude-haiku-4-5: 200k token context (~800k chars) — 100k chars leaves ample room for prompt + response
 # gpt-4o-mini: 128k token context (~500k chars)
 MAX_CONTENT_CHARS = 100_000
+
+# Contact address sent to open scholarly APIs (Crossref polite pool, Unpaywall
+# requires it). Not secret — it's an identifier so the APIs can reach us if our
+# traffic misbehaves. Override per-deploy via CONTACT_EMAIL.
+CONTACT_EMAIL = os.getenv("CONTACT_EMAIL", "hello@filter.fyi")

--- a/bot/fetcher.py
+++ b/bot/fetcher.py
@@ -1,15 +1,16 @@
 import asyncio
+import html
 import logging
 import re
 from functools import lru_cache
 from pathlib import Path
-from urllib.parse import urlparse
+from urllib.parse import quote, unquote, urlparse
 
 import httpx
 import requests
 
 from bot import fetch_errors
-from bot.config import MAX_CONTENT_CHARS
+from bot.config import CONTACT_EMAIL, MAX_CONTENT_CHARS
 from bot.ssrf import BlockedURLError, assert_public_url
 
 logger = logging.getLogger(__name__)
@@ -637,6 +638,138 @@ async def fetch_url(url: str) -> dict:
     return result
 
 
+# --- Academic / scholarly fallback ------------------------------------------
+# Many publisher article pages (Springer, Wiley, Elsevier, …) JS- or login-wall
+# the HTML, so a plain fetch gets a "please enable JavaScript" stub. But the
+# same articles are addressable by DOI through free, no-key scholarly APIs that
+# return a clean abstract (Crossref) or an open-access copy (Unpaywall). That's
+# a single on-behalf-of-user lookup keyed by an identifier in the URL — not
+# crawling — and it turns a dead-end wall into something analysable.
+
+# A DOI is "10." + a 4–9 digit registrant + "/" + a liberal suffix. In a URL the
+# suffix runs until a query/fragment; we then trim path tails that clearly
+# aren't part of the DOI (e.g. /fulltext, .pdf) that publishers append.
+_DOI_RE = re.compile(r"10\.\d{4,9}/[^\s\"'<>?#]+", re.IGNORECASE)
+_DOI_TRAILING = re.compile(
+    r"(?:/(?:full|fulltext|abstract|pdf|epdf|meta|references|citations))+$|"
+    r"\.(?:pdf|html?|full|abstract)$",
+    re.IGNORECASE,
+)
+
+
+def _extract_doi(url: str) -> str | None:
+    """Pull a DOI out of an article URL, or None. Path-only (ignores query)."""
+    m = _DOI_RE.search(unquote(urlparse(url).path))
+    if not m:
+        return None
+    doi = m.group(0).rstrip(").,;'\"")
+    doi = _DOI_TRAILING.sub("", doi)
+    return doi or None
+
+
+def _strip_jats(s: str) -> str:
+    """Crossref abstracts come as JATS/XML (<jats:p>…</jats:p>). Reduce to plain
+    text and drop a redundant leading 'Abstract' heading."""
+    if not s:
+        return ""
+    text = html.unescape(re.sub(r"<[^>]+>", " ", s))
+    text = re.sub(r"\s+", " ", text).strip()
+    return re.sub(r"^abstract[:\s]+", "", text, flags=re.IGNORECASE).strip()
+
+
+def _format_authors(authors) -> str:
+    if not isinstance(authors, list):
+        return ""
+    names = []
+    for a in authors[:8]:
+        if isinstance(a, dict):
+            name = " ".join(p for p in (a.get("given"), a.get("family")) if p).strip()
+            if name:
+                names.append(name)
+    return ", ".join(names)
+
+
+def _crossref_fetch(doi: str) -> dict | None:
+    """Title + abstract + authors for a DOI from Crossref (free, no key)."""
+    try:
+        resp = requests.get(
+            f"https://api.crossref.org/works/{quote(doi, safe='/')}",
+            headers={"User-Agent": f"filter-fyi/1.0 (mailto:{CONTACT_EMAIL})"},
+            timeout=10,
+        )
+    except Exception as e:
+        logger.info("Crossref fetch failed for %s: %s", doi, e)
+        return None
+    if resp.status_code != 200:
+        return None
+    try:
+        msg = resp.json().get("message", {})
+    except Exception:
+        return None
+    title = " ".join(t for t in (msg.get("title") or []) if t).strip() or None
+    return {
+        "title": title,
+        "abstract": _strip_jats(msg.get("abstract", "")) or None,
+        "authors": _format_authors(msg.get("author")),
+    }
+
+
+def _unpaywall_oa_url(doi: str) -> str | None:
+    """Open-access full-text URL for a DOI from Unpaywall, or None."""
+    try:
+        resp = requests.get(
+            f"https://api.unpaywall.org/v2/{quote(doi, safe='/')}",
+            params={"email": CONTACT_EMAIL},
+            timeout=10,
+        )
+    except Exception as e:
+        logger.info("Unpaywall fetch failed for %s: %s", doi, e)
+        return None
+    if resp.status_code != 200:
+        return None
+    try:
+        loc = (resp.json() or {}).get("best_oa_location") or {}
+    except Exception:
+        return None
+    return loc.get("url_for_pdf") or loc.get("url") or None
+
+
+async def _academic_fetch(url: str, doi: str) -> dict | None:
+    """Best-effort content for a walled academic article via scholarly APIs.
+    Prefers Unpaywall open-access full text, falls back to the Crossref
+    abstract. Returns None when neither yields text (caller keeps the wall)."""
+    loop = asyncio.get_running_loop()
+
+    # 1. Open-access full text (PubMed Central, repositories, publisher OA).
+    oa_url = await loop.run_in_executor(None, _unpaywall_oa_url, doi)
+    if oa_url:
+        try:
+            assert_public_url(oa_url)  # OA URL is attacker-influenceable via the API
+            is_pdf = oa_url.split("?")[0].lower().endswith(".pdf")
+            oa = await (_pdf_fetch(oa_url) if is_pdf else _generic_fetch(oa_url))
+            if oa.get("text", "").strip():
+                oa["source_type"] = "academic"
+                logger.info("Academic OA full text recovered for DOI %s via %s", doi, oa_url)
+                return oa
+        except BlockedURLError as e:
+            logger.info("Unpaywall OA URL blocked for %s: %s", doi, e)
+        except Exception as e:
+            logger.info("Unpaywall OA fetch failed for %s (%s): %s", doi, oa_url, e)
+
+    # 2. Crossref abstract — thin, but real content and enough for a verdict.
+    meta = await loop.run_in_executor(None, _crossref_fetch, doi)
+    if meta and meta.get("abstract"):
+        title = meta.get("title") or url
+        header = title if not meta.get("authors") else f"{title}\nBy: {meta['authors']}"
+        logger.info("Academic abstract recovered for DOI %s via Crossref", doi)
+        return {
+            "text": f"{header}\n\nAbstract:\n{meta['abstract']}"[:MAX_CONTENT_CHARS],
+            "title": title,
+            "source_type": "academic",
+        }
+    return None
+
+
 async def _fetch_url_uncached(url: str) -> dict:
     """The actual routing logic — keep this as the only place that knows the
     source-specific fetchers. `fetch_url` is the cache layer in front."""
@@ -679,4 +812,21 @@ async def _fetch_url_uncached(url: str) -> dict:
     # not a crawler indexing the site. (Same distinction Google draws for its
     # user-triggered fetchers.) SSRF guard, rate limits and summary-only
     # retention still apply.
-    return await _generic_fetch(url)
+    result = await _generic_fetch(url)
+
+    # If the page walled us (Springer/Wiley/… JS- or login-gate) and the URL
+    # carries a DOI, try open scholarly APIs for an abstract or open-access
+    # copy before surfacing the wall. Only on failure modes — a good extract
+    # is left untouched so non-walled sites keep their full text.
+    if result.get("reason") in (
+        fetch_errors.JS_REQUIRED,
+        fetch_errors.PAYWALLED,
+        fetch_errors.NO_TEXT_EXTRACTED,
+    ):
+        doi = _extract_doi(url)
+        if doi:
+            logger.info("Article walled (%s); trying scholarly APIs for DOI %s", result["reason"], doi)
+            academic = await _academic_fetch(url, doi)
+            if academic:
+                return academic
+    return result

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -314,3 +314,183 @@ class TestRobots:
         assert not hasattr(fetcher, "_robots_allows")
         assert not hasattr(fetcher, "_robots_parser_for")
         assert not hasattr(fetch_errors, "BLOCKED_BY_ROBOTS")
+
+
+class TestDOIExtraction:
+    def test_springer_article_url(self):
+        from bot import fetcher
+        assert fetcher._extract_doi(
+            "https://link.springer.com/article/10.1007/s00146-026-03095-6"
+        ) == "10.1007/s00146-026-03095-6"
+
+    def test_doi_org_url(self):
+        from bot import fetcher
+        assert fetcher._extract_doi("https://doi.org/10.1086/681238") == "10.1086/681238"
+
+    def test_trailing_page_suffix_is_trimmed(self):
+        from bot import fetcher
+        assert fetcher._extract_doi(
+            "https://onlinelibrary.wiley.com/doi/10.1111/jne.12345/full"
+        ) == "10.1111/jne.12345"
+
+    def test_query_string_is_ignored(self):
+        from bot import fetcher
+        assert fetcher._extract_doi(
+            "https://example.com/article/10.1007/abc123?utm_source=x"
+        ) == "10.1007/abc123"
+
+    def test_non_academic_url_returns_none(self):
+        from bot import fetcher
+        assert fetcher._extract_doi("https://example.com/blog/some-post") is None
+
+
+class TestJatsAndAuthors:
+    def test_strip_jats_removes_tags_and_heading(self):
+        from bot import fetcher
+        raw = "<jats:title>Abstract</jats:title><jats:p>Hello &amp; welcome.</jats:p>"
+        assert fetcher._strip_jats(raw) == "Hello & welcome."
+
+    def test_strip_jats_empty(self):
+        from bot import fetcher
+        assert fetcher._strip_jats("") == ""
+
+    def test_format_authors(self):
+        from bot import fetcher
+        authors = [{"given": "Ada", "family": "Lovelace"}, {"family": "Turing"}]
+        assert fetcher._format_authors(authors) == "Ada Lovelace, Turing"
+
+    def test_format_authors_non_list(self):
+        from bot import fetcher
+        assert fetcher._format_authors(None) == ""
+
+
+class TestCrossref:
+    def _resp(self, status, payload):
+        r = MagicMock()
+        r.status_code = status
+        r.json.return_value = payload
+        return r
+
+    def test_returns_title_abstract_authors(self, monkeypatch):
+        from bot import fetcher
+        payload = {
+            "message": {
+                "title": ["On Computable Numbers"],
+                "abstract": "<jats:p>A study of decidability.</jats:p>",
+                "author": [{"given": "Alan", "family": "Turing"}],
+            }
+        }
+        monkeypatch.setattr(fetcher.requests, "get", lambda *a, **k: self._resp(200, payload))
+        meta = fetcher._crossref_fetch("10.1112/plms/s2-42.1.230")
+        assert meta["title"] == "On Computable Numbers"
+        assert meta["abstract"] == "A study of decidability."
+        assert meta["authors"] == "Alan Turing"
+
+    def test_non_200_returns_none(self, monkeypatch):
+        from bot import fetcher
+        monkeypatch.setattr(fetcher.requests, "get", lambda *a, **k: self._resp(404, {}))
+        assert fetcher._crossref_fetch("10.0/nope") is None
+
+
+class TestAcademicFetch:
+    def test_prefers_unpaywall_oa_full_text(self, monkeypatch):
+        from bot import fetcher
+
+        monkeypatch.setattr(fetcher, "_unpaywall_oa_url", lambda doi: "https://repo.org/paper.pdf")
+        monkeypatch.setattr(fetcher, "assert_public_url", lambda u: None)
+
+        async def _pdf(u):
+            return {"text": "full open-access body", "title": "Paper", "source_type": "pdf"}
+
+        monkeypatch.setattr(fetcher, "_pdf_fetch", _pdf)
+        # Crossref shouldn't be needed when OA full text is found.
+        monkeypatch.setattr(fetcher, "_crossref_fetch", lambda doi: (_ for _ in ()).throw(AssertionError("should not call")))
+
+        result = asyncio.run(fetcher._academic_fetch("https://pub/10.1/x", "10.1/x"))
+        assert result["text"] == "full open-access body"
+        assert result["source_type"] == "academic"
+
+    def test_falls_back_to_crossref_abstract(self, monkeypatch):
+        from bot import fetcher
+
+        monkeypatch.setattr(fetcher, "_unpaywall_oa_url", lambda doi: None)
+        monkeypatch.setattr(
+            fetcher, "_crossref_fetch",
+            lambda doi: {"title": "Walled Paper", "abstract": "The abstract.", "authors": "A. Author"},
+        )
+        result = asyncio.run(fetcher._academic_fetch("https://pub/10.1/x", "10.1/x"))
+        assert result["source_type"] == "academic"
+        assert result["title"] == "Walled Paper"
+        assert "The abstract." in result["text"]
+        assert "By: A. Author" in result["text"]
+
+    def test_returns_none_when_nothing_found(self, monkeypatch):
+        from bot import fetcher
+        monkeypatch.setattr(fetcher, "_unpaywall_oa_url", lambda doi: None)
+        monkeypatch.setattr(fetcher, "_crossref_fetch", lambda doi: None)
+        assert asyncio.run(fetcher._academic_fetch("https://pub/10.1/x", "10.1/x")) is None
+
+    def test_oa_url_blocked_falls_through_to_abstract(self, monkeypatch):
+        from bot import fetcher
+        from bot.ssrf import BlockedURLError
+
+        monkeypatch.setattr(fetcher, "_unpaywall_oa_url", lambda doi: "http://169.254.169.254/x")
+
+        def _block(u):
+            raise BlockedURLError("private")
+
+        monkeypatch.setattr(fetcher, "assert_public_url", _block)
+        monkeypatch.setattr(fetcher, "_crossref_fetch", lambda doi: {"title": "P", "abstract": "Safe abstract.", "authors": ""})
+        result = asyncio.run(fetcher._academic_fetch("https://pub/10.1/x", "10.1/x"))
+        assert "Safe abstract." in result["text"]
+
+
+class TestArticleAcademicWiring:
+    def test_walled_article_with_doi_uses_academic_fallback(self, monkeypatch):
+        from bot import fetcher
+
+        monkeypatch.setattr(fetcher, "assert_public_url", lambda u: None)
+
+        async def _walled(u):
+            return {"text": "", "title": u, "source_type": "article", "reason": fetcher.fetch_errors.JS_REQUIRED}
+
+        async def _academic(url, doi):
+            return {"text": "abstract body", "title": "T", "source_type": "academic"}
+
+        monkeypatch.setattr(fetcher, "_generic_fetch", _walled)
+        monkeypatch.setattr(fetcher, "_academic_fetch", _academic)
+        result = asyncio.run(
+            fetcher._fetch_url_uncached("https://link.springer.com/article/10.1007/s00146-026-03095-6")
+        )
+        assert result["source_type"] == "academic"
+        assert result["text"] == "abstract body"
+
+    def test_good_extract_does_not_trigger_academic(self, monkeypatch):
+        from bot import fetcher
+
+        monkeypatch.setattr(fetcher, "assert_public_url", lambda u: None)
+
+        async def _good(u):
+            return {"text": "a real full article body", "title": "T", "source_type": "article"}
+
+        monkeypatch.setattr(fetcher, "_generic_fetch", _good)
+        monkeypatch.setattr(
+            fetcher, "_academic_fetch",
+            lambda url, doi: (_ for _ in ()).throw(AssertionError("must not call academic on good extract")),
+        )
+        result = asyncio.run(
+            fetcher._fetch_url_uncached("https://link.springer.com/article/10.1007/s00146-026-03095-6")
+        )
+        assert result["text"] == "a real full article body"
+
+    def test_walled_article_without_doi_keeps_wall(self, monkeypatch):
+        from bot import fetcher
+
+        monkeypatch.setattr(fetcher, "assert_public_url", lambda u: None)
+
+        async def _walled(u):
+            return {"text": "", "title": u, "source_type": "article", "reason": fetcher.fetch_errors.PAYWALLED}
+
+        monkeypatch.setattr(fetcher, "_generic_fetch", _walled)
+        result = asyncio.run(fetcher._fetch_url_uncached("https://nytimes.com/2026/some-story"))
+        assert result["reason"] == fetcher.fetch_errors.PAYWALLED


### PR DESCRIPTION
## Why

Springer/LinkedIn-class pages JS- or login-wall their HTML, so even after dropping the robots gate (#53) a plain fetch just hits a "please enable JavaScript" wall. A headless browser wouldn't reliably help here — these are anti-bot/login walls, not merely JS-render. But **academic** articles carry a DOI in the URL, and that DOI is addressable through free, no-key scholarly APIs that hand back clean content with no scraping.

## What

When the generic article fetch walls (`JS_REQUIRED` / `PAYWALLED` / `NO_TEXT_EXTRACTED`) **and** the URL contains a DOI, fall back to:

1. **Unpaywall** → open-access full text (PMC, repositories, publisher OA), fetched through the existing PDF/generic path.
2. **Crossref** → abstract + title + authors (JATS XML stripped to plain text).

Design notes:
- **Fallback only, never override.** A good extract from the original page is returned untouched, so non-walled sites keep their full text. The DOI path fires solely on wall/empty failure modes.
- **Not crawling.** One identifier-keyed lookup per user request — the same on-behalf-of-user principle as #53.
- **SSRF-guarded.** The OA URL comes from a third-party API, so it's run through `assert_public_url`; a blocked/failed OA fetch falls through to the abstract.
- New `source_type` "academic"; `CONTACT_EMAIL` config (Crossref polite-pool identity + Unpaywall's required email).

## Verified live

Against the exact DOI from the logs — `10.1007/s00146-026-03095-6`:

```
TITLE: Stochastic parrot or not, it is less of a turkey than the colleague two desks over
AUTHORS: Andrea Falegnami, Andrea Tomassi, Michele Levorato, Francesco Costantino
ABSTRACT len: 1614
```

Previously a dead JS wall → now 1.6k chars of analysable abstract.

## Composes with the merged work

- After #53 the article reaches the fetcher instead of being robots-blocked.
- If this fallback still finds nothing (no DOI, or no OA/abstract), #54 surfaces the specific "JS wall — paste the text" message instead of a generic error.

## Tests

DOI extraction (publisher URLs, doi.org, suffix trimming, query strings, negatives), JATS/author formatting, Crossref parse + 404, fallback ordering (OA full text > abstract > None), SSRF-blocked OA URL → abstract, and article-branch wiring (walled+DOI → fallback; good extract & walled-without-DOI left untouched). **240 pass.**

## Follow-up (not in this PR)

Headless/managed browser rendering as an optional tier-3 for genuinely JS-rendered-but-not-walled sites — parked as a separate decision; it doesn't help the anti-bot/login walls that motivated this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)