### PR TITLE
perf(capacity): shed heavy work under load instead of OOM/timeout

### DIFF
--- a/bot/api.py
+++ b/bot/api.py
@@ -26,6 +26,7 @@ from bot.pipeline import (
     analyze_url,
 )
 from bot.auth import require_token
+from bot.concurrency import CapacityError, heavy
 from bot.config import MAX_CONTENT_CHARS
 from bot.fetch_errors import user_message as fetch_error_message
 from bot.db import (
@@ -59,6 +60,26 @@ from bot.transcriber import transcribe
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api")
+
+
+async def _heavy_slot():
+    """Dependency that holds a heavy-work slot for the request, shedding with a
+    fast 503 (rather than queuing past the Worker's ~25s timeout) when the box
+    is already saturated. Applied to the fetch+LLM endpoints, not the light ones.
+    Defined above the routes because Depends(...) is evaluated at import time."""
+    try:
+        async with heavy.slot():
+            yield
+    except CapacityError:
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "error": "busy",
+                "message": "We're handling a burst of requests right now — try again in a few seconds.",
+            },
+            headers={"Retry-After": "5"},
+        )
+
 
 # Keeps references to running background tasks alive until they complete.
 # Without this, Python's GC may collect the task before it finishes.
@@ -159,6 +180,7 @@ async def submit_url(
     url: str = Form(...),
     user_note: str = Form(""),
     user_id: int = Depends(require_token),
+    _slot: None = Depends(_heavy_slot),
 ):
     try:
         result = await analyze_url(
@@ -187,6 +209,7 @@ async def submit_file(
     file: UploadFile = File(...),
     user_note: str = Form(""),
     user_id: int = Depends(require_token),
+    _slot: None = Depends(_heavy_slot),
 ):
     mime = file.content_type or ""
     name = file.filename or "file"
@@ -304,7 +327,11 @@ def _pipeline_error_to_http(e: PipelineError, url: str) -> HTTPException:
 
 
 @router.post("/try")
-async def try_url(req: TryRequest, _: None = Depends(_require_try_secret)):
+async def try_url(
+    req: TryRequest,
+    _secret: None = Depends(_require_try_secret),
+    _slot: None = Depends(_heavy_slot),
+):
     """One-shot analysis for anonymous web users.
 
     Authenticated via a shared `x-filter-fyi-secret` header (the Worker is the

--- a/bot/concurrency.py
+++ b/bot/concurrency.py
@@ -1,0 +1,57 @@
+"""Bound concurrent heavy work so a traffic spike can't pile unbounded load
+onto the single Fly machine.
+
+The expensive request paths (fetch + transcode/transcribe + 1-2 LLM calls) hold
+CPU, RAM, and an LLM slot for seconds at a time. Without a cap, a Product-Hunt-
+style burst lets dozens run at once on 2 shared CPUs / 1 GB → OOM or every
+request crawling past the Worker's ~25s budget and timing out together.
+
+A semaphore caps how many run concurrently; callers that can't get a slot
+within a short wait are shed fast (HTTP 503 upstream) instead of queuing
+forever. The limit and wait are env-tunable so they can be raised after a
+vertical VM bump without a redeploy.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from contextlib import asynccontextmanager
+
+logger = logging.getLogger(__name__)
+
+# Max concurrent heavy requests. Sized for a 2-CPU / 1 GB box; raise it (env)
+# after scaling the VM up for a launch.
+HEAVY_CONCURRENCY = int(os.getenv("HEAVY_CONCURRENCY", "8"))
+# How long a request waits for a slot before being shed. Kept well under the
+# Worker's ~25s budget so the caller gets a clean 503, not a timeout.
+HEAVY_ACQUIRE_TIMEOUT_S = float(os.getenv("HEAVY_ACQUIRE_TIMEOUT_S", "2"))
+
+
+class CapacityError(Exception):
+    """No heavy-work slot freed up within the wait budget — shed the request."""
+
+
+class HeavyLimiter:
+    """A semaphore + bounded-wait acquire. One process-wide instance (`heavy`)
+    guards the heavy endpoints; constructed directly in tests."""
+
+    def __init__(self, limit: int, timeout: float):
+        self.limit = limit
+        self.timeout = timeout
+        self._sem = asyncio.Semaphore(limit)
+
+    @asynccontextmanager
+    async def slot(self):
+        try:
+            await asyncio.wait_for(self._sem.acquire(), timeout=self.timeout)
+        except asyncio.TimeoutError:
+            logger.warning("heavy_slot: shedding request — all %d slots busy", self.limit)
+            raise CapacityError
+        try:
+            yield
+        finally:
+            self._sem.release()
+
+
+heavy = HeavyLimiter(HEAVY_CONCURRENCY, HEAVY_ACQUIRE_TIMEOUT_S)

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -85,11 +85,46 @@ monitor disk usage:
 fly volumes list           # check % used
 ```
 
+## Capacity & scaling
+
+The backend is a **single Fly machine** (`min_machines_running = 1`) because the
+canonical SQLite DB lives on one volume that attaches to one machine at a time —
+so **you cannot `fly scale count > 1`** without re-architecting storage. Vertical
+scaling is the lever.
+
+Three guards keep a traffic spike (e.g. a Product Hunt launch) from tipping the
+box into the OOM / 25s-timeout failure mode in the runbook below:
+
+1. **Heavy-work semaphore** (`bot/concurrency.py`) — caps concurrent fetch+LLM
+   requests (`/try`, `/submit/url`, `/submit/file`). Over the cap, callers are
+   shed with a fast `503 {"error":"busy"}` instead of queuing past the Worker's
+   timeout. Tune with `HEAVY_CONCURRENCY` (default 8) / `HEAVY_ACQUIRE_TIMEOUT_S`.
+2. **Thread pool** sized by `EXECUTOR_WORKERS` (default 16) — the IO-bound LLM
+   calls run here; explicit so it doesn't depend on how Fly reports CPUs.
+3. **Fly edge concurrency** (`fly.toml`): `hard_limit = 20` stops a burst from
+   parking dozens of connections on the box.
+
+**Before a launch / expected spike**, scale the VM up — it's reversible:
+
+```sh
+fly scale show -a filter-fyi-backend
+fly scale vm shared-cpu-4x --memory 4096 -a filter-fyi-backend   # 4 CPU / 4 GB
+# then raise the app guards to match the bigger box:
+fly secrets set -a filter-fyi-backend HEAVY_CONCURRENCY=16 EXECUTOR_WORKERS=32
+# and bump hard_limit in fly.toml before `fly deploy`.
+```
+
+Watch `fly logs` for `heavy_slot: shedding request` (you're at the cap → scale
+up) and machine CPU/RAM in the Fly dashboard. The durable fix for long jobs
+(video transcription holding a slot > 25s) is moving them to background jobs —
+see the roadmap; not yet implemented.
+
 ## Required environment / secrets
 
 | Var | Purpose |
 | --- | --- |
 | `FILTER_FYI_TRY_SECRET` | Shared secret with the Cloudflare Worker (must match) |
+| `HEAVY_CONCURRENCY`, `EXECUTOR_WORKERS` | Capacity tuning (see Capacity & scaling) — safe defaults, raise after a VM bump |
 | `FILTER_FYI_ADMIN_SECRET` | Shared secret for `/api/admin/*` — must match the Worker's `BOT_ADMIN_KEY`. Separate from `FILTER_FYI_TRY_SECRET` so the two can rotate independently |
 | `TELEGRAM_TOKEN` | Telegram bot token (omit to run web-only) |
 | `WEBHOOK_URL` | Public base URL for Telegram webhook mode |

--- a/fly.toml
+++ b/fly.toml
@@ -22,10 +22,14 @@ primary_region = 'fra'
   auto_start_machines = true
   min_machines_running = 1
 
+  # Edge backstop. The app-level bot.concurrency semaphore (default 8) is the
+  # real guard on heavy work; these stop a burst from parking dozens of
+  # connections on a 1 GB box (which previously soaked worker slots → OOM /
+  # 25s timeouts — see OPERATIONS.md runbook). Raise after a VM bump.
   [http_service.concurrency]
     type = 'requests'
-    hard_limit = 40
-    soft_limit = 20
+    hard_limit = 20
+    soft_limit = 10
 
   [[http_service.checks]]
     interval = '30s'

--- a/main.py
+++ b/main.py
@@ -106,8 +106,26 @@ async def _daily_prune_loop() -> None:
             logger.exception("Daily prune failed; will retry tomorrow")
 
 
+# The heavy request paths offload their blocking fetch/transcode/LLM work via
+# loop.run_in_executor(None, ...). Size that pool explicitly instead of relying
+# on the interpreter default (min(32, cpu_count+4)), which varies with how Fly
+# reports CPUs. Threads here are IO-bound (network LLM calls), so we can afford
+# more than the CPU count; the real ceiling on concurrent heavy work is the
+# bot.concurrency semaphore.
+_EXECUTOR_WORKERS = int(os.getenv("EXECUTOR_WORKERS", "16"))
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    import concurrent.futures
+
+    asyncio.get_running_loop().set_default_executor(
+        concurrent.futures.ThreadPoolExecutor(
+            max_workers=_EXECUTOR_WORKERS, thread_name_prefix="heavy"
+        )
+    )
+    logger.info("Default thread pool sized to %d workers", _EXECUTOR_WORKERS)
+
     if telegram_app:
         await telegram_app.initialize()
         if WEBHOOK_URL:

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,0 +1,80 @@
+"""Tests for the heavy-work limiter that sheds load during a spike."""
+import asyncio
+
+import pytest
+
+from bot.concurrency import CapacityError, HeavyLimiter
+
+
+def test_sheds_when_all_slots_busy():
+    async def scenario():
+        lim = HeavyLimiter(limit=2, timeout=0.05)
+        # Fill both slots and hold them.
+        cm1, cm2 = lim.slot(), lim.slot()
+        await cm1.__aenter__()
+        await cm2.__aenter__()
+
+        # A third caller can't get in within the timeout → shed.
+        with pytest.raises(CapacityError):
+            async with lim.slot():
+                pass
+
+        # Free one slot; now a caller gets in.
+        await cm1.__aexit__(None, None, None)
+        async with lim.slot():
+            pass
+
+        await cm2.__aexit__(None, None, None)
+
+    asyncio.run(scenario())
+
+
+def test_slot_is_released_after_use():
+    async def scenario():
+        lim = HeavyLimiter(limit=1, timeout=0.05)
+        # Use and release the single slot repeatedly — no leak.
+        for _ in range(3):
+            async with lim.slot():
+                pass
+        # Still acquirable afterwards.
+        async with lim.slot():
+            pass
+
+    asyncio.run(scenario())
+
+
+def test_slot_released_even_when_body_raises():
+    async def scenario():
+        lim = HeavyLimiter(limit=1, timeout=0.05)
+        with pytest.raises(ValueError):
+            async with lim.slot():
+                raise ValueError("boom")
+        # The exception must not have leaked the slot.
+        async with lim.slot():
+            pass
+
+    asyncio.run(scenario())
+
+
+def test_waiter_gets_in_once_a_slot_frees():
+    async def scenario():
+        lim = HeavyLimiter(limit=1, timeout=1.0)
+        cm = lim.slot()
+        await cm.__aenter__()
+
+        async def release_soon():
+            await asyncio.sleep(0.02)
+            await cm.__aexit__(None, None, None)
+
+        # Waiter blocks until release_soon frees the slot — no CapacityError.
+        async with asyncio.timeout(0.5):
+            await asyncio.gather(
+                release_soon(),
+                _acquire_and_release(lim),
+            )
+
+    async def _acquire_and_release(lim):
+        async with lim.slot():
+            pass
+
+    asyncio.run(scenario())


### PR DESCRIPTION
## Why

Pre-launch hardening for a **Product Hunt-style spike** (the "1000 users signing in, 10 req/day each, concentrated" scenario). The backend is a **single 1GB / 2-CPU Fly machine** — and can't `fly scale count > 1` because the canonical SQLite DB is on one volume. The heavy paths (`/try`, `/submit/url`, `/submit/file`) hold CPU, RAM, and an LLM slot for seconds each; under a burst they piled up unbounded → the OOM / 25s-timeout failure mode already documented in the runbook.

## Three guards (all env-tunable)

1. **Heavy-work semaphore** — `bot/concurrency.py`, a `HeavyLimiter` (default `HEAVY_CONCURRENCY=8`) applied to the three fetch+LLM endpoints. Over the cap, a request waits briefly then is **shed with a fast `503 {"error":"busy"}`** (`Retry-After: 5`) instead of queuing past the Worker's ~25s budget and everyone timing out together.
2. **Explicit thread pool** — `main.py` sizes the `run_in_executor` pool (`EXECUTOR_WORKERS=16`) rather than relying on the interpreter default `min(32, cpu_count+4)`, which varies with how Fly reports CPUs. These threads are IO-bound (network LLM calls), so we can run more than the CPU count; the semaphore is the real ceiling.
3. **Edge backstop** — `fly.toml` `hard_limit` 40 → 20, so a burst can't park dozens of connections on a 1GB box.

## Scaling

`OPERATIONS.md` gains a **Capacity & scaling** section: the pre-spike `fly scale vm shared-cpu-4x --memory 4096` recipe (+ raising `HEAVY_CONCURRENCY`/`EXECUTOR_WORKERS` to match), what to watch (`heavy_slot: shedding request` in logs), and the explicit note that **horizontal scale is blocked by the single SQLite volume**. The durable fix for long video jobs (background processing so they don't hold a slot > 25s) remains roadmap.

## Tests

New `tests/test_concurrency.py` (sheds when full, releases after use, releases on exception, waiter gets in once a slot frees). The existing `test_api` suite exercises the happy path through the new dependency. **284 passed.**

## Note for the frontend Worker

The backend now returns `503 {"error":"busy", "message": …}` under saturation. The Worker already surfaces backend failure messages (#39), so this should render as a friendly "try again in a few seconds." Worth a quick confirm during the spike; a dedicated busy-state UI could be a fast follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)