### PR TITLE
fix(capacity): guard at analyze_url so the async job path is bounded too

### DIFF
--- a/bot/api.py
+++ b/bot/api.py
@@ -19,6 +19,7 @@ from bot.analyzer import UsageContext, analyze, analyze_image, to_json_str, to_p
 from bot.agent_brief import build_actions
 from bot.pipeline import (
     ERR_ANALYZE_FAILED,
+    ERR_BUSY,
     ERR_FETCH_FAILED,
     ERR_NO_TEXT,
     ERR_NO_TRANSCRIPT,
@@ -63,10 +64,11 @@ router = APIRouter(prefix="/api")
 
 
 async def _heavy_slot():
-    """Dependency that holds a heavy-work slot for the request, shedding with a
-    fast 503 (rather than queuing past the Worker's ~25s timeout) when the box
-    is already saturated. Applied to the fetch+LLM endpoints, not the light ones.
-    Defined above the routes because Depends(...) is evaluated at import time."""
+    """Holds a heavy-work slot for the request, shedding with a fast 503 when
+    the box is saturated. Used by the direct-analysis endpoints that do NOT go
+    through `analyze_url` (which takes its own slot) — currently `/submit/file`,
+    whose transcribe+analyze work is heavy in its own right. Defined above the
+    routes because Depends(...) is evaluated at import time."""
     try:
         async with heavy.slot():
             yield
@@ -89,6 +91,11 @@ _background_tasks: set[asyncio.Task] = set()
 # can tell the browser what stage it's at. Keyed by job_id; cleaned up in the
 # finally block of _run_job. Safe for the single-process Fly deployment.
 _job_steps: dict[str, str] = {}
+
+# How long a polling job waits for a heavy-work slot before giving up as busy.
+# Generous (the browser is patiently polling) so transient bursts queue and
+# succeed rather than failing fast like the synchronous web callers do.
+_JOB_CAPACITY_WAIT_S = float(os.getenv("JOB_CAPACITY_WAIT_S", "45"))
 
 # Preview length sent to the Worker — keeps the payload compact while still
 # giving the UI something to render. The full extracted text only ever exists
@@ -180,7 +187,6 @@ async def submit_url(
     url: str = Form(...),
     user_note: str = Form(""),
     user_id: int = Depends(require_token),
-    _slot: None = Depends(_heavy_slot),
 ):
     try:
         result = await analyze_url(
@@ -311,6 +317,12 @@ def _pipeline_error_to_http(e: PipelineError, url: str) -> HTTPException:
     URL endpoint returns — kept centralised so the Worker contract stays
     consistent across /api/try, /api/library/add, and /api/job results."""
     reason = e.fetched.get("reason")
+    if e.code == ERR_BUSY:
+        return HTTPException(
+            status_code=503,
+            detail={"error": "busy", "message": str(e)},
+            headers={"Retry-After": "5"},
+        )
     if e.code in (ERR_NO_TEXT, ERR_NO_TRANSCRIPT):
         return HTTPException(
             status_code=422,
@@ -327,11 +339,7 @@ def _pipeline_error_to_http(e: PipelineError, url: str) -> HTTPException:
 
 
 @router.post("/try")
-async def try_url(
-    req: TryRequest,
-    _secret: None = Depends(_require_try_secret),
-    _slot: None = Depends(_heavy_slot),
-):
+async def try_url(req: TryRequest, _: None = Depends(_require_try_secret)):
     """One-shot analysis for anonymous web users.
 
     Authenticated via a shared `x-filter-fyi-secret` header (the Worker is the
@@ -771,6 +779,10 @@ async def _run_job(
                 save_for_user_id=user_id,
                 user_note=user_note,
                 on_step=_on_step,
+                # The browser is polling, not holding a 25s request — so queue
+                # for a slot under load instead of shedding immediately. Only
+                # errors as busy if the backlog is still draining after this.
+                capacity_timeout=_JOB_CAPACITY_WAIT_S,
             )
         except PipelineError as e:
             set_job_error(job_id, e.code, fetch_error_message(e.fetched.get("reason"), url))

--- a/bot/concurrency.py
+++ b/bot/concurrency.py
@@ -34,24 +34,38 @@ class CapacityError(Exception):
 
 class HeavyLimiter:
     """A semaphore + bounded-wait acquire. One process-wide instance (`heavy`)
-    guards the heavy endpoints; constructed directly in tests."""
+    guards every heavy path; constructed directly in tests.
+
+    `acquire`/`release` are used to wrap a long body that has its own
+    try/finally (the URL pipeline); `slot()` is the same thing as a context
+    manager for callers that don't (e.g. file uploads)."""
 
     def __init__(self, limit: int, timeout: float):
         self.limit = limit
         self.timeout = timeout
         self._sem = asyncio.Semaphore(limit)
 
-    @asynccontextmanager
-    async def slot(self):
+    async def acquire(self, timeout: float | None = None) -> None:
+        """Wait up to `timeout` (default `self.timeout`) for a slot; raise
+        CapacityError if none frees up. A larger timeout lets a caller queue
+        (e.g. the polling job runner) rather than shed (synchronous web)."""
+        wait = self.timeout if timeout is None else timeout
         try:
-            await asyncio.wait_for(self._sem.acquire(), timeout=self.timeout)
+            await asyncio.wait_for(self._sem.acquire(), timeout=wait)
         except asyncio.TimeoutError:
-            logger.warning("heavy_slot: shedding request — all %d slots busy", self.limit)
+            logger.warning("heavy: shedding work — all %d slots busy", self.limit)
             raise CapacityError
+
+    def release(self) -> None:
+        self._sem.release()
+
+    @asynccontextmanager
+    async def slot(self, timeout: float | None = None):
+        await self.acquire(timeout)
         try:
             yield
         finally:
-            self._sem.release()
+            self.release()
 
 
 heavy = HeavyLimiter(HEAVY_CONCURRENCY, HEAVY_ACQUIRE_TIMEOUT_S)

--- a/bot/pipeline.py
+++ b/bot/pipeline.py
@@ -41,6 +41,7 @@ from bot.analyzer import (
     summarize_content,
     to_json_str,
 )
+from bot.concurrency import CapacityError, heavy
 from bot.db import record_processed_url, save_item
 from bot.fetcher import fetch_url, whisper_cap_for
 
@@ -62,6 +63,7 @@ ERR_FETCH_FAILED = "fetch-failed"            # network / timeout / connector err
 ERR_NO_TEXT = "extraction-failed"            # fetch ok but yielded empty text
 ERR_NO_TRANSCRIPT = "no-transcript"          # video-with-no-transcript variant of NO_TEXT
 ERR_ANALYZE_FAILED = "analyze-failed"        # LLM call failed mid-chain
+ERR_BUSY = "busy"                            # shed: no heavy-work slot free (overload)
 
 _VIDEO_SOURCE_TYPES: frozenset[str] = frozenset({"youtube", "video"})
 
@@ -115,6 +117,7 @@ async def analyze_url(
     include_images: bool | None = None,
     max_whisper_duration: int | None = None,
     on_step: Optional[Callable[[str], None]] = None,
+    capacity_timeout: float | None = None,
 ) -> PipelineResult:
     """Run the full URL → analysis chain.
 
@@ -135,6 +138,11 @@ async def analyze_url(
     `on_step` is an optional sync callback invoked with stable labels
     ("fetching" | "describing-images" | "summarizing" | "analyzing") so
     callers like the async job runner can surface progress to the UI.
+
+    `capacity_timeout` caps how long we wait for a heavy-work slot before
+    shedding with `PipelineError(ERR_BUSY)`. None → the limiter default (short;
+    synchronous web callers shed fast so they don't blow the Worker's ~25s
+    budget); the polling job runner passes a larger value to queue instead.
     """
     def _step(label: str) -> None:
         if on_step is not None:
@@ -145,6 +153,16 @@ async def analyze_url(
 
     if max_whisper_duration is None:
         max_whisper_duration = whisper_cap_for(signed_in=ctx.user_id is not None)
+
+    # Bound total concurrent heavy work across EVERY entry point (web /try, the
+    # async job runner, /library/add, Telegram) by taking a slot before any
+    # fetch/transcribe/LLM work — this is the one chokepoint they all share.
+    # Acquired outside the audit `try` so a shed request isn't recorded as
+    # processed; released in that try's `finally`.
+    try:
+        await heavy.acquire(capacity_timeout)
+    except CapacityError:
+        raise PipelineError(ERR_BUSY, message="Service is busy; please try again in a few seconds.")
 
     # Audit-log bookkeeping. Every successful AND failed call writes one row
     # to `processed_urls`, so the Usage tile can show "what we tried and how
@@ -237,6 +255,8 @@ async def analyze_url(
         audit_error_code = e.code
         raise
     finally:
+        # Free the slot before the audit write so a waiter can start sooner.
+        heavy.release()
         record_processed_url(
             url=url,
             title=fetched.get("title") or "",

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -95,10 +95,15 @@ scaling is the lever.
 Three guards keep a traffic spike (e.g. a Product Hunt launch) from tipping the
 box into the OOM / 25s-timeout failure mode in the runbook below:
 
-1. **Heavy-work semaphore** (`bot/concurrency.py`) — caps concurrent fetch+LLM
-   requests (`/try`, `/submit/url`, `/submit/file`). Over the cap, callers are
-   shed with a fast `503 {"error":"busy"}` instead of queuing past the Worker's
-   timeout. Tune with `HEAVY_CONCURRENCY` (default 8) / `HEAVY_ACQUIRE_TIMEOUT_S`.
+1. **Heavy-work semaphore** (`bot/concurrency.py`) — caps concurrent heavy work
+   at the one chokepoint every URL path shares, `pipeline.analyze_url` (web
+   `/try`, the async job runner `/job`→`_run_job`, `/library/add`, Telegram).
+   Synchronous web callers shed fast with `503 {"error":"busy"}` rather than
+   queuing past the Worker's ~25s budget; the polling **job runner** waits up to
+   `JOB_CAPACITY_WAIT_S` (default 45) so transient bursts queue and still
+   succeed. `/submit/file` (transcribe+analyze, no `analyze_url`) takes the same
+   slot via a route dependency. Tune with `HEAVY_CONCURRENCY` (default 8) /
+   `HEAVY_ACQUIRE_TIMEOUT_S` (default 2, the synchronous shed budget).
 2. **Thread pool** sized by `EXECUTOR_WORKERS` (default 16) — the IO-bound LLM
    calls run here; explicit so it doesn't depend on how Fly reports CPUs.
 3. **Fly edge concurrency** (`fly.toml`): `hard_limit = 20` stops a burst from

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -78,3 +78,39 @@ def test_waiter_gets_in_once_a_slot_frees():
             pass
 
     asyncio.run(scenario())
+
+
+def test_acquire_release_pair_frees_the_slot():
+    async def scenario():
+        lim = HeavyLimiter(limit=1, timeout=0.05)
+        await lim.acquire()
+        # No slot left → next acquire sheds.
+        with pytest.raises(CapacityError):
+            await lim.acquire()
+        lim.release()
+        # Freed → acquire succeeds again.
+        await lim.acquire()
+        lim.release()
+
+    asyncio.run(scenario())
+
+
+def test_acquire_timeout_override_beats_the_default():
+    async def scenario():
+        # Default timeout is tiny, but a generous per-call override lets a
+        # caller queue until a slot frees (the job-runner pattern).
+        lim = HeavyLimiter(limit=1, timeout=0.01)
+        await lim.acquire()
+
+        async def release_soon():
+            await asyncio.sleep(0.05)
+            lim.release()
+
+        async def queue_with_override():
+            await lim.acquire(timeout=1.0)  # waits past the 0.01 default
+            lim.release()
+
+        async with asyncio.timeout(0.5):
+            await asyncio.gather(release_soon(), queue_with_override())
+
+    asyncio.run(scenario())

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -351,3 +351,68 @@ class TestProgressCallback:
             "x", ctx=UsageContext(), on_step=bad_callback,
         ))
         assert result.analysis["verdict"] == "watch"  # ran to completion
+
+
+class TestCapacityGuard:
+    """analyze_url is the single chokepoint that bounds heavy work for every
+    entry point (web /try, the async job runner, /library/add, Telegram)."""
+
+    def test_sheds_with_busy_when_no_slot(self, pipeline, monkeypatch):
+        from bot.analyzer import UsageContext
+        from bot.concurrency import HeavyLimiter
+
+        # No free slots → acquire times out → ERR_BUSY, raised before any fetch.
+        monkeypatch.setattr(pipeline, "heavy", HeavyLimiter(limit=0, timeout=0.01))
+        with pytest.raises(pipeline.PipelineError) as ei:
+            asyncio.run(pipeline.analyze_url("https://example.com", ctx=UsageContext()))
+        assert ei.value.code == pipeline.ERR_BUSY
+
+    def test_shed_happens_before_fetch(self, pipeline, monkeypatch):
+        from bot.analyzer import UsageContext
+        from bot.concurrency import HeavyLimiter
+
+        called = {"fetch": False}
+
+        async def tripwire_fetch(url, **kwargs):
+            called["fetch"] = True
+            return {}
+
+        monkeypatch.setattr(pipeline, "fetch_url", tripwire_fetch)
+        monkeypatch.setattr(pipeline, "heavy", HeavyLimiter(limit=0, timeout=0.01))
+        with pytest.raises(pipeline.PipelineError):
+            asyncio.run(pipeline.analyze_url("https://example.com", ctx=UsageContext()))
+        assert called["fetch"] is False  # shed without spending a fetch
+
+    def test_slot_released_across_sequential_calls(self, pipeline, monkeypatch):
+        from bot.analyzer import UsageContext
+        from bot.concurrency import HeavyLimiter
+
+        # Capacity 1: if the slot leaked, the 2nd call would time out as busy.
+        monkeypatch.setattr(pipeline, "heavy", HeavyLimiter(limit=1, timeout=0.3))
+        for _ in range(3):
+            result = asyncio.run(
+                pipeline.analyze_url("https://example.com", ctx=UsageContext())
+            )
+            assert result.analysis["verdict"] == "watch"
+
+    def test_slot_released_even_when_analyze_fails(self, pipeline, monkeypatch):
+        from bot.analyzer import UsageContext
+        from bot.concurrency import HeavyLimiter
+
+        monkeypatch.setattr(pipeline, "heavy", HeavyLimiter(limit=1, timeout=0.3))
+
+        def boom(text, **_kwargs):
+            raise RuntimeError("llm down")
+
+        monkeypatch.setattr(pipeline, "analyze", boom)
+        with pytest.raises(pipeline.PipelineError):
+            asyncio.run(pipeline.analyze_url("https://example.com", ctx=UsageContext()))
+
+        # The slot must be free again — a working call now succeeds.
+        monkeypatch.setattr(
+            pipeline, "analyze", lambda text, **_k: {"verdict": "watch"}
+        )
+        result = asyncio.run(
+            pipeline.analyze_url("https://example.com", ctx=UsageContext())
+        )
+        assert result.analysis["verdict"] == "watch"


### PR DESCRIPTION
## Why

Follow-up to #65, fixing a hole the `/code-review` caught: the semaphore was a per-endpoint dependency on `/try`, `/submit/url`, `/submit/file` — but the **Worker's primary analysis path is `/job`**, whose background `_run_job()` calls `analyze_url()` directly ([api.py docstring](../bot/api.py): *"The Worker calls this instead of /api/try or /api/library/add"*). That path took **no slot**, so a Product Hunt-style spike — the exact scenario #65 set out to protect — bypassed the cap entirely and could still OOM the 1 GB box. `/library/add` and the Telegram URL handler had the same gap.

## Fix — guard the shared chokepoint, not the endpoints

Moved the semaphore into `pipeline.analyze_url`, which **every** URL path routes through. It takes a heavy slot before any fetch/transcribe/LLM work and releases it in the existing `finally`. Now `/try`, `/job`→`_run_job`, `/library/add`, and Telegram are all bounded by one semaphore.

Shed-vs-queue is chosen per caller, since their deadlines differ:
- **Synchronous web** (`/try`, `/submit/url`, `/library/add`) — shed fast (default ~2 s wait → `PipelineError(ERR_BUSY)` → **503 `{"error":"busy"}`**) so they don't blow the Worker's ~25 s budget.
- **Polling job runner** (`_run_job`) — waits up to `JOB_CAPACITY_WAIT_S` (default **45 s**) so transient bursts queue and still succeed. Queued jobs block on the semaphore *before* fetching, so they hold no Chromium/buffers — cheap to queue.
- `/submit/file` keeps its route-dependency slot (it does transcribe+analyze without `analyze_url`); same semaphore, no double-acquire.

Removed the now-redundant `_heavy_slot` dependency from `/try` and `/submit/url` to avoid a double-acquire (and self-deadlock) now that `analyze_url` self-guards.

## API

`HeavyLimiter` gains `acquire()`/`release()` (with `slot()` built on them) and a per-call timeout override.

## Tests

New cases in `test_pipeline.py` (ERR_BUSY shed, shed happens *before* fetch, slot released across sequential calls, slot released even when `analyze` raises) and `test_concurrency.py` (acquire/release symmetry, timeout override). **290 passed.**

## Note

A determined flood of `/job` POSTs can still spawn many *queued* `_run_job` tasks (each cheap while blocked on the semaphore). Bounding the queue depth / shedding new `/job`s when the backlog is deep is a possible follow-up, but the OOM vector (unbounded *concurrent* heavy work) is closed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)