### PR TITLE
feat(signals): close the feedback loop into analyze() (#69)

### DIFF
--- a/bot/analyzer.py
+++ b/bot/analyzer.py
@@ -268,7 +268,7 @@ DEFAULT_PROFILE = (
 
 
 _PROMPT = """You are my personal AI research analyst.
-{profile_block}
+{profile_block}{signals_block}
 Analyze the following content and produce a structured analysis covering the required fields. Be concrete and specific to this person — `why_it_matters` should speak to their situation, not give generic advice.
 
 The suggestions are the point of this analysis — make them the strongest part:
@@ -295,6 +295,20 @@ def _load_profile(user_id: int | None) -> str:
         return DEFAULT_PROFILE
     from bot.db import get_user_profile
     return get_user_profile(user_id) or DEFAULT_PROFILE
+
+
+def _load_signals(user_id: int | None) -> str:
+    """Behaviour-signal digest for signed-in users (see bot/signals.py).
+    Empty for anon users and on any failure — signals are an enhancement and
+    must never break analysis."""
+    if user_id is None:
+        return ""
+    try:
+        from bot.signals import build_signal_digest
+        return build_signal_digest(user_id)
+    except Exception:
+        logger.exception("signal digest failed; analysing without signals")
+        return ""
 
 
 def _normalize(raw: dict) -> dict:
@@ -366,7 +380,7 @@ def _legacy_suggestions(raw: dict) -> list[dict]:
 # hit-rate tile to the admin dashboard separately once we have a feel for
 # how often this fires.
 
-def _cache_key_analyze(text: str, profile: str, model: str) -> str:
+def _cache_key_analyze(text: str, profile: str, model: str, signals: str = "") -> str:
     h = hashlib.sha256()
     h.update(b"analyze\x00")
     h.update(_PROVIDER.encode()); h.update(b"\x00")
@@ -374,6 +388,9 @@ def _cache_key_analyze(text: str, profile: str, model: str) -> str:
     h.update(_PROMPT.encode()); h.update(b"\x00")
     h.update(json.dumps(_TOOL_SCHEMA, sort_keys=True).encode()); h.update(b"\x00")
     h.update((profile or "").encode()); h.update(b"\x00")
+    # Behaviour-signal digest (#69). Day-coarsened upstream (bot/signals.py),
+    # so the key is stable within a UTC day rather than churning per click.
+    h.update((signals or "").encode()); h.update(b"\x00")
     h.update(text.encode())
     return h.hexdigest()
 
@@ -458,13 +475,14 @@ def analyze(text: str, user_id: int | None = None, *, ctx: UsageContext | None =
         ctx = UsageContext(user_id=user_id, anon_id=ctx.anon_id, job_id=ctx.job_id, source_type=ctx.source_type)
 
     profile = _load_profile(ctx.user_id)
+    signals = _load_signals(ctx.user_id)
     model = _resolve_model("analyze", ctx)
 
     # Content-addressed cache lookup. Key spans every input that affects the
     # output, so a prompt/model/schema change auto-invalidates. Skips the
     # upstream LLM call entirely on hit — no llm_calls row written because
     # nothing was actually called.
-    cache_key = _cache_key_analyze(text, profile, model)
+    cache_key = _cache_key_analyze(text, profile, model, signals)
     cached = _try_cache_get(cache_key)
     if cached is not None:
         try:
@@ -478,7 +496,12 @@ def analyze(text: str, user_id: int | None = None, *, ctx: UsageContext | None =
             logger.warning("analyze cache had non-JSON payload; refreshing")
 
     profile_block = f"\nAbout the person you are analysing for:\n{profile}\n" if profile else ""
-    prompt = _PROMPT.format(profile_block=profile_block, text=text)
+    signals_block = f"\n{signals}\n" if signals else ""
+    prompt = _PROMPT.format(profile_block=profile_block, signals_block=signals_block, text=text)
+
+    # Traces feed the eval pipeline — they must capture the full
+    # personalization context the model saw, signals included.
+    trace_profile = profile + (f"\n\n[signals]\n{signals}" if signals else "")
 
     client = _get_client()
     started = time.monotonic()
@@ -497,7 +520,7 @@ def analyze(text: str, user_id: int | None = None, *, ctx: UsageContext | None =
             for block in resp.content:
                 if getattr(block, "type", None) == "tool_use" and block.name == "record_analysis":
                     result = _normalize(block.input)
-                    _capture_trace(model=model, text=text, profile=profile, output=result, ctx=ctx)
+                    _capture_trace(model=model, text=text, profile=trace_profile, output=result, ctx=ctx)
                     _try_cache_set(cache_key, "analyze", json.dumps(result, ensure_ascii=False))
                     return result
             raise RuntimeError("Anthropic did not return a record_analysis tool_use block")
@@ -516,7 +539,7 @@ def analyze(text: str, user_id: int | None = None, *, ctx: UsageContext | None =
         except json.JSONDecodeError as e:
             raise RuntimeError(f"OpenAI returned non-JSON content: {e}: {content[:200]}")
         result = _normalize(raw)
-        _capture_trace(model=model, text=text, profile=profile, output=result, ctx=ctx)
+        _capture_trace(model=model, text=text, profile=trace_profile, output=result, ctx=ctx)
         _try_cache_set(cache_key, "analyze", json.dumps(result, ensure_ascii=False))
         return result
     except Exception as e:

--- a/bot/api.py
+++ b/bot/api.py
@@ -34,6 +34,7 @@ from bot.db import (
     FEEDBACK_SIGNALS,
     LINK_CODE_TTL_SECONDS,
     SAVED_SUGGESTION_STATUSES,
+    SUGGESTION_SIGNAL_EVENTS,
     create_job,
     create_link_code,
     delete_item,
@@ -43,9 +44,11 @@ from bot.db import (
     get_item,
     get_job_record,
     get_saved_suggestions,
+    get_suggestion_signals,
     get_user,
     get_user_profile,
     record_feedback,
+    record_suggestion_signal,
     save_item,
     save_suggestion,
     search_items,
@@ -463,6 +466,17 @@ async def user_export(user_id: int, _: None = Depends(_require_try_secret)):
             }
             for s in get_saved_suggestions(user_id)
         ],
+        "suggestion_signals": [
+            {
+                "url": r["url"],
+                "event": r["event"],
+                "suggestion_index": r["suggestion_index"],
+                "suggestion_text": r["suggestion_text"],
+                "reason": r["reason"],
+                "created_at": r["created_at"],
+            }
+            for r in get_suggestion_signals(user_id, limit=10_000)
+        ],
     }
 
 
@@ -527,6 +541,40 @@ async def feedback(req: _FeedbackRequest, _: None = Depends(_require_try_secret)
     if not get_item(req.item_id, req.user_id):
         raise HTTPException(status_code=404, detail={"error": "not-found"})
     record_feedback(req.user_id, req.item_id, req.signal)
+
+
+class _SuggestionSignalRequest(BaseModel):
+    user_id: int
+    event: str
+    url: str = ""
+    suggestion_index: int | None = None
+    suggestion_text: str = ""
+    reason: str = ""
+
+
+@router.post("/suggestion-signals", status_code=201)
+async def suggestion_signal(
+    req: _SuggestionSignalRequest, _: None = Depends(_require_try_secret)
+):
+    """Record one suggestion interaction event for a signed-in user (#69).
+
+    Forwarded by the Worker alongside its D1 write — D1 keeps the canonical
+    stream (incl. anonymous traffic) for product analytics; this copy is what
+    the analyzer's behaviour-signal digest reads (bot/signals.py). Signed-in
+    only by design: anon events can't personalize anything.
+    """
+    if req.event not in SUGGESTION_SIGNAL_EVENTS:
+        raise HTTPException(status_code=400, detail={"error": "invalid-event"})
+    if not get_user(req.user_id):
+        raise HTTPException(status_code=404, detail={"error": "not-found"})
+    record_suggestion_signal(
+        req.user_id,
+        req.event,
+        url=req.url,
+        suggestion_index=req.suggestion_index,
+        suggestion_text=req.suggestion_text,
+        reason=req.reason,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/bot/db.py
+++ b/bot/db.py
@@ -133,6 +133,7 @@ _CREATE_INDEXES_SQL = [
     "CREATE INDEX IF NOT EXISTS idx_feedback_item ON feedback(item_id)",
     "CREATE INDEX IF NOT EXISTS idx_saved_suggestions_user ON saved_suggestions(user_id, created_at DESC)",
     "CREATE INDEX IF NOT EXISTS idx_saved_suggestions_item ON saved_suggestions(item_id)",
+    "CREATE INDEX IF NOT EXISTS idx_suggestion_signals_user ON suggestion_signals(user_id, created_at DESC)",
     "CREATE INDEX IF NOT EXISTS idx_jobs_updated_at ON jobs(updated_at DESC)",
     "CREATE INDEX IF NOT EXISTS idx_llm_calls_ts ON llm_calls(ts DESC)",
     "CREATE INDEX IF NOT EXISTS idx_llm_calls_user ON llm_calls(user_id, ts DESC)",
@@ -301,6 +302,33 @@ CREATE TABLE IF NOT EXISTS processed_urls (
 # available without re-collecting.
 PROCESSED_URLS_RETENTION_SECONDS = 90 * 24 * 3_600
 
+# Suggestion-level interaction signals for signed-in users, forwarded by the
+# Worker (the canonical event stream incl. anonymous traffic stays in D1 —
+# this copy exists so the analyzer can learn from dismiss reasons and
+# tried/done outcomes; see bot/signals.py). Mirrors the Worker's
+# SUGGESTION_EVENTS vocabulary.
+_CREATE_SUGGESTION_SIGNALS_SQL = """\
+CREATE TABLE IF NOT EXISTS suggestion_signals (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id          INTEGER NOT NULL,
+    url              TEXT NOT NULL DEFAULT '',
+    event            TEXT NOT NULL,
+    suggestion_index INTEGER,
+    suggestion_text  TEXT NOT NULL DEFAULT '',
+    reason           TEXT NOT NULL DEFAULT '',
+    created_at       TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%S', 'now')),
+    FOREIGN KEY (user_id) REFERENCES users(id)
+)"""
+
+SUGGESTION_SIGNAL_EVENTS = frozenset({
+    "shown", "open", "copy", "open_chatgpt", "open_claude", "dismiss",
+    "save", "tried", "done",
+})
+
+# Long enough to learn stable preferences, short enough to forget stale ones
+# (and to bound disk growth — pruned daily with the other audit tables).
+SUGGESTION_SIGNALS_RETENTION_SECONDS = 180 * 24 * 3_600
+
 # Allowed feedback signals. Explicit taps + cheap implicit proxies. Kept as an
 # allowlist so the data stays clean enough to learn from.
 FEEDBACK_SIGNALS = frozenset({
@@ -412,6 +440,7 @@ def _init() -> None:
         conn.execute(_CREATE_LLM_CACHE_SQL)
         conn.execute(_CREATE_LLM_CACHE_HITS_SQL)
         conn.execute(_CREATE_PROCESSED_URLS_SQL)
+        conn.execute(_CREATE_SUGGESTION_SIGNALS_SQL)
         for stmt in _CREATE_INDEXES_SQL:
             conn.execute(stmt)
 
@@ -518,6 +547,7 @@ def delete_user(user_id: int) -> dict:
         conn.execute("DELETE FROM link_codes WHERE user_id = ?", (user_id,))
         conn.execute("DELETE FROM feedback WHERE user_id = ?", (user_id,))
         conn.execute("DELETE FROM saved_suggestions WHERE user_id = ?", (user_id,))
+        conn.execute("DELETE FROM suggestion_signals WHERE user_id = ?", (user_id,))
         user_deleted = conn.execute(
             "DELETE FROM users WHERE id = ?", (user_id,)
         ).rowcount
@@ -710,6 +740,61 @@ def delete_saved_suggestion(saved_id: int, user_id: int) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# Suggestion signals (forwarded by the Worker for signed-in users)
+# ---------------------------------------------------------------------------
+
+def record_suggestion_signal(
+    user_id: int,
+    event: str,
+    *,
+    url: str = "",
+    suggestion_index: int | None = None,
+    suggestion_text: str = "",
+    reason: str = "",
+) -> int:
+    """Store one suggestion interaction event. Caller validates the event
+    against SUGGESTION_SIGNAL_EVENTS; values are clipped here so a misbehaving
+    caller can't bloat the table."""
+    with _get_conn() as conn:
+        cur = conn.execute(
+            "INSERT INTO suggestion_signals "
+            "(user_id, url, event, suggestion_index, suggestion_text, reason) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (user_id, (url or "")[:2048], event, suggestion_index,
+             (suggestion_text or "")[:2048], (reason or "")[:2048]),
+        )
+        return cur.lastrowid
+
+
+def get_suggestion_signals(
+    user_id: int,
+    *,
+    events: tuple[str, ...] | None = None,
+    before_iso: str | None = None,
+    since_iso: str | None = None,
+    limit: int = 50,
+) -> list[sqlite3.Row]:
+    """A user's signals, newest first. ``before_iso``/``since_iso`` bound the
+    window (the signal digest uses ``before`` for day-stable cache keys)."""
+    q = ("SELECT id, url, event, suggestion_index, suggestion_text, reason, "
+         "created_at FROM suggestion_signals WHERE user_id = ?")
+    args: list = [user_id]
+    if events:
+        q += f" AND event IN ({','.join('?' * len(events))})"
+        args.extend(events)
+    if before_iso:
+        q += " AND created_at < ?"
+        args.append(before_iso)
+    if since_iso:
+        q += " AND created_at >= ?"
+        args.append(since_iso)
+    q += " ORDER BY id DESC LIMIT ?"
+    args.append(limit)
+    with _get_conn() as conn:
+        return conn.execute(q, args).fetchall()
+
+
+# ---------------------------------------------------------------------------
 # Account linking (web ↔ Telegram)
 # ---------------------------------------------------------------------------
 
@@ -876,10 +961,15 @@ def prune_maintenance(now=None) -> dict:
         processed_urls = conn.execute(
             "DELETE FROM processed_urls WHERE ts < ?", (processed_urls_cutoff,)
         ).rowcount or 0
+        suggestion_signals = conn.execute(
+            "DELETE FROM suggestion_signals WHERE created_at < ?",
+            (_ts(now - timedelta(seconds=SUGGESTION_SIGNALS_RETENTION_SECONDS)),),
+        ).rowcount or 0
     return {
         "error_log": errors, "url_cache": cache, "link_codes": codes,
         "jobs": jobs, "processed_updates": updates, "llm_cache": llm_cache,
         "llm_cache_hits": llm_cache_hits, "processed_urls": processed_urls,
+        "suggestion_signals": suggestion_signals,
     }
 
 

--- a/bot/signals.py
+++ b/bot/signals.py
@@ -1,0 +1,106 @@
+"""Per-user behaviour-signal digest fed into the analyzer (#69).
+
+The product collects rich interaction signals — dismissals with free-text
+reasons, now/later/never triage, tried/done outcomes — and until now fed none
+of them back into `analyze()`. This module distils them into a short text
+block injected into the analyze prompt next to the profile, so the 100th
+analysis really is more *them* than the first.
+
+Sources (backend SQLite only — the canonical event stream incl. anonymous
+traffic stays in D1; the Worker forwards signed-in events to
+``/api/suggestion-signals``):
+- ``suggestion_signals``: dismiss events carry the user's own words for why a
+  suggestion didn't fit ("too generic", "already done", …) — the highest-value
+  signal we have.
+- ``saved_suggestions``: completed/tried outcomes (with effort labels) and the
+  size of the still-parked backlog.
+
+Cache stability: the digest text is part of the analyze cache key, so a digest
+that changed on every click would make the cache miss constantly. Only rows
+from **before today 00:00 UTC** are included — the digest (and the key) is
+stable within a UTC day, and learning lags reality by at most a day.
+
+Anonymous users have no user_id here and always get an empty digest — their
+analyses are unchanged (data-isolation invariant).
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+# Hard bound — like the profile, this is injected into every analysis prompt.
+SIGNAL_DIGEST_MAX_CHARS = 1200
+# Look-back for dismissals; older taste signals go stale.
+DISMISS_WINDOW_DAYS = 60
+DISMISS_MAX = 6
+OUTCOME_MAX = 6
+# A backlog parked longer than this reads as overcommitment — nudge the model
+# toward fewer/smaller steps rather than piling on.
+PARKED_STALE_DAYS = 14
+
+
+def _day_start(now: datetime) -> str:
+    return now.strftime("%Y-%m-%dT00:00:00")
+
+
+def _quote(text: str, limit: int = 90) -> str:
+    text = " ".join((text or "").split())
+    return text[:limit] + ("…" if len(text) > limit else "")
+
+
+def build_signal_digest(user_id: int | None, *, now: datetime | None = None) -> str:
+    """Render the user's recent behaviour as a compact prompt block.
+
+    Returns "" when there's no user or nothing learned yet — callers can drop
+    the block entirely and the prompt is byte-identical to the pre-#69 one.
+    """
+    if user_id is None:
+        return ""
+    from bot.db import get_saved_suggestions, get_suggestion_signals
+
+    now = now or datetime.now(timezone.utc)
+    cutoff = _day_start(now)
+    since = (now - timedelta(days=DISMISS_WINDOW_DAYS)).strftime("%Y-%m-%dT%H:%M:%S")
+
+    lines: list[str] = []
+
+    dismissals = get_suggestion_signals(
+        user_id, events=("dismiss",), before_iso=cutoff, since_iso=since,
+        limit=DISMISS_MAX,
+    )
+    for d in dismissals:
+        line = f'- Dismissed "{_quote(d["suggestion_text"])}"'
+        if d["reason"]:
+            line += f' — their reason: "{_quote(d["reason"])}"'
+        lines.append(line)
+
+    done_lines: list[str] = []
+    parked_stale = 0
+    stale_cutoff = (now - timedelta(days=PARKED_STALE_DAYS)).strftime("%Y-%m-%dT%H:%M:%S")
+    for s in get_saved_suggestions(user_id):
+        # Day-stable: ignore anything the user touched today.
+        if s["updated_at"] >= cutoff:
+            continue
+        if s["status"] in ("done", "tried") and len(done_lines) < OUTCOME_MAX:
+            verb = "Completed" if s["status"] == "done" else "Tried"
+            effort = f' ({s["effort"]})' if s["effort"] else ""
+            done_lines.append(f'- {verb} "{_quote(s["title"])}"{effort}')
+        elif s["status"] == "saved" and s["created_at"] < stale_cutoff:
+            parked_stale += 1
+    lines.extend(done_lines)
+
+    if parked_stale:
+        lines.append(
+            f"- {parked_stale} earlier suggestion{'s' if parked_stale != 1 else ''} "
+            "still parked unactioned on their shortlist — favour fewer, smaller, "
+            "more specific next steps over adding ambitious ones."
+        )
+
+    if not lines:
+        return ""
+
+    out = (
+        "Recent behaviour signals from this person (use them to calibrate the "
+        "suggestions — match what they complete, avoid what they dismiss; "
+        "never mention these signals explicitly):\n" + "\n".join(lines)
+    )
+    return out[:SIGNAL_DIGEST_MAX_CHARS]

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -423,7 +423,7 @@ class TestPruneMaintenance:
         assert counts == {
             "error_log": 1, "url_cache": 1, "link_codes": 1, "jobs": 1,
             "processed_updates": 1, "llm_cache": 1, "llm_cache_hits": 1,
-            "processed_urls": 1,
+            "processed_urls": 1, "suggestion_signals": 0,
         }
 
         with db._get_conn() as conn:
@@ -443,7 +443,7 @@ class TestPruneMaintenance:
         assert counts == {
             "error_log": 0, "url_cache": 0, "link_codes": 0, "jobs": 0,
             "processed_updates": 0, "llm_cache": 0, "llm_cache_hits": 0,
-            "processed_urls": 0,
+            "processed_urls": 0, "suggestion_signals": 0,
         }
 
 

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,0 +1,246 @@
+"""Behaviour-signal feedback loop (#69): storage, the day-coarsened digest,
+its injection into analyze(), and the Worker-facing ingest endpoint.
+
+The two contracts that matter most:
+  1. The signal digest only changes once per UTC day (today's events are
+     excluded), so the analyze cache key stays stable between meaningful
+     changes instead of churning per click.
+  2. Anonymous analyses are byte-identical to before — signals are signed-in
+     only (data-isolation invariant).
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+
+NOW = datetime(2026, 6, 12, 15, 0, tzinfo=timezone.utc)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.strftime("%Y-%m-%dT%H:%M:%S")
+
+
+def _backdate_signal(db, signal_id: int, dt: datetime) -> None:
+    with db._get_conn() as conn:
+        conn.execute("UPDATE suggestion_signals SET created_at = ? WHERE id = ?",
+                     (_iso(dt), signal_id))
+
+
+def _dismiss(db, uid, text="Build a RAG demo", reason="too generic", *, days_ago=1):
+    sid = db.record_suggestion_signal(uid, "dismiss", suggestion_text=text, reason=reason)
+    _backdate_signal(db, sid, NOW - timedelta(days=days_ago))
+    return sid
+
+
+def _add_outcome(db, uid, *, status="done", title="Add a reranker", effort="~2 hrs",
+                 days_ago=2):
+    item_id = db.save_item(uid, "article", "https://ex.com/a", "c", "{}")
+    saved_id = db.save_suggestion(
+        user_id=uid, item_id=item_id, suggestion_index=0,
+        title=title, detail="d", effort=effort, first_step="", grounded_in="",
+    )
+    if status != "saved":
+        db.update_saved_suggestion_status(saved_id, uid, status)
+    ts = _iso(NOW - timedelta(days=days_ago))
+    with db._get_conn() as conn:
+        conn.execute("UPDATE saved_suggestions SET created_at = ?, updated_at = ? WHERE id = ?",
+                     (ts, ts, saved_id))
+    return saved_id
+
+
+class TestStorage:
+    def test_record_and_fetch(self, db):
+        uid = db.upsert_user_by_email("u@example.com")
+        db.record_suggestion_signal(uid, "dismiss", url="https://ex.com",
+                                    suggestion_index=2, suggestion_text="t", reason="r")
+        rows = db.get_suggestion_signals(uid)
+        assert len(rows) == 1
+        assert rows[0]["event"] == "dismiss"
+        assert rows[0]["suggestion_index"] == 2
+        assert rows[0]["reason"] == "r"
+
+    def test_values_are_clipped(self, db):
+        uid = db.upsert_user_by_email("u@example.com")
+        db.record_suggestion_signal(uid, "dismiss", reason="x" * 5000)
+        assert len(db.get_suggestion_signals(uid)[0]["reason"]) == 2048
+
+    def test_user_scoping(self, db):
+        a = db.upsert_user_by_email("a@example.com")
+        b = db.upsert_user_by_email("b@example.com")
+        db.record_suggestion_signal(a, "dismiss", reason="mine")
+        assert db.get_suggestion_signals(b) == []
+
+    def test_delete_user_erases_signals(self, db):
+        uid = db.upsert_user_by_email("u@example.com")
+        db.record_suggestion_signal(uid, "dismiss")
+        db.delete_user(uid)
+        with db._get_conn() as conn:
+            n = conn.execute("SELECT COUNT(*) FROM suggestion_signals").fetchone()[0]
+        assert n == 0
+
+    def test_prune_drops_old_signals_only(self, db):
+        uid = db.upsert_user_by_email("u@example.com")
+        old = db.record_suggestion_signal(uid, "dismiss", reason="ancient")
+        _backdate_signal(db, old, NOW - timedelta(days=200))
+        db.record_suggestion_signal(uid, "dismiss", reason="fresh")
+        counts = db.prune_maintenance(now=NOW)
+        assert counts["suggestion_signals"] == 1
+        rows = db.get_suggestion_signals(uid)
+        assert [r["reason"] for r in rows] == ["fresh"]
+
+
+class TestSignalDigest:
+    def test_anon_and_empty_users_get_empty_digest(self, db):
+        from bot.signals import build_signal_digest
+        assert build_signal_digest(None, now=NOW) == ""
+        uid = db.upsert_user_by_email("u@example.com")
+        assert build_signal_digest(uid, now=NOW) == ""
+
+    def test_dismissals_with_reasons_are_included(self, db):
+        from bot.signals import build_signal_digest
+        uid = db.upsert_user_by_email("u@example.com")
+        _dismiss(db, uid, text="Build a RAG demo", reason="too generic")
+        d = build_signal_digest(uid, now=NOW)
+        assert 'Dismissed "Build a RAG demo"' in d
+        assert 'their reason: "too generic"' in d
+        assert "never mention these signals" in d
+
+    def test_todays_events_are_excluded_for_cache_stability(self, db):
+        from bot.signals import build_signal_digest
+        uid = db.upsert_user_by_email("u@example.com")
+        sid = db.record_suggestion_signal(uid, "dismiss", suggestion_text="fresh", reason="r")
+        _backdate_signal(db, sid, NOW - timedelta(hours=2))  # today, before NOW
+        assert build_signal_digest(uid, now=NOW) == ""
+        # The same event counts from tomorrow on.
+        assert "fresh" in build_signal_digest(uid, now=NOW + timedelta(days=1))
+
+    def test_stale_dismissals_age_out(self, db):
+        from bot.signals import DISMISS_WINDOW_DAYS, build_signal_digest
+        uid = db.upsert_user_by_email("u@example.com")
+        _dismiss(db, uid, text="ancient", days_ago=DISMISS_WINDOW_DAYS + 5)
+        assert build_signal_digest(uid, now=NOW) == ""
+
+    def test_outcomes_and_stale_backlog_are_summarised(self, db):
+        from bot.signals import PARKED_STALE_DAYS, build_signal_digest
+        uid = db.upsert_user_by_email("u@example.com")
+        _add_outcome(db, uid, status="done", title="Add a reranker", effort="~2 hrs")
+        _add_outcome(db, uid, status="tried", title="Eval harness", effort="")
+        _add_outcome(db, uid, status="saved", title="Parked thing",
+                     days_ago=PARKED_STALE_DAYS + 1)
+        d = build_signal_digest(uid, now=NOW)
+        assert 'Completed "Add a reranker" (~2 hrs)' in d
+        assert 'Tried "Eval harness"' in d
+        assert "1 earlier suggestion still parked" in d
+
+    def test_digest_is_bounded(self, db):
+        from bot.signals import SIGNAL_DIGEST_MAX_CHARS, build_signal_digest
+        uid = db.upsert_user_by_email("u@example.com")
+        for i in range(20):
+            _dismiss(db, uid, text=f"suggestion {i} " + "x" * 200, reason="y" * 200)
+        assert len(build_signal_digest(uid, now=NOW)) <= SIGNAL_DIGEST_MAX_CHARS
+
+
+class _CapturingAnthropic:
+    """Fake Anthropic client that records the prompt it was called with."""
+
+    def __init__(self, tool_input):
+        self.prompts: list[str] = []
+
+        def create(**kw):
+            self.prompts.append(kw["messages"][0]["content"])
+            return SimpleNamespace(
+                content=[SimpleNamespace(type="tool_use", name="record_analysis",
+                                         input=tool_input)],
+                usage=SimpleNamespace(input_tokens=1, output_tokens=1),
+            )
+
+        self.messages = SimpleNamespace(create=create)
+
+
+_TOOL_INPUT = {
+    "main_idea": "x", "why_it_matters": "y", "grounded_in": "g", "category": "c",
+    "time_required": "5m", "verdict": "watch", "suggestions": [],
+}
+
+
+@pytest.fixture
+def fake_analyzer(db, monkeypatch):
+    from bot import analyzer
+    monkeypatch.setattr(analyzer, "_PROVIDER", "anthropic")
+    monkeypatch.setattr(analyzer, "_MODEL", "claude-haiku-4-5-20251001")
+    monkeypatch.setattr(analyzer, "_PREMIUM_MODEL", "claude-haiku-4-5-20251001")
+    fake = _CapturingAnthropic(_TOOL_INPUT)
+    monkeypatch.setattr(analyzer, "_get_client", lambda: fake)
+    return analyzer, fake
+
+
+class TestAnalyzerIntegration:
+    def test_signals_block_reaches_the_prompt(self, db, fake_analyzer, monkeypatch):
+        analyzer, fake = fake_analyzer
+        uid = db.upsert_user_by_email("u@example.com")
+        _dismiss(db, uid, reason="too generic")
+        monkeypatch.setattr(analyzer, "_load_signals",
+                            lambda user_id: __import__("bot.signals", fromlist=["build_signal_digest"]).build_signal_digest(user_id, now=NOW))
+        analyzer.analyze("content", ctx=analyzer.UsageContext(user_id=uid))
+        assert "too generic" in fake.prompts[0]
+
+    def test_anon_prompt_carries_no_signals_block(self, db, fake_analyzer):
+        analyzer, fake = fake_analyzer
+        analyzer.analyze("content", ctx=analyzer.UsageContext(user_id=None))
+        assert "behaviour signals" not in fake.prompts[0].lower()
+
+    def test_cache_key_changes_with_signals(self, db):
+        from bot import analyzer
+        base = analyzer._cache_key_analyze("t", "p", "m")
+        assert analyzer._cache_key_analyze("t", "p", "m", "sig") != base
+        assert analyzer._cache_key_analyze("t", "p", "m", "") == base
+
+    def test_signal_failure_never_breaks_analysis(self, db, fake_analyzer, monkeypatch):
+        analyzer, fake = fake_analyzer
+        uid = db.upsert_user_by_email("u@example.com")
+
+        def boom(user_id, **kw):
+            raise RuntimeError("db hiccup")
+
+        import bot.signals
+        monkeypatch.setattr(bot.signals, "build_signal_digest", boom)
+        result = analyzer.analyze("content", ctx=analyzer.UsageContext(user_id=uid))
+        assert result["verdict"] == "watch"
+
+
+class TestIngestEndpoint:
+    def test_records_a_signal(self, client, auth_headers, db):
+        uid = db.upsert_user_by_email("u@example.com")
+        r = client.post("/api/suggestion-signals", headers=auth_headers, json={
+            "user_id": uid, "event": "dismiss", "url": "https://ex.com",
+            "suggestion_index": 1, "suggestion_text": "t", "reason": "too generic",
+        })
+        assert r.status_code == 201
+        rows = db.get_suggestion_signals(uid)
+        assert rows[0]["reason"] == "too generic"
+
+    def test_invalid_event_rejected(self, client, auth_headers, db):
+        uid = db.upsert_user_by_email("u@example.com")
+        r = client.post("/api/suggestion-signals", headers=auth_headers,
+                        json={"user_id": uid, "event": "totally-made-up"})
+        assert r.status_code == 400
+
+    def test_unknown_user_rejected(self, client, auth_headers):
+        r = client.post("/api/suggestion-signals", headers=auth_headers,
+                        json={"user_id": 99999, "event": "dismiss"})
+        assert r.status_code == 404
+
+    def test_requires_shared_secret(self, client):
+        r = client.post("/api/suggestion-signals",
+                        json={"user_id": 1, "event": "dismiss"})
+        assert r.status_code == 401
+
+    def test_export_includes_signals(self, client, auth_headers, db):
+        uid = db.upsert_user_by_email("u@example.com")
+        db.record_suggestion_signal(uid, "dismiss", reason="too generic")
+        r = client.get(f"/api/users/{uid}/export", headers=auth_headers)
+        assert r.status_code == 200
+        sig = r.json()["suggestion_signals"]
+        assert len(sig) == 1 and sig[0]["reason"] == "too generic"


### PR DESCRIPTION
## What

Implements the backend half of #69. The product already collects the signals that would make suggestions improve with use — this PR makes `analyze()` actually learn from them.

**Storage** — new `suggestion_signals` table + `POST /api/suggestion-signals` (try-secret gated). Signed-in users only: the canonical event stream (including anonymous traffic) stays in D1 for product analytics; this copy exists so the analyzer can read it. Values clipped server-side; signals are erased on account deletion, included in the GDPR export, and pruned after 180 days alongside the other audit tables.

**The behaviour digest** (`bot/signals.py`) — a compact block (≤1200 chars, same bound philosophy as the profile) rendered from:
- recent dismissals *with the user's own reasons* ("too generic", "already done") — the highest-value signal,
- completed/tried suggestions with their effort labels (what this person actually finishes),
- a stale-backlog nudge when parked suggestions pile up ("favour fewer, smaller, more specific steps").

**Analyzer integration** — the digest is injected next to the profile and instructs the model to calibrate silently, never cite the signals. It's part of the analyze cache key.

**The cache-key design point:** a digest that changed on every click would make the analyze cache miss constantly. Only events from **before today 00:00 UTC** enter the digest, so it (and the key) is stable within a UTC day — learning lags reality by at most a day, and the cache hit rate survives. Anon users get an empty digest and a byte-identical prompt to before. A signal-digest failure degrades to no-signals rather than breaking analysis. `analyze_traces` now captures profile+signals together so Phase-2 eval sees the full personalization context.

## Tests

20 new tests in `tests/test_signals.py`: storage scoping/clipping/erasure/pruning, digest assembly (empty, reasons, day-coarsening, window aging, outcome summarising, char bound), analyzer integration with a prompt-capturing fake client (signals reach the prompt; anon prompt unchanged; cache-key sensitivity; failure isolation), and all four endpoint paths + export. **Full suite: 310 passed** (`make test`).

## What's still needed to light it up

The Worker currently writes suggestion events to D1 only — a small frontend PR (next up) forwards signed-in events to the new endpoint. Until that lands, this PR is inert-but-safe: the digest is empty for everyone, prompts and cache keys are unchanged except for the template-version bump (one-time cache invalidation, by design).

Acceptance criterion "cache hit rate does not collapse" is observable post-deploy on the admin Cost pillar; the once-a-day key rotation bounds the worst case to one extra LLM call per active user per day.

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)