### PR TITLE
feat(ops): run scripts.prune daily in-process

### DIFF
--- a/bot/scheduling.py
+++ b/bot/scheduling.py
@@ -1,0 +1,23 @@
+"""Helpers for the in-process daily maintenance loops (error scan, prune).
+
+These jobs run *inside* the bot process rather than as separate Fly scheduled
+machines because the Fly volume holding the SQLite DB attaches to only one
+machine at a time — a second machine couldn't open the same database. See the
+loops in main.py.
+"""
+from __future__ import annotations
+
+from datetime import datetime, time as dtime, timedelta, timezone
+
+
+def next_daily_run(now: datetime, hour_utc: int) -> datetime:
+    """Return the next UTC datetime at ``hour_utc``:00 strictly after ``now``.
+
+    If today's slot is still ahead it's used; if it has already passed (or is
+    exactly ``now``) the slot rolls to tomorrow. Shared by the scan and prune
+    loops so the scheduling logic lives (and is tested) in one place.
+    """
+    candidate = datetime.combine(now.date(), dtime(hour_utc, 0), tzinfo=timezone.utc)
+    if candidate <= now:
+        candidate += timedelta(days=1)
+    return candidate

--- a/main.py
+++ b/main.py
@@ -15,7 +15,7 @@ import logging
 import os
 import secrets
 from contextlib import asynccontextmanager
-from datetime import datetime, time as dtime, timedelta, timezone
+from datetime import datetime, timezone
 from pathlib import Path
 
 from dotenv import load_dotenv
@@ -51,12 +51,22 @@ if TOKEN:
     telegram_app = build_application(TOKEN)
 
 
-# Daily error scan: runs once a day inside the bot process because the Fly
-# volume holding the SQLite DB can only be attached to one machine at a time.
-# Disabled when SCAN_ERRORS_ENABLED is unset/false so local dev doesn't file
-# issues by accident.
+# Daily maintenance loops run once a day inside the bot process because the Fly
+# volume holding the SQLite DB can only be attached to one machine at a time —
+# a separate scheduled machine couldn't open the same database.
+from bot.scheduling import next_daily_run  # noqa: E402
+
+# Error scan: disabled when SCAN_ERRORS_ENABLED is unset/false so local dev
+# doesn't file GH issues by accident.
 _SCAN_ERRORS_ENABLED = os.getenv("SCAN_ERRORS_ENABLED", "").lower() in ("1", "true", "yes")
 _SCAN_HOUR_UTC = int(os.getenv("SCAN_ERRORS_HOUR_UTC", "3"))
+
+# Prune: bounds disk growth (old error_log, expired caches/jobs/link codes).
+# Defaults ON — it's idempotent and side-effect-free (only deletes already-
+# expired rows), so it should just run in prod without a manual flag. Offset an
+# hour from the scan so the two don't fire together. Opt out with PRUNE_ENABLED=false.
+_PRUNE_ENABLED = os.getenv("PRUNE_ENABLED", "true").lower() in ("1", "true", "yes")
+_PRUNE_HOUR_UTC = int(os.getenv("PRUNE_HOUR_UTC", "4"))
 
 
 async def _daily_error_scan_loop() -> None:
@@ -65,9 +75,7 @@ async def _daily_error_scan_loop() -> None:
 
     while True:
         now = datetime.now(timezone.utc)
-        next_run = datetime.combine(now.date(), dtime(_SCAN_HOUR_UTC, 0), tzinfo=timezone.utc)
-        if next_run <= now:
-            next_run += timedelta(days=1)
+        next_run = next_daily_run(now, _SCAN_HOUR_UTC)
         sleep_s = (next_run - now).total_seconds()
         logger.info("Next error scan at %s UTC (%.0fs)", next_run.isoformat(), sleep_s)
         try:
@@ -77,6 +85,25 @@ async def _daily_error_scan_loop() -> None:
             raise
         except Exception:
             logger.exception("Daily error scan failed; will retry tomorrow")
+
+
+async def _daily_prune_loop() -> None:
+    """Wake once a day at PRUNE_HOUR_UTC and run bot.db.prune_maintenance."""
+    from bot.db import prune_maintenance
+
+    while True:
+        now = datetime.now(timezone.utc)
+        next_run = next_daily_run(now, _PRUNE_HOUR_UTC)
+        sleep_s = (next_run - now).total_seconds()
+        logger.info("Next prune at %s UTC (%.0fs)", next_run.isoformat(), sleep_s)
+        try:
+            await asyncio.sleep(sleep_s)
+            counts = await asyncio.to_thread(prune_maintenance)
+            logger.info("prune: %s", counts)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("Daily prune failed; will retry tomorrow")
 
 
 @asynccontextmanager
@@ -104,17 +131,20 @@ async def lifespan(app: FastAPI):
             logger.info("Telegram polling started")
         await telegram_app.start()
 
-    scan_task: asyncio.Task | None = None
+    maintenance_tasks: list[asyncio.Task] = []
     if _SCAN_ERRORS_ENABLED:
-        scan_task = asyncio.create_task(_daily_error_scan_loop())
+        maintenance_tasks.append(asyncio.create_task(_daily_error_scan_loop()))
         logger.info("Daily error scan enabled (hour=%d UTC)", _SCAN_HOUR_UTC)
+    if _PRUNE_ENABLED:
+        maintenance_tasks.append(asyncio.create_task(_daily_prune_loop()))
+        logger.info("Daily prune enabled (hour=%d UTC)", _PRUNE_HOUR_UTC)
 
     yield
 
-    if scan_task:
-        scan_task.cancel()
+    for task in maintenance_tasks:
+        task.cancel()
         try:
-            await scan_task
+            await task
         except asyncio.CancelledError:
             pass
 

--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -1,0 +1,33 @@
+"""Unit tests for the daily-loop scheduling helper shared by the scan + prune
+loops in main.py."""
+from datetime import datetime, timezone
+
+from bot.scheduling import next_daily_run
+
+
+def _utc(y, mo, d, h, mi=0, s=0):
+    return datetime(y, mo, d, h, mi, s, tzinfo=timezone.utc)
+
+
+def test_slot_later_today_is_used():
+    # 01:00, target 04:00 → same day 04:00.
+    assert next_daily_run(_utc(2026, 6, 10, 1), 4) == _utc(2026, 6, 10, 4)
+
+
+def test_slot_already_passed_rolls_to_tomorrow():
+    # 05:00, target 04:00 → next day 04:00.
+    assert next_daily_run(_utc(2026, 6, 10, 5), 4) == _utc(2026, 6, 11, 4)
+
+
+def test_exactly_on_the_slot_rolls_to_tomorrow():
+    # Exactly 04:00 counts as passed, so we don't fire twice in one tick.
+    assert next_daily_run(_utc(2026, 6, 10, 4), 4) == _utc(2026, 6, 11, 4)
+
+
+def test_result_is_always_in_the_future():
+    now = _utc(2026, 6, 10, 4, 0, 1)
+    assert next_daily_run(now, 4) > now
+
+
+def test_crosses_month_boundary():
+    assert next_daily_run(_utc(2026, 6, 30, 23), 4) == _utc(2026, 7, 1, 4)


### PR DESCRIPTION
## Why

`prune_maintenance()` and `scripts/prune.py` already existed, but **nothing scheduled them** — so `error_log`, expired `url_cache`/`llm_cache`/jobs, and dead `link_codes` grow unbounded on the fixed-size Fly volume. Left alone that eventually fills the disk and takes the app down. This was the last open item from the May pre-launch hardening list.

## Approach

A daily in-process loop that mirrors the existing **error-scan** loop. Both deliberately run *inside the bot process* rather than as a separate Fly scheduled machine: the Fly volume holding the SQLite DB attaches to one machine at a time, so a second machine couldn't open the same database.

- **Defaults ON** (`PRUNE_ENABLED=false` to opt out). Prune is idempotent and side-effect-free — it only deletes already-expired rows — so it should just run in prod without a manual flag. (Contrast the scan loop, which stays opt-in because it files GitHub issues.) Avoids the "looks configured but isn't" trap.
- Runs at `PRUNE_HOUR_UTC` (default **04:00 UTC**), offset an hour from the scan so they don't fire together.
- Extracted the shared "next daily run at hour" calc into `bot.scheduling.next_daily_run()` — now used by **both** loops, and unit-tested (incl. the exactly-on-the-slot and month-boundary edges) without needing to import the FastAPI app.

## Tests

New `tests/test_scheduling.py`; `prune_maintenance` itself was already covered in `test_db.py`. Full suite: **280 passed**.

## Deploy note

No new secrets. It activates on next deploy. To pin a different window: `fly secrets set PRUNE_HOUR_UTC=4` (or `PRUNE_ENABLED=false` to disable). Independent of #63 — merge order doesn't matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)