### PR TITLE
fix(transcribe): bound audio download size for long-video transcription

### DIFF
--- a/bot/fetcher.py
+++ b/bot/fetcher.py
@@ -388,8 +388,13 @@ def _yt_dlp_transcribe(url: str) -> dict:
 
     ydl_opts = {
         "quiet": True,
-        "format": "bestaudio/best",
-        "postprocessors": [{"key": "FFmpegExtractAudio", "preferredcodec": "mp3"}],
+        # Prefer a low-bitrate audio stream (YouTube's ~50 kbps Opus) over the
+        # 160 kbps default: Whisper only needs 16 kHz speech, so the high
+        # bitrate buys nothing and a 2 h best-quality download is 100 MB+ of
+        # transient disk on the 1 GB box. We also drop the FFmpegExtractAudio
+        # re-encode — the transcriber does a single transcode to the compact
+        # upload format, so a second high-quality intermediate is pure waste.
+        "format": "ba[abr<=64]/ba/b",
         "outtmpl": "audio.%(ext)s",
     }
     try:
@@ -400,8 +405,10 @@ def _yt_dlp_transcribe(url: str) -> dict:
             if not info:
                 raise ValueError("yt-dlp returned no info")
 
+            # We didn't re-encode, so the file keeps its native extension
+            # (.webm/.m4a/.opus). Grab whatever single media file landed.
             audio_file = next(
-                (os.path.join(tmpdir, f) for f in os.listdir(tmpdir) if f.endswith(".mp3")),
+                (os.path.join(tmpdir, f) for f in sorted(os.listdir(tmpdir)) if f.startswith("audio.")),
                 None,
             )
             if not audio_file:

--- a/bot/transcriber.py
+++ b/bot/transcriber.py
@@ -39,6 +39,10 @@ else:
 # with no meaningful accuracy loss on speech.
 _UPLOAD_TARGET_HZ = 16_000
 _UPLOAD_OPUS_BITRATE = "16k"
+# Hard ceiling checked before upload. At 16 kbps Opus this is ~3.4 h of audio —
+# beyond the 2 h signed-in cap — so it never trips in normal use; it just turns
+# a pathological case into a clean WHISPER_FAILED instead of a provider 413.
+_MAX_UPLOAD_BYTES = 24 * 1024 * 1024
 
 _model = None
 _hosted_client = None
@@ -95,6 +99,12 @@ def _transcribe_hosted(file_path: str) -> str:
     client = _get_hosted_client()
     upload_path = _compress_for_upload(file_path)
     try:
+        size = os.path.getsize(upload_path)
+        if size > _MAX_UPLOAD_BYTES:
+            raise ValueError(
+                f"compressed audio {size / 1e6:.1f} MB exceeds the "
+                f"{_MAX_UPLOAD_BYTES / 1e6:.0f} MB upload limit"
+            )
         with open(upload_path, "rb") as f:
             resp = client.audio.transcriptions.create(
                 model=_HOSTED_MODEL,

--- a/tests/test_transcriber.py
+++ b/tests/test_transcriber.py
@@ -65,3 +65,24 @@ def test_hosted_upload_compresses_and_cleans_up(tmp_path):
     # The compressed temp upload is removed; the original is left to its caller.
     assert not compressed.exists()
     assert src.exists()
+
+
+def test_hosted_rejects_oversize_upload_and_cleans_up(tmp_path):
+    src = tmp_path / "audio.mp3"
+    src.write_bytes(b"fake-audio")
+    compressed = tmp_path / "big.ogg"
+    compressed.write_bytes(b"x" * (transcriber._MAX_UPLOAD_BYTES + 1))
+
+    fake_client = MagicMock()
+
+    with patch.object(transcriber, "_get_hosted_client", return_value=fake_client), \
+         patch.object(transcriber, "_compress_for_upload", return_value=str(compressed)):
+        try:
+            transcriber._transcribe_hosted(str(src))
+            assert False, "expected oversize upload to raise"
+        except ValueError:
+            pass
+
+    # We bail before hitting the provider, and still clean up the temp upload.
+    fake_client.audio.transcriptions.create.assert_not_called()
+    assert not compressed.exists()


### PR DESCRIPTION
Closes #52.

## Problem
`_yt_dlp_transcribe` downloaded **bestaudio** (~160 kbps) and re-encoded it to a high-quality MP3, which `bot/transcriber.py` then re-encoded **again** to 16 kHz mono Opus for upload. On the 1 GB Fly box a 2 h video was ~100 MB+ of transient disk plus two redundant transcodes — and Whisper only needs 16 kHz speech, so the high bitrate bought nothing.

## Changes
- **Low-bitrate source:** `format: "ba[abr<=64]/ba/b"` — prefer YouTube's ~50 kbps Opus audio stream, falling back to bestaudio then best. ~3× smaller download.
- **No MP3 intermediate:** dropped the `FFmpegExtractAudio` postprocessor; the native audio file (`.webm`/`.m4a`/`.opus`) goes straight to the transcriber's single Opus pass. One transcode instead of two.
- **Upload-size guard:** `_transcribe_hosted` bails with `WHISPER_FAILED` if the compressed file still exceeds 24 MB (the provider cap), turning a pathological case into a clean error instead of a 413. At 16 kbps Opus that's ~3.4 h of audio — beyond the 2 h signed-in cap, so it never trips in normal use.

## Verification
- Real end-to-end run (`_yt_dlp_transcribe` → Groq) on a short video returns an accurate transcript with the new no-MP3 / native-extension path.
- 251 tests pass, incl. a new oversize-upload guard test.

## Note
Local yt-dlp can't show the win directly — without an EJS challenge solver it only sees the muxed 360p format, so the `abr<=64` filter falls through to the muxed stream locally. Production has `nodejs` (Dockerfile) and sees the full DASH format list, where the low-bitrate Opus selection applies. The change is an improvement in both cases (the dropped MP3 re-encode helps even in the degraded fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)