### PR TITLE
ops(litestream): R2/non-AWS endpoint via config fields, not URL query

### DIFF
--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -74,8 +74,13 @@ Run it daily — either a scheduled Fly machine or cron:
 python -m scripts.prune
 ```
 
-Stored media (transcribed mp4s under `data/files/`) is the other growth vector;
-files for deleted users are removed by account erasure, but monitor disk usage:
+The other growth vector is **user-uploaded files** (PDFs, images, audio a user
+submits directly), saved under the file store and referenced by
+`items.file_path`. Note this is *not* scraped third-party media: URL / YouTube /
+StreamYard content is downloaded to a temp dir, transcribed, and deleted — only
+the derived brief is persisted (`items.content`), never the source media or its
+full text. Uploaded files for deleted users are removed by account erasure, but
+monitor disk usage:
 ```sh
 fly volumes list           # check % used
 ```

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -26,21 +26,33 @@ giving near-real-time, point-in-time recovery. It's baked into the image but
 **only runs when `LITESTREAM_REPLICA_URL` is set** — otherwise the container
 starts plain uvicorn (see `docker-entrypoint.sh`), so local dev is unaffected.
 
-To enable, provision an S3-compatible bucket (Fly's Tigris, Backblaze B2,
-Cloudflare R2, …) and set Fly secrets:
+To enable, provision an S3-compatible bucket (Cloudflare R2, Fly's Tigris,
+Backblaze B2, …) and set Fly secrets. On **Litestream 0.3.x the endpoint and
+region are config fields, not URL query params** — set them as their own env
+vars (see [`litestream.yml`](../litestream.yml)), or a non-AWS target silently
+resolves to AWS S3 and fails:
 
 ```sh
-fly secrets set \
+fly secrets set -a filter-fyi-backend \
   LITESTREAM_REPLICA_URL="s3://<bucket>/filter-fyi-backend" \
+  LITESTREAM_ENDPOINT="https://<accountid>.r2.cloudflarestorage.com" \
+  LITESTREAM_REGION="auto" \
   LITESTREAM_ACCESS_KEY_ID="<key>" \
   LITESTREAM_SECRET_ACCESS_KEY="<secret>"
-# For non-AWS endpoints also set the endpoint, e.g. Tigris:
-#   LITESTREAM_REPLICA_URL="s3://<bucket>/filter-fyi-backend?endpoint=https://fly.storage.tigris.dev"
+# Tigris: endpoint https://fly.storage.tigris.dev, region auto.
+# Plain AWS S3: omit LITESTREAM_ENDPOINT; set the real region.
 ```
+
+The R2 access key + secret come from an **R2 API token** (R2 → Manage R2 API
+Tokens → Object Read & Write); the secret is shown only once. The endpoint's
+`<accountid>` is the host prefix of the bucket's S3 API URL.
 
 Config: [`litestream.yml`](../litestream.yml) (30-day retention, daily
 snapshots). On boot the entrypoint runs `litestream restore -if-db-not-exists`,
 so a fresh/recovered volume self-heals from the replica.
+
+> Tip: if a restore fails with a host/DNS error against R2, add
+> `force-path-style: true` to the replica in `litestream.yml`.
 
 **Restore manually:**
 ```sh

--- a/litestream.yml
+++ b/litestream.yml
@@ -4,15 +4,29 @@
 # the app under `litestream replicate` when it is, and plain uvicorn when it
 # isn't (so local dev and un-provisioned environments are unaffected).
 #
-# LITESTREAM_REPLICA_URL example (S3-compatible, e.g. Tigris/Backblaze/R2):
-#   s3://my-bucket/filter-fyi-backend
-# with LITESTREAM_ACCESS_KEY_ID / LITESTREAM_SECRET_ACCESS_KEY in the env.
+# Five env vars drive the replica (all unset locally → backup stays off):
+#   LITESTREAM_REPLICA_URL        s3://<bucket>/<prefix>  (bucket + path)
+#   LITESTREAM_ENDPOINT           S3 endpoint for non-AWS providers
+#   LITESTREAM_REGION             region ("auto" for R2)
+#   LITESTREAM_ACCESS_KEY_ID      \ S3 credentials (Fly secrets, never
+#   LITESTREAM_SECRET_ACCESS_KEY  / committed)
+#
+# Cloudflare R2 example:
+#   LITESTREAM_REPLICA_URL=s3://filter-fyi-backups/filter-fyi-backend
+#   LITESTREAM_ENDPOINT=https://<accountid>.r2.cloudflarestorage.com
+#   LITESTREAM_REGION=auto
+#
+# NOTE: on Litestream 0.3.x the endpoint/region must be config fields — they
+# are NOT read from a "?endpoint=" query string on the URL. Leaving them as
+# separate keys here is what makes a non-AWS (R2/Tigris) target actually work.
 #
 # Docs: https://litestream.io/reference/config/
 dbs:
   - path: ${DATA_DIR}/research.db
     replicas:
       - url: ${LITESTREAM_REPLICA_URL}
+        endpoint: ${LITESTREAM_ENDPOINT}
+        region: ${LITESTREAM_REGION}
         # Keep ~30 days of point-in-time history.
         retention: 720h
         snapshot-interval: 24h


### PR DESCRIPTION
## Why

Enabling Litestream against **Cloudflare R2** before opening login. The replica config only had `url: ${LITESTREAM_REPLICA_URL}`, and `OPERATIONS.md` told you to append `?endpoint=...` to that URL — but on **Litestream 0.3.x** (our pinned version) `endpoint`/`region` are config **fields**, not URL query params. So an R2/Tigris target would silently resolve to AWS S3 and fail to back up — the worst kind of backup bug (looks configured, isn't).

## Change

- `litestream.yml`: add explicit `endpoint: ${LITESTREAM_ENDPOINT}` / `region: ${LITESTREAM_REGION}` keys.
- `OPERATIONS.md`: correct R2 recipe (API-token creds, endpoint host, `region: auto`) + a `force-path-style: true` fallback note.

## Safety / no behaviour change when unset

The entrypoint still gates the entire feature on `LITESTREAM_REPLICA_URL`; when it's unset (local dev, un-provisioned envs) the app runs plain uvicorn exactly as before. The two new vars just interpolate empty in that case.

## Deploy sequence (separate, manual)

1. Merge + deploy this.
2. Set the five Fly secrets (`LITESTREAM_REPLICA_URL`, `_ENDPOINT`, `_REGION`, `_ACCESS_KEY_ID`, `_SECRET_ACCESS_KEY`) → triggers a restart, Litestream activates.
3. Verify in `fly logs` + run a throwaway `litestream restore` (see OPERATIONS.md).
4. Also bump the Fly volume snapshot retention to 30d (baseline layer, covers media).

🤖 Generated with [Claude Code](https://claude.com/claude-code)