### PR TITLE
fix(youtube): summarise in the spoken language, not the first-listed caption track

### DIFF
--- a/bot/fetcher.py
+++ b/bot/fetcher.py
@@ -54,6 +54,41 @@ def _youtube_oembed_title(url: str) -> str | None:
 _WHISPER_FALLBACK_MAX_DURATION_S = 180
 
 
+def _lang_base(code: str) -> str:
+    """Bare language subtag, e.g. 'en-US' / 'en-GB' → 'en', 'zh-Hans' → 'zh'."""
+    return (code or "").split("-")[0].lower()
+
+
+def _select_transcript(transcripts: list):
+    """Choose which caption track to summarise from.
+
+    Creators often upload many *manual translation* tracks (this video has 20+:
+    Arabic, Bulgarian, Chinese, …). Naively taking the first manual track picks
+    whichever language YouTube lists first — alphabetically Arabic — so an
+    English video gets summarised in Arabic (issue #57).
+
+    The auto-generated (ASR) track is transcribed from the actual audio, so its
+    language is the video's spoken language. Anchor on it: prefer the manual
+    track in that language (human-authored, cleaner), then the ASR track
+    itself. Only when there's no ASR track to anchor on do we fall back to a
+    manual track — English first (the common original), else whatever's listed
+    first — and finally any generated track.
+    """
+    generated = next((t for t in transcripts if t.is_generated), None)
+    manuals = [t for t in transcripts if not t.is_generated]
+
+    original_lang = generated.language_code if generated else None
+    if original_lang:
+        manual_in_original = next(
+            (t for t in manuals if _lang_base(t.language_code) == _lang_base(original_lang)),
+            None,
+        )
+        return manual_in_original or generated
+
+    english_manual = next((t for t in manuals if _lang_base(t.language_code) == "en"), None)
+    return english_manual or (manuals[0] if manuals else None) or generated
+
+
 def _youtube_transcript(url: str) -> dict:
     from youtube_transcript_api import YouTubeTranscriptApi
 
@@ -65,15 +100,14 @@ def _youtube_transcript(url: str) -> dict:
     thumb = _youtube_thumbnail(video_id)
     try:
         api = YouTubeTranscriptApi()
-        # Enumerate every available transcript instead of forcing 'en'. Prefer
-        # manually-created over auto-generated, but DON'T translate — keep the
-        # source language so the LLM summarises in the speaker's tongue. The
-        # previous `api.fetch(video_id)` defaulted to English and silently
-        # dropped to yt-dlp for every non-English-captioned video.
+        # Enumerate every available transcript and pick the one in the video's
+        # spoken language (see _select_transcript) — never translate, so the LLM
+        # summarises in the speaker's tongue. We don't force 'en' (that silently
+        # dropped non-English-captioned videos to yt-dlp) nor take the first
+        # manual track (that summarised multi-subtitle videos in a random
+        # language — issue #57).
         transcripts = list(api.list(video_id))
-        manual = next((t for t in transcripts if not t.is_generated), None)
-        generated = next((t for t in transcripts if t.is_generated), None)
-        transcript = manual or generated
+        transcript = _select_transcript(transcripts)
         if transcript is not None:
             fetched = transcript.fetch()
             text = " ".join(snippet.text for snippet in fetched)

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -44,11 +44,11 @@ class TestYouTubeFallbackChain:
         assert result["language"] == "en"
 
     def test_prefers_manual_over_auto_generated_transcript(self):
-        """When both manual and auto-generated transcripts exist, the manually
-        created one wins — it's usually higher fidelity (real captions vs. ASR)."""
+        """When manual and auto-generated transcripts exist *in the spoken
+        language*, the manually created one wins — higher fidelity than ASR."""
         from bot import fetcher
 
-        manual = self._mock_transcript(language_code="de", is_generated=False, snippets=("manual",))
+        manual = self._mock_transcript(language_code="en", is_generated=False, snippets=("manual",))
         auto = self._mock_transcript(language_code="en", is_generated=True, snippets=("auto",))
         with patch("youtube_transcript_api.YouTubeTranscriptApi") as TranscriptApi, \
              patch.object(fetcher, "_youtube_oembed_title", return_value="t"):
@@ -58,7 +58,42 @@ class TestYouTubeFallbackChain:
 
         assert "manual" in result["text"]
         assert "auto" not in result["text"]
-        assert result["language"] == "de"
+        assert result["language"] == "en"
+
+    def test_picks_spoken_language_not_first_listed_manual(self):
+        """Issue #57: a video with many manual *translation* tracks (Arabic
+        first, alphabetically) plus an English ASR track is English-spoken — we
+        must summarise the English manual track, not the first-listed Arabic."""
+        from bot import fetcher
+
+        ar = self._mock_transcript(language_code="ar", is_generated=False, snippets=("arabic",))
+        en = self._mock_transcript(language_code="en", is_generated=False, snippets=("english",))
+        fr = self._mock_transcript(language_code="fr", is_generated=False, snippets=("french",))
+        en_auto = self._mock_transcript(language_code="en", is_generated=True, snippets=("asr",))
+        with patch("youtube_transcript_api.YouTubeTranscriptApi") as TranscriptApi, \
+             patch.object(fetcher, "_youtube_oembed_title", return_value="t"):
+            TranscriptApi.return_value.list.return_value = [ar, fr, en, en_auto]
+            result = fetcher._youtube_transcript(YOUTUBE_URL)
+
+        assert "english" in result["text"]
+        assert "arabic" not in result["text"]
+        assert result["language"] == "en"
+
+    def test_anchors_on_asr_language_for_non_english_video(self):
+        """A French-spoken video (French ASR) with Arabic + French manual tracks
+        picks the French manual — not the first-listed Arabic, not English."""
+        from bot import fetcher
+
+        ar = self._mock_transcript(language_code="ar", is_generated=False, snippets=("arabic",))
+        fr = self._mock_transcript(language_code="fr", is_generated=False, snippets=("francais",))
+        fr_auto = self._mock_transcript(language_code="fr", is_generated=True, snippets=("asr",))
+        with patch("youtube_transcript_api.YouTubeTranscriptApi") as TranscriptApi, \
+             patch.object(fetcher, "_youtube_oembed_title", return_value="t"):
+            TranscriptApi.return_value.list.return_value = [ar, fr, fr_auto]
+            result = fetcher._youtube_transcript(YOUTUBE_URL)
+
+        assert "francais" in result["text"]
+        assert result["language"] == "fr"
 
     def test_uses_non_english_auto_generated_when_thats_all_there_is(self):
         """A German-only auto-generated transcript should be picked up (regression


### PR DESCRIPTION
Closes #57.

## Problem
`https://www.youtube.com/watch?v=LUgKKvJdcZo` is an English video, but the summary came back in **Arabic**.

The video has 20+ **manually-uploaded translation** caption tracks (Arabic, Bulgarian, Chinese, … English, French, …). `_youtube_transcript` took the *first manual track*, and YouTube lists them alphabetically → **Arabic**. So the transcript — and the whole downstream summary/analysis — was Arabic.

## Fix
The auto-generated (ASR) track is transcribed from the actual audio, so its language is the video's **spoken** language. New `_select_transcript()`:

1. Anchor on the ASR track's language.
2. Prefer the **manual** track in that language (human-authored > ASR).
3. Else the ASR track itself.
4. Only when there's no ASR track to anchor on: fall back to a manual track — English first (the common original), else first listed.

For this video that yields the English manual track (verified live: `language: en`, English text). Preserves the earlier behaviour that keeps genuinely non-English videos in their own language (a French-spoken video with French + Arabic manual tracks now correctly picks French, not Arabic and not English).

## Tests
242 pass, incl. updated `test_prefers_manual_over_auto_generated_transcript` (now same-language, its real intent) and two new regression tests: the #57 multi-translation case and the non-English-anchor case.

## Note
Overlaps `_youtube_transcript` with #51 (tiered transcription). Whichever merges second needs a trivial rebase of that one selection block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)