### PR TITLE
feat(shortlist): saved-suggestions store + API (later / tried / done)

### DIFF
--- a/bot/api.py
+++ b/bot/api.py
@@ -31,21 +31,26 @@ from bot.fetch_errors import user_message as fetch_error_message
 from bot.db import (
     FEEDBACK_SIGNALS,
     LINK_CODE_TTL_SECONDS,
+    SAVED_SUGGESTION_STATUSES,
     create_job,
     create_link_code,
     delete_item,
+    delete_saved_suggestion,
     delete_user,
     get_all_items,
     get_item,
     get_job_record,
+    get_saved_suggestions,
     get_user,
     get_user_profile,
     record_feedback,
     save_item,
+    save_suggestion,
     search_items,
     set_job_done,
     set_job_error,
     set_user_profile,
+    update_saved_suggestion_status,
     upsert_user_by_email,
 )
 from bot.storage import full_path, save_file
@@ -407,6 +412,22 @@ async def user_export(user_id: int, _: None = Depends(_require_try_secret)):
             }
             for i in items
         ],
+        "saved_suggestions": [
+            {
+                "id": s["id"],
+                "item_id": s["item_id"],
+                "suggestion_index": s["suggestion_index"],
+                "title": s["title"],
+                "detail": s["detail"],
+                "effort": s["effort"],
+                "first_step": s["first_step"],
+                "grounded_in": s["grounded_in"],
+                "status": s["status"],
+                "created_at": s["created_at"],
+                "updated_at": s["updated_at"],
+            }
+            for s in get_saved_suggestions(user_id)
+        ],
     }
 
 
@@ -471,6 +492,96 @@ async def feedback(req: _FeedbackRequest, _: None = Depends(_require_try_secret)
     if not get_item(req.item_id, req.user_id):
         raise HTTPException(status_code=404, detail={"error": "not-found"})
     record_feedback(req.user_id, req.item_id, req.signal)
+
+
+# ---------------------------------------------------------------------------
+# Shortlist (saved suggestions) — "later" parks a suggestion here; the Worker
+# proxies these as /api/v1/saved-suggestions and injects the session's user_id.
+# ---------------------------------------------------------------------------
+
+class _SaveSuggestionRequest(BaseModel):
+    user_id: int
+    item_id: int
+    suggestion_index: int
+    title: str = ""
+    detail: str = ""
+    effort: str = ""
+    first_step: str = ""
+    grounded_in: str = ""
+
+
+class _SuggestionStatusRequest(BaseModel):
+    user_id: int
+    status: str
+
+
+@router.post("/saved-suggestions", status_code=201)
+async def saved_suggestion_create(
+    req: _SaveSuggestionRequest, _: None = Depends(_require_try_secret)
+):
+    """Park ("later") a suggestion on the user's Shortlist. Idempotent on
+    (user, item, suggestion_index). Ownership-scoped: the item must belong to
+    the user (404 otherwise), so you can't pin against someone else's read."""
+    if not get_item(req.item_id, req.user_id):
+        raise HTTPException(status_code=404, detail={"error": "not-found"})
+    saved_id = save_suggestion(
+        req.user_id,
+        req.item_id,
+        req.suggestion_index,
+        title=req.title,
+        detail=req.detail,
+        effort=req.effort,
+        first_step=req.first_step,
+        grounded_in=req.grounded_in,
+    )
+    return {"id": saved_id, "status": "saved"}
+
+
+@router.get("/saved-suggestions")
+async def saved_suggestions_list(user_id: int, _: None = Depends(_require_try_secret)):
+    """The user's Shortlist, newest first. Each row carries its source URL and
+    the source item's title (for the back-link) alongside the snapshot."""
+    out = []
+    for r in get_saved_suggestions(user_id):
+        _, item_title = _extract_verdict_and_title(r["item_analysis"])
+        out.append({
+            "id": r["id"],
+            "item_id": r["item_id"],
+            "suggestion_index": r["suggestion_index"],
+            "title": r["title"],
+            "detail": r["detail"],
+            "effort": r["effort"],
+            "first_step": r["first_step"],
+            "grounded_in": r["grounded_in"],
+            "status": r["status"],
+            "created_at": r["created_at"],
+            "updated_at": r["updated_at"],
+            "source": r["source"],
+            "item_title": item_title,
+        })
+    return out
+
+
+@router.patch("/saved-suggestions/{saved_id}")
+async def saved_suggestion_update(
+    saved_id: int, req: _SuggestionStatusRequest, _: None = Depends(_require_try_secret)
+):
+    """Advance a shortlisted suggestion's status (saved → tried → done)."""
+    if req.status not in SAVED_SUGGESTION_STATUSES:
+        raise HTTPException(status_code=400, detail={"error": "invalid-status"})
+    if not update_saved_suggestion_status(saved_id, req.user_id, req.status):
+        raise HTTPException(status_code=404, detail={"error": "not-found"})
+    return {"id": saved_id, "status": req.status}
+
+
+@router.delete("/saved-suggestions/{saved_id}", status_code=204)
+async def saved_suggestion_delete(
+    saved_id: int, user_id: int, _: None = Depends(_require_try_secret)
+):
+    """Remove a suggestion from the Shortlist. Ownership-scoped (404 for
+    someone else's id, mirroring the library delete)."""
+    if not delete_saved_suggestion(saved_id, user_id):
+        raise HTTPException(status_code=404, detail={"error": "not-found"})
 
 
 class _LibraryAddRequest(BaseModel):

--- a/bot/db.py
+++ b/bot/db.py
@@ -94,6 +94,35 @@ CREATE TABLE IF NOT EXISTS feedback (
     FOREIGN KEY (item_id) REFERENCES items(id)
 )"""
 
+# Suggestions a user parked for later — the "Shortlist". Unlike the append-only
+# feedback log, this is durable, user-owned state: one row per saved suggestion,
+# carrying a snapshot of the suggestion text (suggestions are regenerated per
+# analysis and aren't stably keyed, so we snapshot rather than re-derive) plus
+# the item_id it came from for the back-link. `status` advances saved → tried →
+# done as the user follows up. UNIQUE(user, item, index) makes "save" idempotent.
+_CREATE_SAVED_SUGGESTIONS_SQL = """\
+CREATE TABLE IF NOT EXISTS saved_suggestions (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id          INTEGER NOT NULL,
+    item_id          INTEGER NOT NULL,
+    suggestion_index INTEGER NOT NULL,
+    title            TEXT NOT NULL DEFAULT '',
+    detail           TEXT NOT NULL DEFAULT '',
+    effort           TEXT NOT NULL DEFAULT '',
+    first_step       TEXT NOT NULL DEFAULT '',
+    grounded_in      TEXT NOT NULL DEFAULT '',
+    status           TEXT NOT NULL DEFAULT 'saved',
+    created_at       TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%S', 'now')),
+    updated_at       TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%S', 'now')),
+    UNIQUE(user_id, item_id, suggestion_index),
+    FOREIGN KEY (user_id) REFERENCES users(id),
+    FOREIGN KEY (item_id) REFERENCES items(id)
+)"""
+
+# Statuses a shortlisted suggestion can hold. 'tried'/'done' mirror the
+# FEEDBACK_SIGNALS taps so the follow-up reads consistently across surfaces.
+SAVED_SUGGESTION_STATUSES = frozenset({"saved", "tried", "done"})
+
 _CREATE_INDEXES_SQL = [
     "CREATE INDEX IF NOT EXISTS idx_items_user ON items(user_id, created_at DESC)",
     "CREATE INDEX IF NOT EXISTS idx_link_codes_expires ON link_codes(expires_at)",
@@ -102,6 +131,8 @@ _CREATE_INDEXES_SQL = [
     "CREATE INDEX IF NOT EXISTS idx_error_log_fingerprint ON error_log(fingerprint)",
     "CREATE INDEX IF NOT EXISTS idx_feedback_user ON feedback(user_id, created_at DESC)",
     "CREATE INDEX IF NOT EXISTS idx_feedback_item ON feedback(item_id)",
+    "CREATE INDEX IF NOT EXISTS idx_saved_suggestions_user ON saved_suggestions(user_id, created_at DESC)",
+    "CREATE INDEX IF NOT EXISTS idx_saved_suggestions_item ON saved_suggestions(item_id)",
     "CREATE INDEX IF NOT EXISTS idx_jobs_updated_at ON jobs(updated_at DESC)",
     "CREATE INDEX IF NOT EXISTS idx_llm_calls_ts ON llm_calls(ts DESC)",
     "CREATE INDEX IF NOT EXISTS idx_llm_calls_user ON llm_calls(user_id, ts DESC)",
@@ -370,6 +401,7 @@ def _init() -> None:
         conn.execute(_CREATE_URL_CACHE_SQL)
         conn.execute(_CREATE_ERROR_LOG_SQL)
         conn.execute(_CREATE_FEEDBACK_SQL)
+        conn.execute(_CREATE_SAVED_SUGGESTIONS_SQL)
         conn.execute(_CREATE_JOBS_SQL)
         # Added after jobs shipped: carries the user-facing failure message so
         # the Worker can show *why* a job failed instead of a generic string.
@@ -485,6 +517,7 @@ def delete_user(user_id: int) -> dict:
         ).rowcount
         conn.execute("DELETE FROM link_codes WHERE user_id = ?", (user_id,))
         conn.execute("DELETE FROM feedback WHERE user_id = ?", (user_id,))
+        conn.execute("DELETE FROM saved_suggestions WHERE user_id = ?", (user_id,))
         user_deleted = conn.execute(
             "DELETE FROM users WHERE id = ?", (user_id,)
         ).rowcount
@@ -574,8 +607,9 @@ def delete_item(item_id: int, user_id: int | None = None) -> None:
             )
         else:
             conn.execute("DELETE FROM items WHERE id = ?", (item_id,))
-        # Drop any feedback that referenced this item (no orphans).
+        # Drop any feedback / shortlist rows that referenced this item (no orphans).
         conn.execute("DELETE FROM feedback WHERE item_id = ?", (item_id,))
+        conn.execute("DELETE FROM saved_suggestions WHERE item_id = ?", (item_id,))
 
 
 def record_feedback(user_id: int, item_id: int, signal: str) -> None:
@@ -585,6 +619,94 @@ def record_feedback(user_id: int, item_id: int, signal: str) -> None:
             "INSERT INTO feedback (user_id, item_id, signal) VALUES (?, ?, ?)",
             (user_id, item_id, signal),
         )
+
+
+# ---------------------------------------------------------------------------
+# Shortlist (saved suggestions)
+# ---------------------------------------------------------------------------
+
+_SAVED_SUGGESTION_COLS = (
+    "id, item_id, suggestion_index, title, detail, effort, first_step, "
+    "grounded_in, status, created_at, updated_at"
+)
+
+
+def save_suggestion(
+    user_id: int,
+    item_id: int,
+    suggestion_index: int,
+    *,
+    title: str = "",
+    detail: str = "",
+    effort: str = "",
+    first_step: str = "",
+    grounded_in: str = "",
+) -> int:
+    """Add (or refresh) a shortlisted suggestion. Idempotent on
+    (user_id, item_id, suggestion_index): saving the same suggestion again
+    refreshes its snapshot + updated_at and preserves its current status,
+    rather than creating a duplicate row. Returns the row id."""
+    with _get_conn() as conn:
+        existing = conn.execute(
+            "SELECT id FROM saved_suggestions "
+            "WHERE user_id = ? AND item_id = ? AND suggestion_index = ?",
+            (user_id, item_id, suggestion_index),
+        ).fetchone()
+        if existing:
+            conn.execute(
+                "UPDATE saved_suggestions SET title = ?, detail = ?, effort = ?, "
+                "first_step = ?, grounded_in = ?, "
+                "updated_at = strftime('%Y-%m-%dT%H:%M:%S', 'now') WHERE id = ?",
+                (title, detail, effort, first_step, grounded_in, existing["id"]),
+            )
+            return existing["id"]
+        cur = conn.execute(
+            "INSERT INTO saved_suggestions (user_id, item_id, suggestion_index, "
+            "title, detail, effort, first_step, grounded_in) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (user_id, item_id, suggestion_index, title, detail, effort,
+             first_step, grounded_in),
+        )
+        return cur.lastrowid
+
+
+def get_saved_suggestions(user_id: int) -> list[sqlite3.Row]:
+    """All of a user's shortlisted suggestions, newest first. Joins the source
+    item so the caller can render a back-link (source URL + the item's title,
+    which lives inside the item's analysis JSON)."""
+    cols = ", ".join(f"s.{c}" for c in _SAVED_SUGGESTION_COLS.replace(" ", "").split(","))
+    with _get_conn() as conn:
+        return conn.execute(
+            f"SELECT {cols}, "
+            "       i.source AS source, i.analysis AS item_analysis "
+            "FROM saved_suggestions s JOIN items i ON i.id = s.item_id "
+            "WHERE s.user_id = ? ORDER BY s.created_at DESC, s.id DESC",
+            (user_id,),
+        ).fetchall()
+
+
+def update_saved_suggestion_status(saved_id: int, user_id: int, status: str) -> bool:
+    """Advance a shortlisted suggestion's status. Ownership-scoped — returns
+    False if the row doesn't exist or belongs to another user."""
+    with _get_conn() as conn:
+        cur = conn.execute(
+            "UPDATE saved_suggestions SET status = ?, "
+            "updated_at = strftime('%Y-%m-%dT%H:%M:%S', 'now') "
+            "WHERE id = ? AND user_id = ?",
+            (status, saved_id, user_id),
+        )
+        return cur.rowcount > 0
+
+
+def delete_saved_suggestion(saved_id: int, user_id: int) -> bool:
+    """Remove one shortlisted suggestion. Ownership-scoped — returns False if
+    the row doesn't exist or belongs to another user."""
+    with _get_conn() as conn:
+        cur = conn.execute(
+            "DELETE FROM saved_suggestions WHERE id = ? AND user_id = ?",
+            (saved_id, user_id),
+        )
+        return cur.rowcount > 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -498,3 +498,132 @@ class TestJobFlow:
         rec = db.get_job_record("job-5")
         assert rec["status"] == "error"
         assert rec["error"] == "no-transcript"
+
+
+# ---------------------------------------------------------------------------
+# Shortlist (saved suggestions) — /api/saved-suggestions
+# ---------------------------------------------------------------------------
+
+class TestShortlist:
+    def _user_with_one_item(self, client, auth_headers, email="s@b.com"):
+        uid = client.post(
+            "/api/users/upsert", json={"email": email}, headers=auth_headers
+        ).json()["user_id"]
+        item_id = client.post(
+            "/api/library/add",
+            json={"user_id": uid, "url": "https://example.com/x"},
+            headers=auth_headers,
+        ).json()["id"]
+        return uid, item_id
+
+    def _save(self, client, auth_headers, uid, item_id, index=0, **extra):
+        body = {"user_id": uid, "item_id": item_id, "suggestion_index": index,
+                "title": "Wire up a RAG demo", "detail": "Stand up a demo."}
+        body.update(extra)
+        return client.post("/api/saved-suggestions", json=body, headers=auth_headers)
+
+    def test_save_creates_and_lists(self, client, auth_headers):
+        uid, item_id = self._user_with_one_item(client, auth_headers)
+        r = self._save(client, auth_headers, uid, item_id)
+        assert r.status_code == 201
+        assert r.json()["status"] == "saved"
+
+        rows = client.get(f"/api/saved-suggestions?user_id={uid}", headers=auth_headers).json()
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["item_id"] == item_id
+        assert row["suggestion_index"] == 0
+        assert row["status"] == "saved"
+        assert row["title"] == "Wire up a RAG demo"
+        # Back-link fields from the joined item.
+        assert row["source"] == "https://example.com/x"
+        assert "RAG" in row["item_title"]
+
+    def test_save_is_idempotent(self, client, auth_headers):
+        uid, item_id = self._user_with_one_item(client, auth_headers)
+        first = self._save(client, auth_headers, uid, item_id).json()["id"]
+        # Saving the same (item, index) again refreshes rather than duplicates.
+        second = self._save(client, auth_headers, uid, item_id, detail="Refreshed.").json()["id"]
+        assert first == second
+        rows = client.get(f"/api/saved-suggestions?user_id={uid}", headers=auth_headers).json()
+        assert len(rows) == 1
+        assert rows[0]["detail"] == "Refreshed."
+
+    def test_distinct_indexes_are_separate_rows(self, client, auth_headers):
+        uid, item_id = self._user_with_one_item(client, auth_headers)
+        self._save(client, auth_headers, uid, item_id, index=0)
+        self._save(client, auth_headers, uid, item_id, index=1)
+        rows = client.get(f"/api/saved-suggestions?user_id={uid}", headers=auth_headers).json()
+        assert {r["suggestion_index"] for r in rows} == {0, 1}
+
+    def test_save_against_other_users_item_404(self, client, auth_headers):
+        uid, item_id = self._user_with_one_item(client, auth_headers)
+        r = client.post(
+            "/api/saved-suggestions",
+            json={"user_id": 99999, "item_id": item_id, "suggestion_index": 0},
+            headers=auth_headers,
+        )
+        assert r.status_code == 404
+
+    def test_status_advances(self, client, auth_headers):
+        uid, item_id = self._user_with_one_item(client, auth_headers)
+        saved_id = self._save(client, auth_headers, uid, item_id).json()["id"]
+        r = client.patch(
+            f"/api/saved-suggestions/{saved_id}",
+            json={"user_id": uid, "status": "tried"},
+            headers=auth_headers,
+        )
+        assert r.status_code == 200
+        rows = client.get(f"/api/saved-suggestions?user_id={uid}", headers=auth_headers).json()
+        assert rows[0]["status"] == "tried"
+
+    def test_invalid_status_rejected(self, client, auth_headers):
+        uid, item_id = self._user_with_one_item(client, auth_headers)
+        saved_id = self._save(client, auth_headers, uid, item_id).json()["id"]
+        r = client.patch(
+            f"/api/saved-suggestions/{saved_id}",
+            json={"user_id": uid, "status": "bogus"},
+            headers=auth_headers,
+        )
+        assert r.status_code == 400
+
+    def test_status_update_wrong_user_404(self, client, auth_headers):
+        uid, item_id = self._user_with_one_item(client, auth_headers)
+        saved_id = self._save(client, auth_headers, uid, item_id).json()["id"]
+        r = client.patch(
+            f"/api/saved-suggestions/{saved_id}",
+            json={"user_id": 99999, "status": "done"},
+            headers=auth_headers,
+        )
+        assert r.status_code == 404
+
+    def test_delete_removes(self, client, auth_headers):
+        uid, item_id = self._user_with_one_item(client, auth_headers)
+        saved_id = self._save(client, auth_headers, uid, item_id).json()["id"]
+        r = client.delete(f"/api/saved-suggestions/{saved_id}?user_id={uid}", headers=auth_headers)
+        assert r.status_code == 204
+        assert client.get(f"/api/saved-suggestions?user_id={uid}", headers=auth_headers).json() == []
+
+    def test_delete_wrong_user_404(self, client, auth_headers):
+        uid, item_id = self._user_with_one_item(client, auth_headers)
+        saved_id = self._save(client, auth_headers, uid, item_id).json()["id"]
+        r = client.delete(f"/api/saved-suggestions/{saved_id}?user_id=99999", headers=auth_headers)
+        assert r.status_code == 404
+        assert len(client.get(f"/api/saved-suggestions?user_id={uid}", headers=auth_headers).json()) == 1
+
+    def test_deleting_item_cascades_shortlist(self, client, auth_headers):
+        uid, item_id = self._user_with_one_item(client, auth_headers)
+        self._save(client, auth_headers, uid, item_id)
+        client.delete(f"/api/library/{item_id}?user_id={uid}", headers=auth_headers)
+        assert client.get(f"/api/saved-suggestions?user_id={uid}", headers=auth_headers).json() == []
+
+    def test_export_includes_shortlist(self, client, auth_headers):
+        uid, item_id = self._user_with_one_item(client, auth_headers)
+        self._save(client, auth_headers, uid, item_id)
+        export = client.get(f"/api/users/{uid}/export", headers=auth_headers).json()
+        assert len(export["saved_suggestions"]) == 1
+        assert export["saved_suggestions"][0]["item_id"] == item_id
+
+    def test_requires_secret(self, client):
+        r = client.get("/api/saved-suggestions?user_id=1")
+        assert r.status_code == 401


### PR DESCRIPTION
Backend half of the **Shortlist** feature — the durable home for suggestions a user parks via the new `later ▸` action. (Frontend PR follows; it proxies these as `/api/v1/saved-suggestions` and drives the UI.)

## What this adds
- **`saved_suggestions` table** (Fly SQLite): one row per saved suggestion. Snapshots the suggestion text (`title/detail/effort/first_step/grounded_in`) because suggestions are regenerated per analysis and aren't stably keyed, plus `item_id` for the back-link to the source read. `status` advances `saved → tried → done`. `UNIQUE(user_id, item_id, suggestion_index)` makes "save" idempotent. Created with `CREATE TABLE IF NOT EXISTS` at startup — additive, no migration hazards.
- **db accessors** (all ownership-scoped): `save_suggestion` (idempotent upsert — re-saving refreshes the snapshot, never duplicates), `get_saved_suggestions` (joins `items` for the source URL + title), `update_saved_suggestion_status`, `delete_saved_suggestion`. `delete_item` / `delete_user` now purge shortlist rows too (no orphans); the GDPR export includes them.
- **Endpoints** (Worker-gated via the shared secret, mirroring the library routes): `POST /api/saved-suggestions`, `GET /api/saved-suggestions?user_id=`, `PATCH /api/saved-suggestions/{id}` (status), `DELETE /api/saved-suggestions/{id}`. Returns `404` (not `403`) for another user's id so ids don't leak.

## Why a separate table (not the feedback log)
The existing `feedback` table is an append-only personalization signal log (many rows per item). The Shortlist is durable, user-owned *state* the person comes back to — different lifecycle, so it gets its own table on the canonical store (and is reachable from Telegram later per the unified-identity direction). `tried`/`done` statuses still mirror `FEEDBACK_SIGNALS`, and the frontend will also log those as feedback signals for the personalization loop.

## Tests
12 new pytest cases (`TestShortlist`): create/list with back-link fields, idempotency, distinct indexes as separate rows, cross-user isolation on every verb, status validation, item-delete cascade, and export inclusion. Full suite: **275 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)