### PR TITLE
feat: processed_urls audit log + /api/admin/usage-overview endpoint

### DIFF
--- a/bot/admin.py
+++ b/bot/admin.py
@@ -356,3 +356,175 @@ async def cost_overview_endpoint(
     rendering — see `cost_overview()` for the full shape.
     """
     return cost_overview(days)
+
+
+_USAGE_LIST_DEFAULT_LIMIT = 50
+_USAGE_LIST_MAX_LIMIT = 200
+
+
+def usage_overview(days: int, limit: int, offset: int) -> dict:
+    """Activity rollup from `processed_urls` plus a paginated row list.
+
+    Returned shape:
+
+        {
+          "range_days": int,
+          "as_of": ISO-8601 UTC,
+          "kpis": {
+            "total": int,        # all URLs processed in window
+            "ok": int,
+            "errors": int,
+            "error_rate": float
+          },
+          "by_source_type": [{source_type, total, ok, errors}, ...],
+          "by_error_code":  [{error_code, count}, ...],
+          "transcript_sources": [{source, count}, ...],   # for video URLs
+                                                          # 'youtube' | 'whisper'
+                                                          # | 'description' | 'none'
+          "rows": [{ts, url, title, source_type, user_id, anon_id, status,
+                    error_code, transcript_source, latency_ms}, ...],
+          "total_rows": int,    # for pagination
+          "limit": int, "offset": int
+        }
+    """
+    since = _since_iso(days)
+    with _get_conn() as conn:
+        kpi_row = conn.execute(
+            """
+            SELECT
+                COUNT(*)                                                AS total,
+                SUM(CASE WHEN status='ok'    THEN 1 ELSE 0 END)         AS ok,
+                SUM(CASE WHEN status='error' THEN 1 ELSE 0 END)         AS errors
+            FROM processed_urls
+            WHERE ts >= ?
+            """,
+            (since,),
+        ).fetchone()
+
+        source_rows = conn.execute(
+            """
+            SELECT
+                COALESCE(NULLIF(source_type, ''), '(unknown)') AS source_type,
+                COUNT(*)                                       AS total,
+                SUM(CASE WHEN status='ok'    THEN 1 ELSE 0 END) AS ok,
+                SUM(CASE WHEN status='error' THEN 1 ELSE 0 END) AS errors
+            FROM processed_urls
+            WHERE ts >= ?
+            GROUP BY source_type
+            ORDER BY total DESC
+            """,
+            (since,),
+        ).fetchall()
+
+        # Error codes (non-empty only) — top failure modes.
+        error_rows = conn.execute(
+            """
+            SELECT error_code, COUNT(*) AS count
+            FROM processed_urls
+            WHERE ts >= ? AND status = 'error' AND error_code != ''
+            GROUP BY error_code
+            ORDER BY count DESC
+            """,
+            (since,),
+        ).fetchall()
+
+        # Transcript source split — drives the Whisper-vs-YouTube question.
+        # Filter to video source types so the denominator is meaningful.
+        transcript_rows = conn.execute(
+            """
+            SELECT
+                COALESCE(NULLIF(transcript_source, ''), '(none)') AS source,
+                COUNT(*)                                          AS count
+            FROM processed_urls
+            WHERE ts >= ? AND source_type IN ('youtube', 'video')
+            GROUP BY transcript_source
+            ORDER BY count DESC
+            """,
+            (since,),
+        ).fetchall()
+
+        # Paginated list of recent rows. Total is window-wide for the
+        # "showing X of N" UX in the table.
+        total_rows_row = conn.execute(
+            "SELECT COUNT(*) AS n FROM processed_urls WHERE ts >= ?", (since,),
+        ).fetchone()
+
+        list_rows = conn.execute(
+            """
+            SELECT id, ts, url, title, source_type, user_id, anon_id,
+                   status, error_code, transcript_source, latency_ms
+            FROM processed_urls
+            WHERE ts >= ?
+            ORDER BY ts DESC, id DESC
+            LIMIT ? OFFSET ?
+            """,
+            (since, limit, offset),
+        ).fetchall()
+
+    total = kpi_row["total"] or 0
+    errors = kpi_row["errors"] or 0
+    error_rate = (errors / total) if total > 0 else 0.0
+
+    return {
+        "range_days": days,
+        "as_of": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "kpis": {
+            "total": total,
+            "ok": kpi_row["ok"] or 0,
+            "errors": errors,
+            "error_rate": round(error_rate, 4),
+        },
+        "by_source_type": [
+            {
+                "source_type": r["source_type"],
+                "total": r["total"],
+                "ok": r["ok"] or 0,
+                "errors": r["errors"] or 0,
+            }
+            for r in source_rows
+        ],
+        "by_error_code": [
+            {"error_code": r["error_code"], "count": r["count"]}
+            for r in error_rows
+        ],
+        "transcript_sources": [
+            {"source": r["source"], "count": r["count"]}
+            for r in transcript_rows
+        ],
+        "rows": [
+            {
+                "id": r["id"],
+                "ts": r["ts"],
+                "url": r["url"],
+                "title": r["title"],
+                "source_type": r["source_type"],
+                "user_id": r["user_id"],
+                "anon_id": r["anon_id"],
+                "status": r["status"],
+                "error_code": r["error_code"],
+                "transcript_source": r["transcript_source"],
+                "latency_ms": r["latency_ms"],
+            }
+            for r in list_rows
+        ],
+        "total_rows": total_rows_row["n"] or 0,
+        "limit": limit,
+        "offset": offset,
+    }
+
+
+@router.get("/usage-overview")
+async def usage_overview_endpoint(
+    days: int = Query(default=_DEFAULT_DAYS, ge=1, le=_MAX_DAYS),
+    limit: int = Query(default=_USAGE_LIST_DEFAULT_LIMIT, ge=1, le=_USAGE_LIST_MAX_LIMIT),
+    offset: int = Query(default=0, ge=0),
+    _: None = Depends(_require_admin_secret),
+) -> dict:
+    """Activity rollup + paginated URL list from `processed_urls`.
+
+    Powers the Usage pillar of the admin dashboard. Includes transcript-
+    source split (YouTube captions vs Whisper vs description fallback) so
+    operators can see how much video traffic is going through the expensive
+    Whisper path. See `usage_overview()` for the full response shape.
+    """
+    return usage_overview(days, limit, offset)

--- a/bot/db.py
+++ b/bot/db.py
@@ -112,6 +112,9 @@ _CREATE_INDEXES_SQL = [
     "CREATE INDEX IF NOT EXISTS idx_llm_cache_created_at ON llm_cache(created_at)",
     "CREATE INDEX IF NOT EXISTS idx_llm_cache_hits_ts ON llm_cache_hits(ts DESC)",
     "CREATE INDEX IF NOT EXISTS idx_llm_cache_hits_purpose ON llm_cache_hits(purpose, ts DESC)",
+    "CREATE INDEX IF NOT EXISTS idx_processed_urls_ts ON processed_urls(ts DESC)",
+    "CREATE INDEX IF NOT EXISTS idx_processed_urls_user ON processed_urls(user_id, ts DESC)",
+    "CREATE INDEX IF NOT EXISTS idx_processed_urls_status ON processed_urls(status, ts DESC)",
 ]
 
 # Per-call LLM usage log. One row per upstream API call (analyze, summary,
@@ -239,6 +242,34 @@ CREATE TABLE IF NOT EXISTS llm_cache_hits (
 # dashboard's longest window.
 LLM_CACHE_HITS_RETENTION_SECONDS = 30 * 24 * 3_600
 
+# Audit log of every URL that went through `bot.pipeline.analyze_url`.
+# Populated on success and on failure — the failure rows let the dashboard
+# show "URLs we tried, why we couldn't" without joining `error_log`. The
+# `transcript_source` column captures whether a video used the YouTube-
+# provided captions vs Whisper vs description fallback, which is the main
+# driver of cost variability on video traffic. Metadata-only — full content
+# stays in `items` / `llm_cache`.
+_CREATE_PROCESSED_URLS_SQL = """\
+CREATE TABLE IF NOT EXISTS processed_urls (
+    id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts                 TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%S', 'now')),
+    url                TEXT    NOT NULL,
+    title              TEXT    NOT NULL DEFAULT '',
+    source_type        TEXT    NOT NULL DEFAULT '',
+    user_id            INTEGER,
+    anon_id            TEXT,
+    job_id             TEXT,
+    status             TEXT    NOT NULL DEFAULT 'ok',
+    error_code         TEXT    NOT NULL DEFAULT '',
+    transcript_source  TEXT    NOT NULL DEFAULT '',
+    latency_ms         INTEGER NOT NULL DEFAULT 0
+)"""
+
+# 90 days — longer than other audit tables because this one drives the
+# Usage pillar's headline counts and we want a quarterly-ish window
+# available without re-collecting.
+PROCESSED_URLS_RETENTION_SECONDS = 90 * 24 * 3_600
+
 # Allowed feedback signals. Explicit taps + cheap implicit proxies. Kept as an
 # allowlist so the data stays clean enough to learn from.
 FEEDBACK_SIGNALS = frozenset({
@@ -348,6 +379,7 @@ def _init() -> None:
         conn.execute(_CREATE_PROCESSED_UPDATES_SQL)
         conn.execute(_CREATE_LLM_CACHE_SQL)
         conn.execute(_CREATE_LLM_CACHE_HITS_SQL)
+        conn.execute(_CREATE_PROCESSED_URLS_SQL)
         for stmt in _CREATE_INDEXES_SQL:
             conn.execute(stmt)
 
@@ -696,6 +728,7 @@ def prune_maintenance(now=None) -> dict:
     updates_cutoff = _ts(now - timedelta(seconds=PROCESSED_UPDATES_RETENTION_SECONDS))
     llm_cache_cutoff = _ts(now - timedelta(seconds=LLM_CACHE_TTL_SECONDS))
     llm_cache_hits_cutoff = _ts(now - timedelta(seconds=LLM_CACHE_HITS_RETENTION_SECONDS))
+    processed_urls_cutoff = _ts(now - timedelta(seconds=PROCESSED_URLS_RETENTION_SECONDS))
     with _get_conn() as conn:
         errors = conn.execute("DELETE FROM error_log WHERE ts < ?", (err_cutoff,)).rowcount or 0
         cache = conn.execute(
@@ -718,10 +751,13 @@ def prune_maintenance(now=None) -> dict:
         llm_cache_hits = conn.execute(
             "DELETE FROM llm_cache_hits WHERE ts < ?", (llm_cache_hits_cutoff,)
         ).rowcount or 0
+        processed_urls = conn.execute(
+            "DELETE FROM processed_urls WHERE ts < ?", (processed_urls_cutoff,)
+        ).rowcount or 0
     return {
         "error_log": errors, "url_cache": cache, "link_codes": codes,
         "jobs": jobs, "processed_updates": updates, "llm_cache": llm_cache,
-        "llm_cache_hits": llm_cache_hits,
+        "llm_cache_hits": llm_cache_hits, "processed_urls": processed_urls,
     }
 
 
@@ -862,6 +898,43 @@ def estimate_avg_cost_per_call(purpose: str, lookback_days: int = 7) -> float:
         return float(row["avg_cost"] or 0.0)
     except Exception:
         return 0.0
+
+
+# ---------------------------------------------------------------------------
+# Processed URLs audit log
+# ---------------------------------------------------------------------------
+
+def record_processed_url(
+    *,
+    url: str,
+    title: str = "",
+    source_type: str = "",
+    user_id: int | None = None,
+    anon_id: str | None = None,
+    job_id: str | None = None,
+    status: str = "ok",
+    error_code: str = "",
+    transcript_source: str = "",
+    latency_ms: int = 0,
+) -> None:
+    """Log one URL that went through the pipeline. Best-effort — a DB blip
+    here must NEVER break the analyse path, the audit log is observability,
+    not correctness."""
+    try:
+        with _get_conn() as conn:
+            conn.execute(
+                "INSERT INTO processed_urls "
+                "(url, title, source_type, user_id, anon_id, job_id, "
+                "status, error_code, transcript_source, latency_ms) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    url, title, source_type, user_id, anon_id, job_id,
+                    status, error_code, transcript_source, int(latency_ms),
+                ),
+            )
+    except Exception:
+        import logging as _logging
+        _logging.getLogger(__name__).exception("record_processed_url failed")
 
 
 # ---------------------------------------------------------------------------

--- a/bot/fetcher.py
+++ b/bot/fetcher.py
@@ -126,6 +126,7 @@ def _youtube_transcript(url: str, max_whisper_duration: int = WHISPER_MAX_DURATI
                 "source_type": "youtube",
                 "image_urls": [thumb],
                 "language": transcript.language_code,
+                "transcript_source": "youtube",
             }
     except Exception:
         logger.info(f"No transcript for {video_id}, falling back to yt-dlp")
@@ -136,7 +137,13 @@ def _youtube_transcript(url: str, max_whisper_duration: int = WHISPER_MAX_DURATI
     # If yt-dlp also got us a transcript (or extraction died entirely), use what
     # we have. The Whisper branch only kicks in when we're left with a
     # description-only answer AND the video is short enough.
-    if extract.get("has_transcript") or not extract.get("text"):
+    if extract.get("has_transcript"):
+        extract.setdefault("transcript_source", "youtube")
+        return extract
+    if not extract.get("text"):
+        # Genuine extraction failure (no description either) — pipeline will
+        # surface ERR_NO_TRANSCRIPT. Tag for the audit log.
+        extract.setdefault("transcript_source", "none")
         return extract
 
     duration = extract.get("duration") or 0
@@ -149,14 +156,18 @@ def _youtube_transcript(url: str, max_whisper_duration: int = WHISPER_MAX_DURATI
         if whisper.get("text"):
             whisper["source_type"] = "youtube"
             whisper.setdefault("image_urls", []).append(thumb)
+            whisper["transcript_source"] = "whisper"
             return whisper
         logger.info(f"YouTube {video_id}: Whisper fallback also failed, returning description")
         # Description-only answer: still useful, but mark the limitation.
         extract["reason"] = fetch_errors.WHISPER_FAILED
+        extract["transcript_source"] = "description"
     elif duration > max_whisper_duration:
         extract["reason"] = fetch_errors.VIDEO_TOO_LONG_FOR_WHISPER
+        extract["transcript_source"] = "description"
     else:
         extract["reason"] = fetch_errors.NO_TRANSCRIPT
+        extract["transcript_source"] = "description"
 
     return extract
 

--- a/bot/pipeline.py
+++ b/bot/pipeline.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import logging
+import time
 from dataclasses import dataclass
 from typing import Callable, Optional
 
@@ -40,7 +41,7 @@ from bot.analyzer import (
     summarize_content,
     to_json_str,
 )
-from bot.db import save_item
+from bot.db import record_processed_url, save_item
 from bot.fetcher import fetch_url, whisper_cap_for
 
 logger = logging.getLogger(__name__)
@@ -145,77 +146,109 @@ async def analyze_url(
     if max_whisper_duration is None:
         max_whisper_duration = whisper_cap_for(signed_in=ctx.user_id is not None)
 
-    _step("fetching")
+    # Audit-log bookkeeping. Every successful AND failed call writes one row
+    # to `processed_urls`, so the Usage tile can show "what we tried and how
+    # it went" without joining `error_log`. `fetched` may stay empty (a
+    # fetch failure) or get the partial dict from a downstream error.
+    started = time.monotonic()
+    fetched: dict = {}
+    audit_status = "ok"
+    audit_error_code = ""
+
     try:
-        fetched = await fetch_url(url, max_whisper_duration=max_whisper_duration)
-    except Exception as e:
-        logger.exception("pipeline: fetch_url crashed for %s", url)
-        raise PipelineError(ERR_FETCH_FAILED, message=str(e))
+        _step("fetching")
+        try:
+            fetched = await fetch_url(url, max_whisper_duration=max_whisper_duration)
+        except Exception as e:
+            logger.exception("pipeline: fetch_url crashed for %s", url)
+            raise PipelineError(ERR_FETCH_FAILED, message=str(e))
 
-    text = (fetched.get("text") or "").strip()
-    source_type = fetched.get("source_type") or "article"
-    reason = fetched.get("reason")
+        text = (fetched.get("text") or "").strip()
+        source_type = fetched.get("source_type") or "article"
+        reason = fetched.get("reason")
 
-    # Bail before analysing when there's nothing usable: either no text at all,
-    # or a degraded fetch (`reason` set) whose fallback is just a title-only
-    # stub. Both surface the fetch `reason` to the caller rather than running
-    # the analyser on a thin snippet — see _MIN_ANALYZABLE_CHARS.
-    if not text or (reason and len(text) < _MIN_ANALYZABLE_CHARS):
-        # Distinguish video-with-no-transcript from generic extraction
-        # failure so callers can surface the right UX.
-        code = ERR_NO_TRANSCRIPT if source_type in _VIDEO_SOURCE_TYPES else ERR_NO_TEXT
-        raise PipelineError(code, fetched=fetched)
+        # Bail before analysing when there's nothing usable: either no text at all,
+        # or a degraded fetch (`reason` set) whose fallback is just a title-only
+        # stub. Both surface the fetch `reason` to the caller rather than running
+        # the analyser on a thin snippet — see _MIN_ANALYZABLE_CHARS.
+        if not text or (reason and len(text) < _MIN_ANALYZABLE_CHARS):
+            # Distinguish video-with-no-transcript from generic extraction
+            # failure so callers can surface the right UX.
+            code = ERR_NO_TRANSCRIPT if source_type in _VIDEO_SOURCE_TYPES else ERR_NO_TEXT
+            raise PipelineError(code, fetched=fetched)
 
-    # ctx may not have source_type set when the caller built it before
-    # fetching — fill it in here so downstream rows carry the right tag.
-    if not ctx.source_type:
-        ctx.source_type = source_type
+        # ctx may not have source_type set when the caller built it before
+        # fetching — fill it in here so downstream rows carry the right tag.
+        if not ctx.source_type:
+            ctx.source_type = source_type
 
-    # Inline image descriptions: append to text so they enter the summary
-    # (and therefore the analyze input) deterministically. analyze_image()
-    # is content-addressed-cached, so this is free on repeats.
-    if include_images is None:
-        include_images = source_type in _INCLUDE_IMAGES_BY_DEFAULT
-    if include_images:
-        image_urls = fetched.get("image_urls") or []
-        if image_urls:
-            _step("describing-images")
-            text = text + await _describe_images(image_urls, ctx=ctx)
+        # Inline image descriptions: append to text so they enter the summary
+        # (and therefore the analyze input) deterministically. analyze_image()
+        # is content-addressed-cached, so this is free on repeats.
+        if include_images is None:
+            include_images = source_type in _INCLUDE_IMAGES_BY_DEFAULT
+        if include_images:
+            image_urls = fetched.get("image_urls") or []
+            if image_urls:
+                _step("describing-images")
+                text = text + await _describe_images(image_urls, ctx=ctx)
 
-    # Summarise on a thread so we don't block the event loop on the LLM
-    # call. The async wrapper around a sync call mirrors what _run_job did.
-    # `published_at` (when available from yt-dlp) anchors the model's
-    # interpretation of relative dates in the source — without it, models
-    # silently default to their training-cutoff year.
-    _step("summarizing")
-    published_at = fetched.get("published_at") or ""
-    loop = asyncio.get_running_loop()
-    summary = await loop.run_in_executor(
-        None,
-        lambda: summarize_content(text, ctx=ctx, published_at=published_at),
-    )
-
-    _step("analyzing")
-    try:
-        analysis = await loop.run_in_executor(None, lambda: analyze(summary, ctx=ctx))
-    except Exception as e:
-        logger.exception("pipeline: analyze crashed for %s", url)
-        raise PipelineError(ERR_ANALYZE_FAILED, fetched=fetched, message=str(e))
-
-    saved_id: int | None = None
-    if save_for_user_id is not None:
-        saved_id = save_item(
-            user_id=save_for_user_id,
-            source_type=source_type,
-            source=url,
-            content=summary,
-            analysis=to_json_str(analysis),
-            user_note=user_note,
+        # Summarise on a thread so we don't block the event loop on the LLM
+        # call. The async wrapper around a sync call mirrors what _run_job did.
+        # `published_at` (when available from yt-dlp) anchors the model's
+        # interpretation of relative dates in the source — without it, models
+        # silently default to their training-cutoff year.
+        _step("summarizing")
+        published_at = fetched.get("published_at") or ""
+        loop = asyncio.get_running_loop()
+        summary = await loop.run_in_executor(
+            None,
+            lambda: summarize_content(text, ctx=ctx, published_at=published_at),
         )
 
-    return PipelineResult(
-        fetched=fetched, summary=summary, analysis=analysis, saved_id=saved_id,
-    )
+        _step("analyzing")
+        try:
+            analysis = await loop.run_in_executor(None, lambda: analyze(summary, ctx=ctx))
+        except Exception as e:
+            logger.exception("pipeline: analyze crashed for %s", url)
+            raise PipelineError(ERR_ANALYZE_FAILED, fetched=fetched, message=str(e))
+
+        saved_id: int | None = None
+        if save_for_user_id is not None:
+            saved_id = save_item(
+                user_id=save_for_user_id,
+                source_type=source_type,
+                source=url,
+                content=summary,
+                analysis=to_json_str(analysis),
+                user_note=user_note,
+            )
+
+        return PipelineResult(
+            fetched=fetched, summary=summary, analysis=analysis, saved_id=saved_id,
+        )
+    except PipelineError as e:
+        # Pull whatever the exception carries — for ERR_NO_TEXT / ERR_NO_TRANSCRIPT
+        # / ERR_ANALYZE_FAILED the fetched dict is attached, so the audit row
+        # still shows the title and source_type even on failure.
+        if e.fetched:
+            fetched = e.fetched
+        audit_status = "error"
+        audit_error_code = e.code
+        raise
+    finally:
+        record_processed_url(
+            url=url,
+            title=fetched.get("title") or "",
+            source_type=fetched.get("source_type") or "",
+            user_id=ctx.user_id,
+            anon_id=ctx.anon_id,
+            job_id=ctx.job_id,
+            status=audit_status,
+            error_code=audit_error_code,
+            transcript_source=fetched.get("transcript_source") or "",
+            latency_ms=int((time.monotonic() - started) * 1000),
+        )
 
 
 async def _describe_images(image_urls: list[str], *, ctx: UsageContext) -> str:

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -291,6 +291,165 @@ class TestCacheStats:
         assert abs(by["analyze"]["cost_saved_usd"] - 0.004) < 1e-9
 
 
+def _stamp_url(db, *, days_ago: int = 0, **overrides) -> None:
+    """Insert one processed_urls row with `ts` set N days ago. Defaults to a
+    successful article fetch — tests pass `status='error'`, `error_code=`,
+    `transcript_source=`, etc. when they need to exercise specific cases."""
+    ts = (datetime.now(timezone.utc) - timedelta(days=days_ago)).strftime(
+        "%Y-%m-%dT%H:%M:%S"
+    )
+    row = {
+        "url": "https://example.com/post",
+        "title": "A title",
+        "source_type": "article",
+        "user_id": None,
+        "anon_id": None,
+        "job_id": None,
+        "status": "ok",
+        "error_code": "",
+        "transcript_source": "",
+        "latency_ms": 500,
+    }
+    row.update(overrides)
+    with db._get_conn() as conn:
+        conn.execute(
+            "INSERT INTO processed_urls (ts, url, title, source_type, "
+            "user_id, anon_id, job_id, status, error_code, transcript_source, "
+            "latency_ms) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                ts, row["url"], row["title"], row["source_type"],
+                row["user_id"], row["anon_id"], row["job_id"], row["status"],
+                row["error_code"], row["transcript_source"], row["latency_ms"],
+            ),
+        )
+
+
+class TestUsageOverviewEmpty:
+    def test_empty_table_returns_zero_kpis_and_empty_lists(
+        self, admin_client, admin_headers
+    ):
+        body = admin_client.get(
+            "/api/admin/usage-overview?days=7", headers=admin_headers
+        ).json()
+        assert body["range_days"] == 7
+        assert body["kpis"] == {
+            "total": 0, "ok": 0, "errors": 0, "error_rate": 0.0,
+        }
+        assert body["by_source_type"] == []
+        assert body["by_error_code"] == []
+        assert body["transcript_sources"] == []
+        assert body["rows"] == []
+        assert body["total_rows"] == 0
+
+
+class TestUsageOverviewWithData:
+    def test_kpis_count_ok_and_errors(self, db, admin_client, admin_headers):
+        _stamp_url(db, status="ok")
+        _stamp_url(db, status="ok")
+        _stamp_url(db, status="error", error_code="fetch-failed")
+
+        body = admin_client.get(
+            "/api/admin/usage-overview", headers=admin_headers
+        ).json()
+        assert body["kpis"]["total"] == 3
+        assert body["kpis"]["ok"] == 2
+        assert body["kpis"]["errors"] == 1
+        assert body["kpis"]["error_rate"] == round(1 / 3, 4)
+
+    def test_by_source_type_breakdown(self, db, admin_client, admin_headers):
+        _stamp_url(db, source_type="article", status="ok")
+        _stamp_url(db, source_type="article", status="error", error_code="x")
+        _stamp_url(db, source_type="youtube", status="ok")
+
+        rows = admin_client.get(
+            "/api/admin/usage-overview", headers=admin_headers
+        ).json()["by_source_type"]
+        by_kind = {r["source_type"]: r for r in rows}
+        assert by_kind["article"]["total"] == 2
+        assert by_kind["article"]["ok"] == 1
+        assert by_kind["article"]["errors"] == 1
+        assert by_kind["youtube"]["ok"] == 1
+
+    def test_by_error_code_sorted_by_frequency(self, db, admin_client, admin_headers):
+        for _ in range(3):
+            _stamp_url(db, status="error", error_code="fetch-failed")
+        for _ in range(2):
+            _stamp_url(db, status="error", error_code="no-transcript")
+        # Success rows don't appear in the error breakdown.
+        _stamp_url(db, status="ok")
+
+        rows = admin_client.get(
+            "/api/admin/usage-overview", headers=admin_headers
+        ).json()["by_error_code"]
+        assert [r["error_code"] for r in rows] == ["fetch-failed", "no-transcript"]
+        assert rows[0]["count"] == 3
+        assert rows[1]["count"] == 2
+
+    def test_transcript_sources_only_count_video_rows(
+        self, db, admin_client, admin_headers
+    ):
+        # Articles have no meaningful transcript_source — must not appear.
+        _stamp_url(db, source_type="article", transcript_source="")
+        # 3 YouTube videos: 2 used YT captions, 1 used Whisper.
+        _stamp_url(db, source_type="youtube", transcript_source="youtube")
+        _stamp_url(db, source_type="youtube", transcript_source="youtube")
+        _stamp_url(db, source_type="youtube", transcript_source="whisper")
+        # Plus one description-only fallback.
+        _stamp_url(db, source_type="youtube", transcript_source="description")
+
+        rows = admin_client.get(
+            "/api/admin/usage-overview", headers=admin_headers
+        ).json()["transcript_sources"]
+        by_source = {r["source"]: r["count"] for r in rows}
+        assert by_source == {"youtube": 2, "whisper": 1, "description": 1}
+
+    def test_rows_paginate_and_total_matches_window(
+        self, db, admin_client, admin_headers
+    ):
+        for i in range(5):
+            _stamp_url(db, url=f"https://example.com/p{i}")
+
+        page1 = admin_client.get(
+            "/api/admin/usage-overview?limit=2&offset=0", headers=admin_headers
+        ).json()
+        page2 = admin_client.get(
+            "/api/admin/usage-overview?limit=2&offset=2", headers=admin_headers
+        ).json()
+
+        assert page1["total_rows"] == 5
+        assert page2["total_rows"] == 5
+        assert len(page1["rows"]) == 2
+        assert len(page2["rows"]) == 2
+        # Pages don't overlap.
+        ids_page1 = {r["id"] for r in page1["rows"]}
+        ids_page2 = {r["id"] for r in page2["rows"]}
+        assert ids_page1.isdisjoint(ids_page2)
+
+    def test_rows_ordered_newest_first(self, db, admin_client, admin_headers):
+        _stamp_url(db, url="https://old", days_ago=2)
+        _stamp_url(db, url="https://new", days_ago=0)
+
+        rows = admin_client.get(
+            "/api/admin/usage-overview", headers=admin_headers
+        ).json()["rows"]
+        assert rows[0]["url"] == "https://new"
+        assert rows[1]["url"] == "https://old"
+
+
+class TestUsageRangeFiltering:
+    def test_rows_outside_window_excluded(
+        self, db, admin_client, admin_headers
+    ):
+        _stamp_url(db, url="https://inside", days_ago=2)
+        _stamp_url(db, url="https://outside", days_ago=10)
+
+        body = admin_client.get(
+            "/api/admin/usage-overview?days=7", headers=admin_headers
+        ).json()
+        assert body["kpis"]["total"] == 1
+        assert [r["url"] for r in body["rows"]] == ["https://inside"]
+
+
 class TestRangeFiltering:
     def test_rows_older_than_window_excluded(
         self, db, admin_client, admin_headers

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -409,11 +409,21 @@ class TestPruneMaintenance:
             conn.execute(
                 "INSERT INTO llm_cache_hits (ts, purpose) VALUES (?, 'analyze')", (NEW,),
             )
+            # Old + new processed_urls rows — old should prune (past 90d TTL).
+            conn.execute(
+                "INSERT INTO processed_urls (ts, url, status) VALUES (?, 'https://old', 'ok')",
+                (OLD,),
+            )
+            conn.execute(
+                "INSERT INTO processed_urls (ts, url, status) VALUES (?, 'https://new', 'ok')",
+                (NEW,),
+            )
 
         counts = db.prune_maintenance(now=datetime(2026, 5, 20, tzinfo=timezone.utc))
         assert counts == {
             "error_log": 1, "url_cache": 1, "link_codes": 1, "jobs": 1,
             "processed_updates": 1, "llm_cache": 1, "llm_cache_hits": 1,
+            "processed_urls": 1,
         }
 
         with db._get_conn() as conn:
@@ -424,6 +434,7 @@ class TestPruneMaintenance:
             assert [r["update_id"] for r in conn.execute("SELECT update_id FROM processed_updates")] == [2]
             assert [r["cache_key"] for r in conn.execute("SELECT cache_key FROM llm_cache")] == ["k_new"]
             assert conn.execute("SELECT COUNT(*) AS n FROM llm_cache_hits").fetchone()["n"] == 1
+            assert [r["url"] for r in conn.execute("SELECT url FROM processed_urls")] == ["https://new"]
 
     def test_idempotent_on_empty(self, db):
         from datetime import datetime, timezone
@@ -432,6 +443,7 @@ class TestPruneMaintenance:
         assert counts == {
             "error_log": 0, "url_cache": 0, "link_codes": 0, "jobs": 0,
             "processed_updates": 0, "llm_cache": 0, "llm_cache_hits": 0,
+            "processed_urls": 0,
         }
 
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -240,6 +240,97 @@ class TestImageStrategy:
         assert "IMAGE DESCRIPTIONS" not in captured["summary_input"]
 
 
+class TestProcessedUrlAudit:
+    """analyze_url writes one row to `processed_urls` per call — success or
+    failure — so the admin dashboard's Usage tile reflects every URL that
+    went through the pipeline. This is the basis for the Whisper-vs-YouTube
+    transcript-source breakdown."""
+
+    def _all_rows(self, db):
+        with db._get_conn() as conn:
+            return conn.execute(
+                "SELECT * FROM processed_urls ORDER BY id"
+            ).fetchall()
+
+    def test_success_writes_audit_row(self, pipeline, db):
+        from bot.analyzer import UsageContext
+        asyncio.run(pipeline.analyze_url(
+            "https://example.com/post",
+            ctx=UsageContext(user_id=42),
+        ))
+        rows = self._all_rows(db)
+        assert len(rows) == 1
+        r = rows[0]
+        assert r["url"] == "https://example.com/post"
+        assert r["title"] == "RAG explained"
+        assert r["source_type"] == "article"
+        assert r["user_id"] == 42
+        assert r["status"] == "ok"
+        assert r["error_code"] == ""
+        assert r["latency_ms"] >= 0
+
+    def test_fetch_failure_still_writes_row(self, pipeline, db, monkeypatch):
+        """We don't have title/source_type when fetch itself crashes, but
+        the URL + status + error_code are useful — operators can see what
+        URLs are breaking."""
+        async def boom(url, **_kw):
+            raise RuntimeError("network down")
+        monkeypatch.setattr(pipeline, "fetch_url", boom)
+
+        from bot.analyzer import UsageContext
+        with pytest.raises(pipeline.PipelineError):
+            asyncio.run(pipeline.analyze_url(
+                "https://broken.example.com", ctx=UsageContext()
+            ))
+
+        rows = self._all_rows(db)
+        assert len(rows) == 1
+        assert rows[0]["url"] == "https://broken.example.com"
+        assert rows[0]["status"] == "error"
+        assert rows[0]["error_code"] == "fetch-failed"
+        assert rows[0]["title"] == ""  # no fetched payload available
+
+    def test_no_text_failure_keeps_title_from_fetched(
+        self, pipeline, db, monkeypatch
+    ):
+        async def empty_with_title(url, **_kw):
+            return {"text": "", "title": "Empty page",
+                    "source_type": "article", "image_urls": []}
+        monkeypatch.setattr(pipeline, "fetch_url", empty_with_title)
+
+        from bot.analyzer import UsageContext
+        with pytest.raises(pipeline.PipelineError):
+            asyncio.run(pipeline.analyze_url("x", ctx=UsageContext()))
+
+        rows = self._all_rows(db)
+        assert len(rows) == 1
+        assert rows[0]["status"] == "error"
+        assert rows[0]["error_code"] == "extraction-failed"
+        # Title preserved from the fetched payload so the dashboard shows
+        # something more useful than just the URL on failure rows.
+        assert rows[0]["title"] == "Empty page"
+
+    def test_transcript_source_propagates(self, pipeline, db, monkeypatch):
+        """The whole point of the audit log is the Whisper-vs-YouTube split.
+        Pin that fetcher → row write preserves the tag."""
+        async def whisper_yt(url, **_kw):
+            return {
+                "text": "Whisper transcript of a longer-form video about RAG.",
+                "title": "T",
+                "source_type": "youtube",
+                "image_urls": [],
+                "transcript_source": "whisper",
+            }
+        monkeypatch.setattr(pipeline, "fetch_url", whisper_yt)
+
+        from bot.analyzer import UsageContext
+        asyncio.run(pipeline.analyze_url("x", ctx=UsageContext()))
+        rows = self._all_rows(db)
+        assert len(rows) == 1
+        assert rows[0]["transcript_source"] == "whisper"
+        assert rows[0]["source_type"] == "youtube"
+
+
 class TestProgressCallback:
     def test_on_step_called_with_known_labels(self, pipeline):
         steps: list[str] = []


### PR DESCRIPTION
Wires up the **Usage pillar** of the admin dashboard. Two things the operator now sees:

1. **Whisper vs YouTube transcript split** — how often we fall back to expensive audio transcription instead of using YouTube's captions.
2. **List of every processed URL** — date, title, user, status — across both successful and failed scans.

Frontend tile ships in a paired filter.fyi PR (linked in the next comment).

## What's added

**`bot/db.py`** — new table:
\`\`\`sql
processed_urls(
  ts, url, title, source_type,
  user_id, anon_id, job_id,
  status, error_code, transcript_source,  -- 'youtube'|'whisper'|'description'|'none'
  latency_ms
)
\`\`\`
+ \`record_processed_url()\` writer (best-effort — never raises into the pipeline) and 90-day retention via \`prune_maintenance\`.

**\`bot/fetcher.py\`** — every YouTube return path tags itself:

| Path | \`transcript_source\` |
|---|---|
| YouTubeTranscriptApi success | \`youtube\` |
| yt-dlp with has_transcript | \`youtube\` |
| Whisper succeeded | \`whisper\` |
| All transcript attempts failed → description fallback | \`description\` |
| Full extraction failure (no description either) | \`none\` |

**\`bot/pipeline.py\`** — \`analyze_url\` wraps the body in try/finally so EVERY call writes one row, success or failure. On failure, the exception's \`fetched\` dict (when set) populates title + source_type + transcript_source in the audit row, so failure rows are still useful in the UI.

**\`bot/admin.py\`** — new endpoint:
\`\`\`
GET /api/admin/usage-overview?days=30&limit=50&offset=0
\`\`\`
returns one pre-rolled payload:
\`\`\`json
{
  "kpis": { "total", "ok", "errors", "error_rate" },
  "by_source_type": [{ source_type, total, ok, errors }, ...],
  "by_error_code":  [{ error_code, count }, ...],
  "transcript_sources": [{ source, count }, ...],   // video rows only
  "rows": [{ ts, url, title, source_type, user_id, anon_id,
             status, error_code, transcript_source, latency_ms }, ...],
  "total_rows": ...,
  "limit": ..., "offset": ...
}
\`\`\`

Same auth pattern as \`/api/admin/cost-overview\` (\`x-filter-fyi-admin-secret\`).

## Tests (12 new, 263 total)

| File | What's pinned |
|---|---|
| \`tests/test_db.py\` | \`prune_maintenance\` returns \`processed_urls\` count + 90d retention |
| \`tests/test_pipeline.py\` × 4 | Success writes row; fetch-failure still writes (URL only); ERR_NO_TEXT keeps title from fetched; transcript_source propagates fetcher → row |
| \`tests/test_admin.py\` × 7 | Empty zero-state; ok/error counts; source breakdown; error codes sorted; transcript split filters to video rows only; pagination; newest-first ordering; range filter |

\`make test\` → **263 passed**.

## Worth flagging on review

- **No backfill.** Historic URLs (those in \`items\`, \`anon_summaries\`) won't appear. Counts start from when this deploys.
- **transcript_source on non-video rows is empty** by design. The \`transcript_sources\` aggregation filters to video source_types so the denominator is meaningful.
- **Failure rows include fetch failures** (where we don't know title/source_type) and downstream failures (where we do). The dashboard handles both gracefully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)