### PR TITLE
feat(monitor): channel monitoring via the existing pipeline (#68)

### DIFF
--- a/bot/api.py
+++ b/bot/api.py
@@ -35,15 +35,18 @@ from bot.db import (
     LINK_CODE_TTL_SECONDS,
     SAVED_SUGGESTION_STATUSES,
     SUGGESTION_SIGNAL_EVENTS,
+    add_subscription,
     create_job,
     create_link_code,
     delete_item,
     delete_saved_suggestion,
+    delete_subscription,
     delete_user,
     get_all_items,
     get_item,
     get_job_record,
     get_saved_suggestions,
+    get_subscriptions,
     get_suggestion_signals,
     get_user,
     get_user_profile,
@@ -478,6 +481,15 @@ async def user_export(user_id: int, _: None = Depends(_require_try_secret)):
             }
             for r in get_suggestion_signals(user_id, limit=10_000)
         ],
+        "subscriptions": [
+            {
+                "feed_url": s["feed_url"],
+                "title": s["title"],
+                "source_kind": s["source_kind"],
+                "created_at": s["created_at"],
+            }
+            for s in get_subscriptions(user_id)
+        ],
     }
 
 
@@ -542,6 +554,75 @@ async def feedback(req: _FeedbackRequest, _: None = Depends(_require_try_secret)
     if not get_item(req.item_id, req.user_id):
         raise HTTPException(status_code=404, detail={"error": "not-found"})
     record_feedback(req.user_id, req.item_id, req.signal)
+
+
+# ---------------------------------------------------------------------------
+# Subscriptions (channel monitoring, #68) — Worker-gated CRUD. The poll loop
+# in main.py does the actual monitoring; these endpoints only manage the list.
+# ---------------------------------------------------------------------------
+
+class _SubscriptionCreateRequest(BaseModel):
+    user_id: int
+    url: str
+
+
+@router.post("/subscriptions", status_code=201)
+async def subscription_create(
+    req: _SubscriptionCreateRequest, _: None = Depends(_require_try_secret)
+):
+    """Subscribe a user to a channel/feed. The input URL is resolved to a
+    canonical feed at subscribe time (RSS/Atom passthrough, YouTube channel →
+    Atom feed, HTML page → advertised feed), so bad URLs fail here with a
+    clear message instead of silently never producing drops."""
+    from bot.monitor import FeedError, resolve_feed
+    from bot.ssrf import BlockedURLError
+
+    if not get_user(req.user_id):
+        raise HTTPException(status_code=404, detail={"error": "not-found"})
+    try:
+        resolved = await asyncio.get_running_loop().run_in_executor(
+            None, resolve_feed, req.url
+        )
+    except (FeedError, BlockedURLError) as e:
+        raise HTTPException(
+            status_code=422,
+            detail={"error": "invalid-feed",
+                    "message": str(e) or "No feed found at that URL."},
+        )
+    try:
+        sub_id = add_subscription(
+            req.user_id, resolved["feed_url"],
+            title=resolved["title"], source_kind=resolved["source_kind"],
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=409,
+                            detail={"error": "limit-reached", "message": str(e)})
+    if sub_id is None:
+        raise HTTPException(status_code=409, detail={"error": "already-subscribed"})
+    return {"id": sub_id, **resolved}
+
+
+@router.get("/subscriptions")
+async def subscriptions_list(user_id: int, _: None = Depends(_require_try_secret)):
+    return [
+        {
+            "id": s["id"],
+            "feed_url": s["feed_url"],
+            "title": s["title"],
+            "source_kind": s["source_kind"],
+            "last_polled_at": s["last_polled_at"],
+            "created_at": s["created_at"],
+        }
+        for s in get_subscriptions(user_id)
+    ]
+
+
+@router.delete("/subscriptions/{sub_id}", status_code=204)
+async def subscription_delete(
+    sub_id: int, user_id: int, _: None = Depends(_require_try_secret)
+):
+    if not delete_subscription(sub_id, user_id):
+        raise HTTPException(status_code=404, detail={"error": "not-found"})
 
 
 class _SuggestionSignalRequest(BaseModel):

--- a/bot/db.py
+++ b/bot/db.py
@@ -134,6 +134,8 @@ _CREATE_INDEXES_SQL = [
     "CREATE INDEX IF NOT EXISTS idx_saved_suggestions_user ON saved_suggestions(user_id, created_at DESC)",
     "CREATE INDEX IF NOT EXISTS idx_saved_suggestions_item ON saved_suggestions(item_id)",
     "CREATE INDEX IF NOT EXISTS idx_suggestion_signals_user ON suggestion_signals(user_id, created_at DESC)",
+    "CREATE INDEX IF NOT EXISTS idx_subscriptions_user ON subscriptions(user_id, created_at DESC)",
+    "CREATE INDEX IF NOT EXISTS idx_subscription_items_sub ON subscription_items(subscription_id, status)",
     "CREATE INDEX IF NOT EXISTS idx_jobs_updated_at ON jobs(updated_at DESC)",
     "CREATE INDEX IF NOT EXISTS idx_llm_calls_ts ON llm_calls(ts DESC)",
     "CREATE INDEX IF NOT EXISTS idx_llm_calls_user ON llm_calls(user_id, ts DESC)",
@@ -329,6 +331,56 @@ SUGGESTION_SIGNAL_EVENTS = frozenset({
 # (and to bound disk growth — pruned daily with the other audit tables).
 SUGGESTION_SIGNALS_RETENTION_SECONDS = 180 * 24 * 3_600
 
+# Channel monitoring (#68): the feeds a user follows. `feed_url` is the
+# canonical RSS/Atom URL (YouTube channels resolve to their Atom feed at
+# subscribe time, so the poller only ever speaks one protocol). One row per
+# (user, feed) — two users following the same feed each get their own row,
+# because analysis is lens-personalized per user (the shared *fetch* is
+# deduped by url_cache, not here).
+_CREATE_SUBSCRIPTIONS_SQL = """\
+CREATE TABLE IF NOT EXISTS subscriptions (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id        INTEGER NOT NULL,
+    feed_url       TEXT NOT NULL,
+    title          TEXT NOT NULL DEFAULT '',
+    source_kind    TEXT NOT NULL DEFAULT 'rss',
+    last_polled_at TEXT NOT NULL DEFAULT '',
+    created_at     TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%S', 'now')),
+    UNIQUE(user_id, feed_url),
+    FOREIGN KEY (user_id) REFERENCES users(id)
+)"""
+
+# Entries the poller has seen per subscription — the cross-poll dedupe set and
+# the per-entry processing state. `status`: 'seeded' (present when the user
+# subscribed; never analyzed — subscribing must not trigger a backfill of LLM
+# calls), 'pending' (queued), 'done' (analyzed; item_id links the library row),
+# 'error' (pipeline failed; not retried).
+_CREATE_SUBSCRIPTION_ITEMS_SQL = """\
+CREATE TABLE IF NOT EXISTS subscription_items (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    subscription_id INTEGER NOT NULL,
+    user_id         INTEGER NOT NULL,
+    entry_url       TEXT NOT NULL,
+    entry_title     TEXT NOT NULL DEFAULT '',
+    status          TEXT NOT NULL DEFAULT 'pending',
+    item_id         INTEGER,
+    verdict         TEXT NOT NULL DEFAULT '',
+    created_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%S', 'now')),
+    updated_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%S', 'now')),
+    UNIQUE(subscription_id, entry_url),
+    FOREIGN KEY (subscription_id) REFERENCES subscriptions(id),
+    FOREIGN KEY (user_id) REFERENCES users(id)
+)"""
+
+SUBSCRIPTION_ITEM_STATUSES = frozenset({"seeded", "pending", "done", "error"})
+
+# Cap per user to bound polling load and LLM spend; generous for one person.
+MAX_SUBSCRIPTIONS_PER_USER = 30
+# Old seen-entries are safe to forget once they've long scrolled out of the
+# feed window (feeds carry ~15–50 recent entries) — a year is comfortably past
+# that, and keeps the dedupe set from growing without bound.
+SUBSCRIPTION_ITEMS_RETENTION_SECONDS = 365 * 24 * 3_600
+
 # Allowed feedback signals. Explicit taps + cheap implicit proxies. Kept as an
 # allowlist so the data stays clean enough to learn from.
 FEEDBACK_SIGNALS = frozenset({
@@ -448,6 +500,8 @@ def _init() -> None:
         conn.execute(_CREATE_LLM_CACHE_HITS_SQL)
         conn.execute(_CREATE_PROCESSED_URLS_SQL)
         conn.execute(_CREATE_SUGGESTION_SIGNALS_SQL)
+        conn.execute(_CREATE_SUBSCRIPTIONS_SQL)
+        conn.execute(_CREATE_SUBSCRIPTION_ITEMS_SQL)
         for stmt in _CREATE_INDEXES_SQL:
             conn.execute(stmt)
 
@@ -584,6 +638,8 @@ def delete_user(user_id: int) -> dict:
         conn.execute("DELETE FROM feedback WHERE user_id = ?", (user_id,))
         conn.execute("DELETE FROM saved_suggestions WHERE user_id = ?", (user_id,))
         conn.execute("DELETE FROM suggestion_signals WHERE user_id = ?", (user_id,))
+        conn.execute("DELETE FROM subscription_items WHERE user_id = ?", (user_id,))
+        conn.execute("DELETE FROM subscriptions WHERE user_id = ?", (user_id,))
         user_deleted = conn.execute(
             "DELETE FROM users WHERE id = ?", (user_id,)
         ).rowcount
@@ -853,6 +909,107 @@ def get_suggestion_signals(
 
 
 # ---------------------------------------------------------------------------
+# Subscriptions (channel monitoring, #68)
+# ---------------------------------------------------------------------------
+
+def add_subscription(user_id: int, feed_url: str, *, title: str = "",
+                     source_kind: str = "rss") -> int | None:
+    """Create one subscription. Returns its id, or None when it already exists
+    (idempotent). Raises ValueError at the per-user cap so the API can surface
+    a clear message."""
+    with _get_conn() as conn:
+        n = conn.execute(
+            "SELECT COUNT(*) AS n FROM subscriptions WHERE user_id = ?", (user_id,)
+        ).fetchone()["n"]
+        if n >= MAX_SUBSCRIPTIONS_PER_USER:
+            raise ValueError(f"subscription cap reached ({MAX_SUBSCRIPTIONS_PER_USER})")
+        cur = conn.execute(
+            "INSERT OR IGNORE INTO subscriptions (user_id, feed_url, title, source_kind) "
+            "VALUES (?, ?, ?, ?)",
+            (user_id, feed_url[:2048], title[:300], source_kind),
+        )
+        return cur.lastrowid if cur.rowcount else None
+
+
+def get_subscriptions(user_id: int) -> list[sqlite3.Row]:
+    with _get_conn() as conn:
+        return conn.execute(
+            "SELECT id, feed_url, title, source_kind, last_polled_at, created_at "
+            "FROM subscriptions WHERE user_id = ? ORDER BY created_at DESC, id DESC",
+            (user_id,),
+        ).fetchall()
+
+
+def get_all_subscriptions() -> list[sqlite3.Row]:
+    """Every subscription across users — the poller's worklist."""
+    with _get_conn() as conn:
+        return conn.execute(
+            "SELECT id, user_id, feed_url, title, source_kind, last_polled_at "
+            "FROM subscriptions ORDER BY id"
+        ).fetchall()
+
+
+def delete_subscription(sub_id: int, user_id: int) -> bool:
+    """Remove a subscription and its seen-entry state. Ownership-scoped."""
+    with _get_conn() as conn:
+        cur = conn.execute(
+            "DELETE FROM subscriptions WHERE id = ? AND user_id = ?",
+            (sub_id, user_id),
+        )
+        if not cur.rowcount:
+            return False
+        conn.execute(
+            "DELETE FROM subscription_items WHERE subscription_id = ?", (sub_id,)
+        )
+        return True
+
+
+def mark_subscription_polled(sub_id: int) -> None:
+    with _get_conn() as conn:
+        conn.execute(
+            "UPDATE subscriptions SET last_polled_at = ? WHERE id = ?",
+            (_utcnow_iso(), sub_id),
+        )
+
+
+def record_subscription_entry(
+    sub_id: int, user_id: int, entry_url: str, entry_title: str = "",
+    *, status: str = "pending",
+) -> bool:
+    """Register one feed entry as seen. Returns False if it was already known
+    (the cross-poll dedupe)."""
+    with _get_conn() as conn:
+        cur = conn.execute(
+            "INSERT OR IGNORE INTO subscription_items "
+            "(subscription_id, user_id, entry_url, entry_title, status) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (sub_id, user_id, entry_url[:2048], (entry_title or "")[:300], status),
+        )
+        return cur.rowcount > 0
+
+
+def get_pending_subscription_entries(sub_id: int, limit: int = 10) -> list[sqlite3.Row]:
+    with _get_conn() as conn:
+        return conn.execute(
+            "SELECT id, subscription_id, user_id, entry_url, entry_title "
+            "FROM subscription_items WHERE subscription_id = ? AND status = 'pending' "
+            "ORDER BY id DESC LIMIT ?",
+            (sub_id, limit),
+        ).fetchall()
+
+
+def set_subscription_entry_result(
+    entry_id: int, *, status: str, item_id: int | None = None, verdict: str = "",
+) -> None:
+    with _get_conn() as conn:
+        conn.execute(
+            "UPDATE subscription_items SET status = ?, item_id = ?, verdict = ?, "
+            "updated_at = ? WHERE id = ?",
+            (status, item_id, verdict, _utcnow_iso(), entry_id),
+        )
+
+
+# ---------------------------------------------------------------------------
 # Account linking (web ↔ Telegram)
 # ---------------------------------------------------------------------------
 
@@ -1023,11 +1180,16 @@ def prune_maintenance(now=None) -> dict:
             "DELETE FROM suggestion_signals WHERE created_at < ?",
             (_ts(now - timedelta(seconds=SUGGESTION_SIGNALS_RETENTION_SECONDS)),),
         ).rowcount or 0
+        subscription_items = conn.execute(
+            "DELETE FROM subscription_items WHERE created_at < ?",
+            (_ts(now - timedelta(seconds=SUBSCRIPTION_ITEMS_RETENTION_SECONDS)),),
+        ).rowcount or 0
     return {
         "error_log": errors, "url_cache": cache, "link_codes": codes,
         "jobs": jobs, "processed_updates": updates, "llm_cache": llm_cache,
         "llm_cache_hits": llm_cache_hits, "processed_urls": processed_urls,
         "suggestion_signals": suggestion_signals,
+        "subscription_items": subscription_items,
     }
 
 

--- a/bot/monitor.py
+++ b/bot/monitor.py
@@ -1,0 +1,260 @@
+"""Channel monitoring (#68): poll the feeds a user follows, run new drops
+through the normal analysis pipeline.
+
+Subscribe time does the hard part: any supported input (a raw RSS/Atom URL, a
+YouTube channel/handle URL, or an HTML page that advertises a feed via
+``<link rel="alternate">``) is resolved to one canonical feed URL, so the
+poller only ever speaks RSS/Atom.
+
+Poll cycles run in-process (single-machine SQLite, like the digest/prune
+loops). Every new entry flows through ``bot.pipeline.analyze_url`` with the
+subscriber's user_id — lens personalization, llm_calls cost attribution, the
+url_cache fetch dedupe across subscribers, and the capacity guards all apply
+for free. Monitoring is background load: a busy box (ERR_BUSY) leaves entries
+pending for the next cycle rather than competing with interactive requests.
+
+Cost bounds, in order of importance:
+- subscribing NEVER backfills — entries present at subscribe time are recorded
+  as 'seeded' and not analyzed;
+- at most MAX_NEW_PER_POLL entries per subscription per cycle, and at most
+  MAX_ANALYSES_PER_CYCLE across all subscriptions;
+- per-user subscription cap lives in the DB layer (MAX_SUBSCRIPTIONS_PER_USER).
+"""
+from __future__ import annotations
+
+import logging
+import re
+from urllib.parse import urljoin, urlparse
+
+import feedparser
+import httpx
+
+from bot.ssrf import BlockedURLError, assert_public_url
+
+logger = logging.getLogger(__name__)
+
+# How many of the newest feed entries we look at per poll. Feeds usually carry
+# 15–50; anything older than this window has scrolled past us and is ignored.
+FEED_ENTRY_WINDOW = 25
+# New entries analyzed per subscription per cycle.
+MAX_NEW_PER_POLL = 3
+# Hard ceiling on LLM-bearing work per poll cycle across all subscriptions.
+MAX_ANALYSES_PER_CYCLE = 12
+
+_FETCH_TIMEOUT_S = 20
+_MAX_BODY_BYTES = 5 * 1024 * 1024
+_UA = "filter.fyi feed monitor (+https://filter.fyi)"
+
+_YT_HOSTS = {"youtube.com", "www.youtube.com", "m.youtube.com"}
+_YT_FEED = "https://www.youtube.com/feeds/videos.xml?channel_id={cid}"
+_YT_CHANNEL_ID_RE = re.compile(r'"channelId"\s*:\s*"(UC[0-9A-Za-z_-]{22})"')
+_FEED_LINK_RE = re.compile(
+    r'<link[^>]+rel=["\']alternate["\'][^>]*>', re.IGNORECASE
+)
+_HREF_RE = re.compile(r'href=["\']([^"\']+)["\']', re.IGNORECASE)
+_FEED_TYPE_RE = re.compile(r'type=["\']application/(rss|atom)\+xml["\']', re.IGNORECASE)
+
+
+class FeedError(Exception):
+    """A user-facing problem with a feed URL (unreachable, no feed found…)."""
+
+
+def _get(url: str) -> httpx.Response:
+    """SSRF-guarded GET with a size cap. Re-checks the final URL after
+    redirects (per bot/ssrf.py's documented limitation)."""
+    assert_public_url(url)
+    resp = httpx.get(
+        url, timeout=_FETCH_TIMEOUT_S, follow_redirects=True,
+        headers={"User-Agent": _UA},
+    )
+    assert_public_url(str(resp.url))
+    resp.raise_for_status()
+    if len(resp.content) > _MAX_BODY_BYTES:
+        raise FeedError("Feed is too large to process.")
+    return resp
+
+
+def _looks_like_feed(body: str) -> bool:
+    head = body.lstrip()[:500].lower()
+    return head.startswith("<?xml") or "<rss" in head or "<feed" in head
+
+
+def _discover_feed_in_html(body: str, base_url: str) -> str | None:
+    """First advertised RSS/Atom <link rel="alternate"> in an HTML page."""
+    for tag in _FEED_LINK_RE.findall(body):
+        if not _FEED_TYPE_RE.search(tag):
+            continue
+        href = _HREF_RE.search(tag)
+        if href:
+            return urljoin(base_url, href.group(1))
+    return None
+
+
+def _youtube_feed_url(url: str, body: str | None) -> str | None:
+    """Map any YouTube channel-ish URL to its Atom feed."""
+    parsed = urlparse(url)
+    if parsed.hostname not in _YT_HOSTS:
+        return None
+    m = re.match(r"^/channel/(UC[0-9A-Za-z_-]{22})", parsed.path)
+    if m:
+        return _YT_FEED.format(cid=m.group(1))
+    # Handle/legacy forms (/@name, /c/name, /user/name) carry the channelId
+    # only inside the page markup.
+    if body:
+        m = _YT_CHANNEL_ID_RE.search(body)
+        if m:
+            return _YT_FEED.format(cid=m.group(1))
+    return None
+
+
+def resolve_feed(url: str) -> dict:
+    """Resolve any supported input URL to a canonical feed.
+
+    Returns {feed_url, title, source_kind}. Raises FeedError (user-facing) or
+    BlockedURLError (non-public target).
+    """
+    url = (url or "").strip()
+    if not url:
+        raise FeedError("That doesn't look like a URL.")
+    if "://" not in url:
+        url = "https://" + url
+
+    # Pure-path YouTube channel form needs no page fetch at all.
+    direct_yt = _youtube_feed_url(url, None)
+    if direct_yt:
+        feed_url, kind = direct_yt, "youtube"
+    else:
+        try:
+            resp = _get(url)
+        except BlockedURLError:
+            raise
+        except FeedError:
+            raise
+        except Exception as e:
+            raise FeedError(f"Couldn't reach that URL ({e.__class__.__name__}).")
+        body = resp.text
+        if _looks_like_feed(body):
+            feed_url, kind = str(resp.url), "rss"
+        else:
+            yt = _youtube_feed_url(str(resp.url), body)
+            if yt:
+                feed_url, kind = yt, "youtube"
+            else:
+                discovered = _discover_feed_in_html(body, str(resp.url))
+                if not discovered:
+                    raise FeedError(
+                        "No feed found at that URL. Paste an RSS/Atom feed URL, "
+                        "a YouTube channel URL, or a site that advertises a feed."
+                    )
+                feed_url, kind = discovered, "rss"
+
+    # Validate the resolved feed and pick up its title.
+    try:
+        feed_resp = _get(feed_url)
+    except BlockedURLError:
+        raise
+    except Exception as e:
+        raise FeedError(f"Couldn't fetch the feed ({e.__class__.__name__}).")
+    parsed = feedparser.parse(feed_resp.content)
+    if parsed.bozo and not parsed.entries:
+        raise FeedError("That URL doesn't parse as an RSS/Atom feed.")
+    title = (getattr(parsed.feed, "title", "") or "").strip()
+    return {"feed_url": feed_url, "title": title, "source_kind": kind}
+
+
+def fetch_entries(feed_url: str) -> list[dict]:
+    """The newest FEED_ENTRY_WINDOW entries of a feed: {url, title}."""
+    resp = _get(feed_url)
+    parsed = feedparser.parse(resp.content)
+    out = []
+    for e in parsed.entries[:FEED_ENTRY_WINDOW]:
+        link = (getattr(e, "link", "") or "").strip()
+        if not link:
+            continue
+        out.append({"url": link, "title": (getattr(e, "title", "") or "").strip()})
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Poll cycle
+# ---------------------------------------------------------------------------
+
+async def poll_subscription(sub, *, analysis_budget: int) -> dict:
+    """One subscription: register new entries, analyze up to the budget.
+
+    Returns {"new": n, "analyzed": n, "errors": n, "busy": bool}.
+    """
+    import asyncio
+
+    from bot.analyzer import UsageContext
+    from bot.db import (
+        get_pending_subscription_entries,
+        mark_subscription_polled,
+        record_subscription_entry,
+        set_subscription_entry_result,
+    )
+    from bot.pipeline import ERR_BUSY, PipelineError, analyze_url
+
+    stats = {"new": 0, "analyzed": 0, "errors": 0, "busy": False}
+    entries = await asyncio.to_thread(fetch_entries, sub["feed_url"])
+
+    first_poll = not sub["last_polled_at"]
+    # Subscribing must not trigger a backfill: everything already in the feed
+    # is recorded as seen-but-never-analyzed.
+    status = "seeded" if first_poll else "pending"
+    for e in entries:
+        if record_subscription_entry(sub["id"], sub["user_id"], e["url"], e["title"],
+                                     status=status):
+            stats["new"] += 1
+    mark_subscription_polled(sub["id"])
+    if first_poll:
+        return stats
+
+    for entry in get_pending_subscription_entries(sub["id"], limit=MAX_NEW_PER_POLL):
+        if stats["analyzed"] >= analysis_budget:
+            break
+        try:
+            result = await analyze_url(
+                entry["entry_url"],
+                ctx=UsageContext(user_id=sub["user_id"]),
+                save_for_user_id=sub["user_id"],
+            )
+            set_subscription_entry_result(
+                entry["id"], status="done", item_id=result.saved_id,
+                verdict=(result.analysis.get("verdict") or ""),
+            )
+            stats["analyzed"] += 1
+        except PipelineError as e:
+            if e.code == ERR_BUSY:
+                # Leave pending — the box is saturated with interactive work;
+                # monitoring is the load that sheds first.
+                stats["busy"] = True
+                break
+            set_subscription_entry_result(entry["id"], status="error")
+            stats["errors"] += 1
+    return stats
+
+
+async def poll_all_subscriptions() -> dict:
+    """One cycle over every subscription. Per-subscription failures are
+    contained; the cycle-wide analysis ceiling bounds LLM spend."""
+    from bot.db import get_all_subscriptions
+
+    totals = {"subscriptions": 0, "new": 0, "analyzed": 0, "errors": 0, "feed_errors": 0}
+    budget = MAX_ANALYSES_PER_CYCLE
+    for sub in get_all_subscriptions():
+        totals["subscriptions"] += 1
+        try:
+            stats = await poll_subscription(sub, analysis_budget=budget)
+        except Exception:
+            totals["feed_errors"] += 1
+            logger.warning("poll failed for subscription %s (%s)",
+                           sub["id"], sub["feed_url"], exc_info=True)
+            continue
+        budget -= stats["analyzed"]
+        totals["new"] += stats["new"]
+        totals["analyzed"] += stats["analyzed"]
+        totals["errors"] += stats["errors"]
+        if stats["busy"] or budget <= 0:
+            break
+    return totals

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -143,6 +143,7 @@ see the roadmap; not yet implemented.
 | `DIGEST_UNSUBSCRIBE_SECRET` | HMAC secret for unsubscribe links — sending fails closed without it |
 | `DIGEST_REPLY_TO_EMAIL` | Reply-To for the digest — point at a monitored address (e.g. Cloudflare Email Routing → private inbox) so user replies actually land somewhere |
 | `DIGEST_WEEKDAY`, `DIGEST_HOUR_UTC`, `DIGEST_BASE_URL` | Optional digest tuning (defaults: Friday, 06:00 UTC, base = `WEBHOOK_URL`) |
+| `MONITOR_ENABLED`, `MONITOR_INTERVAL_S` | Channel-monitoring poll loop (default: on, hourly). No-op until users subscribe; LLM spend is bounded per cycle (see `bot/monitor.py`) |
 
 ## Runbook — Fly is wedged / dashboard unreachable
 

--- a/main.py
+++ b/main.py
@@ -76,6 +76,13 @@ _DIGEST_ENABLED = os.getenv("DIGEST_ENABLED", "").lower() in ("1", "true", "yes"
 _DIGEST_WEEKDAY = int(os.getenv("DIGEST_WEEKDAY", "4"))  # Mon=0 … Fri=4
 _DIGEST_HOUR_UTC = int(os.getenv("DIGEST_HOUR_UTC", "6"))
 
+# Channel monitoring (#68): poll subscribed feeds on an interval. Defaults ON
+# like the prune — with no subscriptions each cycle is a no-op, and adding a
+# subscription is an explicit user action. Spend is bounded by the per-cycle
+# analysis ceiling in bot.monitor. Opt out with MONITOR_ENABLED=false.
+_MONITOR_ENABLED = os.getenv("MONITOR_ENABLED", "true").lower() in ("1", "true", "yes")
+_MONITOR_INTERVAL_S = int(os.getenv("MONITOR_INTERVAL_S", "3600"))
+
 
 async def _daily_error_scan_loop() -> None:
     """Wake once a day at SCAN_HOUR_UTC and run scripts.scan_errors.run_scan."""
@@ -131,6 +138,24 @@ async def _weekly_digest_loop() -> None:
             raise
         except Exception:
             logger.exception("Weekly digest run failed; will retry next week")
+
+
+async def _monitor_loop() -> None:
+    """Poll subscribed channels every MONITOR_INTERVAL_S. Interval-based (not
+    a daily slot): drops should surface within the hour, and an idle cycle
+    with no subscriptions costs one SELECT."""
+    from bot.monitor import poll_all_subscriptions
+
+    while True:
+        try:
+            await asyncio.sleep(_MONITOR_INTERVAL_S)
+            stats = await poll_all_subscriptions()
+            if stats["subscriptions"]:
+                logger.info("channel monitor: %s", stats)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("Channel monitor cycle failed; retrying next interval")
 
 
 # The heavy request paths offload their blocking fetch/transcode/LLM work via
@@ -189,6 +214,9 @@ async def lifespan(app: FastAPI):
             "Weekly digest enabled (weekday=%d, hour=%d UTC)",
             _DIGEST_WEEKDAY, _DIGEST_HOUR_UTC,
         )
+    if _MONITOR_ENABLED:
+        maintenance_tasks.append(asyncio.create_task(_monitor_loop()))
+        logger.info("Channel monitor enabled (interval=%ds)", _MONITOR_INTERVAL_S)
 
     yield
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,8 @@ youtube-transcript-api>=1.2.4
 faster-whisper>=1.0.0
 # documents
 pdfplumber>=0.11.0
+# channel monitoring: RSS/Atom (incl. YouTube channel feeds) parsing
+feedparser>=6.0.0
 # GitHub App auth for scripts/scan_errors.py (RS256 JWT → installation token)
 pyjwt[crypto]>=2.8.0
 # web UI file uploads

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -423,7 +423,7 @@ class TestPruneMaintenance:
         assert counts == {
             "error_log": 1, "url_cache": 1, "link_codes": 1, "jobs": 1,
             "processed_updates": 1, "llm_cache": 1, "llm_cache_hits": 1,
-            "processed_urls": 1, "suggestion_signals": 0,
+            "processed_urls": 1, "suggestion_signals": 0, "subscription_items": 0,
         }
 
         with db._get_conn() as conn:
@@ -443,7 +443,7 @@ class TestPruneMaintenance:
         assert counts == {
             "error_log": 0, "url_cache": 0, "link_codes": 0, "jobs": 0,
             "processed_updates": 0, "llm_cache": 0, "llm_cache_hits": 0,
-            "processed_urls": 0, "suggestion_signals": 0,
+            "processed_urls": 0, "suggestion_signals": 0, "subscription_items": 0,
         }
 
 

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,0 +1,354 @@
+"""Channel monitoring (#68): feed resolution, the poll cycle's cost/dedupe
+contracts, and the subscriptions API.
+
+No network anywhere: monitor._get is stubbed for resolution tests, and
+fetch_entries / pipeline.analyze_url are monkeypatched for the poll tests.
+
+The contracts that matter most:
+  1. Subscribing NEVER backfills — entries already in the feed are seeded as
+     seen-but-not-analyzed. Only drops that arrive later cost LLM calls.
+  2. Entries are analyzed once per subscription (cross-poll dedupe), with
+     per-subscription and per-cycle budgets bounding spend.
+  3. A saturated box (ERR_BUSY) leaves entries pending — monitoring sheds
+     before interactive traffic.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+
+import pytest
+
+FEED_XML = """<?xml version="1.0"?>
+<rss version="2.0"><channel><title>My Blog</title>
+<item><link>https://ex.com/post-a</link><title>Post A</title></item>
+<item><link>https://ex.com/post-b</link><title>Post B</title></item>
+</channel></rss>"""
+
+HTML_WITH_FEED = """<!doctype html><html><head>
+<link rel="alternate" type="application/rss+xml" href="/feed.xml">
+</head><body>hi</body></html>"""
+
+HTML_NO_FEED = "<!doctype html><html><head></head><body>plain page</body></html>"
+
+YT_CHANNEL_PAGE = '<html><script>var x = {"channelId":"UCabcdefghijklmnopqrstuv"};</script></html>'
+
+
+def _resp(url: str, body: str):
+    return SimpleNamespace(url=url, text=body, content=body.encode())
+
+
+@pytest.fixture
+def fake_get(monkeypatch):
+    """Route monitor._get through an in-memory URL→body table."""
+    from bot import monitor
+    pages: dict[str, str] = {}
+
+    def get(url):
+        if url not in pages:
+            raise monitor.FeedError(f"unreachable in test: {url}")
+        return _resp(url, pages[url])
+
+    monkeypatch.setattr(monitor, "_get", get)
+    return pages
+
+
+class TestResolveFeed:
+    def test_raw_feed_url_passes_through(self, fake_get):
+        from bot.monitor import resolve_feed
+        fake_get["https://ex.com/feed.xml"] = FEED_XML
+        r = resolve_feed("https://ex.com/feed.xml")
+        assert r == {"feed_url": "https://ex.com/feed.xml", "title": "My Blog",
+                     "source_kind": "rss"}
+
+    def test_html_page_discovers_advertised_feed(self, fake_get):
+        from bot.monitor import resolve_feed
+        fake_get["https://ex.com/blog"] = HTML_WITH_FEED
+        fake_get["https://ex.com/feed.xml"] = FEED_XML
+        r = resolve_feed("https://ex.com/blog")
+        assert r["feed_url"] == "https://ex.com/feed.xml"  # relative href resolved
+        assert r["source_kind"] == "rss"
+
+    def test_youtube_channel_url_maps_to_atom_feed_without_page_fetch(self, fake_get):
+        from bot.monitor import resolve_feed
+        feed = "https://www.youtube.com/feeds/videos.xml?channel_id=UCabcdefghijklmnopqrstuv"
+        fake_get[feed] = FEED_XML
+        r = resolve_feed("https://www.youtube.com/channel/UCabcdefghijklmnopqrstuv")
+        assert r["feed_url"] == feed
+        assert r["source_kind"] == "youtube"
+
+    def test_youtube_handle_page_yields_channel_id(self, fake_get):
+        from bot.monitor import resolve_feed
+        feed = "https://www.youtube.com/feeds/videos.xml?channel_id=UCabcdefghijklmnopqrstuv"
+        fake_get["https://www.youtube.com/@somecreator"] = YT_CHANNEL_PAGE
+        fake_get[feed] = FEED_XML
+        r = resolve_feed("https://www.youtube.com/@somecreator")
+        assert r["feed_url"] == feed
+        assert r["source_kind"] == "youtube"
+
+    def test_page_without_feed_raises_user_facing_error(self, fake_get):
+        from bot.monitor import FeedError, resolve_feed
+        fake_get["https://ex.com/nothing"] = HTML_NO_FEED
+        with pytest.raises(FeedError, match="No feed found"):
+            resolve_feed("https://ex.com/nothing")
+
+    def test_non_public_target_is_blocked(self):
+        # Real SSRF guard, no stub: localhost is rejected before any DNS.
+        from bot.monitor import resolve_feed
+        from bot.ssrf import BlockedURLError
+        with pytest.raises(BlockedURLError):
+            resolve_feed("http://localhost/feed.xml")
+
+    def test_scheme_is_defaulted(self, fake_get):
+        from bot.monitor import resolve_feed
+        fake_get["https://ex.com/feed.xml"] = FEED_XML
+        assert resolve_feed("ex.com/feed.xml")["title"] == "My Blog"
+
+
+class TestFetchEntries:
+    def test_parses_links_and_titles(self, fake_get):
+        from bot.monitor import fetch_entries
+        fake_get["https://ex.com/feed.xml"] = FEED_XML
+        entries = fetch_entries("https://ex.com/feed.xml")
+        assert entries == [
+            {"url": "https://ex.com/post-a", "title": "Post A"},
+            {"url": "https://ex.com/post-b", "title": "Post B"},
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Poll cycle
+# ---------------------------------------------------------------------------
+
+def _fake_result(saved_id=11, verdict="watch"):
+    return SimpleNamespace(saved_id=saved_id, analysis={"verdict": verdict})
+
+
+@pytest.fixture
+def polling(db, monkeypatch):
+    """A user + subscription, with the feed and the pipeline both stubbed.
+    Returns a context object tests mutate (feed entries, analyze behaviour)."""
+    from bot import monitor, pipeline
+
+    ctx = SimpleNamespace(entries=[], analyzed=[], analyze_error=None, db=db)
+    uid = db.upsert_user_by_email("u@example.com")
+    sub_id = db.add_subscription(uid, "https://ex.com/feed.xml", title="My Blog")
+    ctx.user_id, ctx.sub_id = uid, sub_id
+
+    monkeypatch.setattr(monitor, "fetch_entries", lambda feed_url: list(ctx.entries))
+
+    async def fake_analyze_url(url, *, ctx_=None, **kw):
+        if ctx.analyze_error is not None:
+            raise ctx.analyze_error
+        ctx.analyzed.append(url)
+        return _fake_result()
+
+    monkeypatch.setattr(pipeline, "analyze_url", fake_analyze_url)
+
+    def sub_row():
+        return next(s for s in db.get_all_subscriptions() if s["id"] == sub_id)
+
+    def poll():
+        from bot.monitor import poll_subscription
+        return asyncio.run(poll_subscription(sub_row(), analysis_budget=99))
+
+    ctx.poll = poll
+    ctx.statuses = lambda: {
+        r["entry_url"]: r["status"]
+        for r in db._get_conn().execute(
+            "SELECT entry_url, status FROM subscription_items").fetchall()
+    }
+    return ctx
+
+
+class TestPollSubscription:
+    def test_first_poll_seeds_without_analyzing(self, polling):
+        polling.entries = [{"url": "https://ex.com/old", "title": "Old"}]
+        stats = polling.poll()
+        assert stats == {"new": 1, "analyzed": 0, "errors": 0, "busy": False}
+        assert polling.analyzed == []
+        assert polling.statuses() == {"https://ex.com/old": "seeded"}
+
+    def test_new_drop_after_seeding_is_analyzed_once(self, polling):
+        polling.entries = [{"url": "https://ex.com/old", "title": "Old"}]
+        polling.poll()  # seed
+        polling.entries = [{"url": "https://ex.com/new", "title": "New"},
+                           {"url": "https://ex.com/old", "title": "Old"}]
+        stats = polling.poll()
+        assert stats["analyzed"] == 1
+        assert polling.analyzed == ["https://ex.com/new"]
+        assert polling.statuses()["https://ex.com/new"] == "done"
+        # Third poll: nothing new, nothing re-analyzed (cross-poll dedupe).
+        stats = polling.poll()
+        assert stats["new"] == 0 and stats["analyzed"] == 0
+
+    def test_done_entry_links_item_and_verdict(self, polling):
+        polling.entries = []
+        polling.poll()  # seed (empty)
+        polling.entries = [{"url": "https://ex.com/new", "title": "New"}]
+        polling.poll()
+        row = polling.db._get_conn().execute(
+            "SELECT item_id, verdict FROM subscription_items WHERE entry_url = ?",
+            ("https://ex.com/new",),
+        ).fetchone()
+        assert row["item_id"] == 11
+        assert row["verdict"] == "watch"
+
+    def test_busy_box_leaves_entries_pending(self, polling):
+        from bot.pipeline import ERR_BUSY, PipelineError
+        polling.entries = []
+        polling.poll()  # seed
+        polling.entries = [{"url": "https://ex.com/new", "title": "New"}]
+        polling.analyze_error = PipelineError(ERR_BUSY, message="busy")
+        stats = polling.poll()
+        assert stats["busy"] is True
+        assert polling.statuses()["https://ex.com/new"] == "pending"
+        # Capacity returns → the pending entry is picked up next cycle.
+        polling.analyze_error = None
+        stats = polling.poll()
+        assert stats["analyzed"] == 1
+        assert polling.statuses()["https://ex.com/new"] == "done"
+
+    def test_pipeline_failure_marks_error_and_does_not_retry(self, polling):
+        from bot.pipeline import ERR_FETCH_FAILED, PipelineError
+        polling.entries = []
+        polling.poll()
+        polling.entries = [{"url": "https://ex.com/broken", "title": "B"}]
+        polling.analyze_error = PipelineError(ERR_FETCH_FAILED, message="nope")
+        stats = polling.poll()
+        assert stats["errors"] == 1
+        assert polling.statuses()["https://ex.com/broken"] == "error"
+        polling.analyze_error = None
+        assert polling.poll()["analyzed"] == 0  # errored entries stay done-with
+
+    def test_per_poll_cap_bounds_analysis(self, polling, monkeypatch):
+        from bot import monitor
+        monkeypatch.setattr(monitor, "MAX_NEW_PER_POLL", 2)
+        polling.entries = []
+        polling.poll()
+        polling.entries = [{"url": f"https://ex.com/p{i}", "title": str(i)} for i in range(5)]
+        stats = polling.poll()
+        assert stats["analyzed"] == 2
+
+
+class TestPollAllSubscriptions:
+    def test_fan_out_and_contained_feed_failure(self, db, monkeypatch):
+        from bot import monitor, pipeline
+
+        ua = db.upsert_user_by_email("a@example.com")
+        ub = db.upsert_user_by_email("b@example.com")
+        db.add_subscription(ua, "https://ex.com/feed.xml")
+        db.add_subscription(ub, "https://ex.com/feed.xml")   # same feed, 2nd user
+        db.add_subscription(ub, "https://broken.example/feed")
+
+        def fetch(feed_url):
+            if "broken" in feed_url:
+                raise monitor.FeedError("dead feed")
+            return [{"url": "https://ex.com/drop", "title": "Drop"}]
+
+        analyzed = []
+
+        async def fake_analyze_url(url, **kw):
+            analyzed.append(kw["save_for_user_id"])
+            return _fake_result()
+
+        monkeypatch.setattr(monitor, "fetch_entries", fetch)
+        monkeypatch.setattr(pipeline, "analyze_url", fake_analyze_url)
+
+        asyncio.run(monitor.poll_all_subscriptions())  # seeds both good subs
+        totals = asyncio.run(monitor.poll_all_subscriptions())
+        # Seeded entries don't re-analyze; the dead feed doesn't stop the run.
+        assert totals["feed_errors"] == 1
+        assert totals["subscriptions"] == 3
+        # New drop for both subscribers next cycle:
+        def fetch2(feed_url):
+            if "broken" in feed_url:
+                raise monitor.FeedError("dead feed")
+            return [{"url": "https://ex.com/drop2", "title": "Drop 2"}]
+        monkeypatch.setattr(monitor, "fetch_entries", fetch2)
+        totals = asyncio.run(monitor.poll_all_subscriptions())
+        assert totals["analyzed"] == 2
+        assert sorted(analyzed) == sorted([ua, ub])  # one personalized run each
+
+
+# ---------------------------------------------------------------------------
+# API
+# ---------------------------------------------------------------------------
+
+class TestSubscriptionEndpoints:
+    @pytest.fixture
+    def resolved(self, monkeypatch):
+        import bot.monitor
+        monkeypatch.setattr(
+            bot.monitor, "resolve_feed",
+            lambda url: {"feed_url": "https://ex.com/feed.xml", "title": "My Blog",
+                         "source_kind": "rss"},
+        )
+
+    def test_create_list_delete_roundtrip(self, client, auth_headers, db, resolved):
+        uid = db.upsert_user_by_email("u@example.com")
+        r = client.post("/api/subscriptions", headers=auth_headers,
+                        json={"user_id": uid, "url": "https://ex.com/blog"})
+        assert r.status_code == 201
+        sub = r.json()
+        assert sub["feed_url"] == "https://ex.com/feed.xml"
+
+        r = client.get(f"/api/subscriptions?user_id={uid}", headers=auth_headers)
+        assert [s["title"] for s in r.json()] == ["My Blog"]
+
+        r = client.delete(f"/api/subscriptions/{sub['id']}?user_id={uid}",
+                          headers=auth_headers)
+        assert r.status_code == 204
+        assert client.get(f"/api/subscriptions?user_id={uid}", headers=auth_headers).json() == []
+
+    def test_duplicate_subscription_is_409(self, client, auth_headers, db, resolved):
+        uid = db.upsert_user_by_email("u@example.com")
+        body = {"user_id": uid, "url": "https://ex.com/blog"}
+        assert client.post("/api/subscriptions", headers=auth_headers, json=body).status_code == 201
+        r = client.post("/api/subscriptions", headers=auth_headers, json=body)
+        assert r.status_code == 409
+        assert r.json()["detail"]["error"] == "already-subscribed"
+
+    def test_cap_is_409_with_message(self, client, auth_headers, db, resolved, monkeypatch):
+        monkeypatch.setattr(db, "MAX_SUBSCRIPTIONS_PER_USER", 0)
+        uid = db.upsert_user_by_email("u@example.com")
+        r = client.post("/api/subscriptions", headers=auth_headers,
+                        json={"user_id": uid, "url": "https://ex.com/blog"})
+        assert r.status_code == 409
+        assert r.json()["detail"]["error"] == "limit-reached"
+
+    def test_unresolvable_feed_is_422(self, client, auth_headers, db, monkeypatch):
+        import bot.monitor
+
+        def boom(url):
+            raise bot.monitor.FeedError("No feed found at that URL.")
+
+        monkeypatch.setattr(bot.monitor, "resolve_feed", boom)
+        uid = db.upsert_user_by_email("u@example.com")
+        r = client.post("/api/subscriptions", headers=auth_headers,
+                        json={"user_id": uid, "url": "https://ex.com/none"})
+        assert r.status_code == 422
+        assert "No feed found" in r.json()["detail"]["message"]
+
+    def test_delete_is_ownership_scoped(self, client, auth_headers, db, resolved):
+        owner = db.upsert_user_by_email("owner@example.com")
+        other = db.upsert_user_by_email("other@example.com")
+        r = client.post("/api/subscriptions", headers=auth_headers,
+                        json={"user_id": owner, "url": "https://ex.com/blog"})
+        sub_id = r.json()["id"]
+        r = client.delete(f"/api/subscriptions/{sub_id}?user_id={other}", headers=auth_headers)
+        assert r.status_code == 404
+        assert len(client.get(f"/api/subscriptions?user_id={owner}", headers=auth_headers).json()) == 1
+
+    def test_export_and_erasure_cover_subscriptions(self, client, auth_headers, db, resolved):
+        uid = db.upsert_user_by_email("u@example.com")
+        client.post("/api/subscriptions", headers=auth_headers,
+                    json={"user_id": uid, "url": "https://ex.com/blog"})
+        exported = client.get(f"/api/users/{uid}/export", headers=auth_headers).json()
+        assert exported["subscriptions"][0]["feed_url"] == "https://ex.com/feed.xml"
+
+        db.delete_user(uid)
+        with db._get_conn() as conn:
+            assert conn.execute("SELECT COUNT(*) FROM subscriptions").fetchone()[0] == 0
+            assert conn.execute("SELECT COUNT(*) FROM subscription_items").fetchone()[0] == 0


### PR DESCRIPTION
## What

Implements #68 — the actual reason-to-pay from the product audit. Users follow channels; filter.fyi watches them and filters new drops through their lens.

**Subscribe** (`POST /api/subscriptions`, Worker-gated): any supported input — a raw RSS/Atom URL, a YouTube channel/handle URL, or an HTML page advertising a feed — is resolved to one canonical feed URL *at subscribe time*, so bad URLs fail immediately with a clear 422 instead of silently never producing drops. YouTube needs no API key (public Atom feeds). All resolution fetches go through the SSRF guard, including a post-redirect re-check of the final URL.

**Poll** (`bot/monitor.py`, hourly in-process loop like the other maintenance loops): new entries flow through `bot.pipeline.analyze_url` with the subscriber's user_id, which buys everything for free — lens personalization, per-user cost attribution in `llm_calls`, shared fetches across subscribers via `url_cache`, and the #65 capacity guards. Analyzed drops land in the user's library, which means the weekly digest (#67) picks them up with zero extra code.

**Cost discipline** (the part I'd review hardest):
- Subscribing **never backfills** — entries already in the feed are recorded `seeded` and never analyzed. Only drops arriving after you subscribe cost anything.
- ≤3 new entries per subscription per cycle, ≤12 per cycle globally, ≤30 subscriptions per user.
- `ERR_BUSY` from the pipeline leaves entries `pending` for the next cycle — monitoring is explicitly the load that sheds first.
- Failed analyses are marked `error` and not retried; failed *feeds* are contained per-subscription.

**Lifecycle:** subscriptions erased with the user, included in the GDPR export; seen-entry rows pruned after a year (they're only needed while entries remain in the feed window). New dep: `feedparser`. Env: `MONITOR_ENABLED` (default on — no-op without subscriptions), `MONITOR_INTERVAL_S` (default 3600).

## Tests

21 new in `tests/test_monitor.py`, all network-free: feed resolution (passthrough, HTML discovery, YouTube channel + handle, no-feed error, SSRF block, scheme defaulting), the poll contracts (seed-no-backfill, analyze-once dedupe, busy-shedding + retry, error no-retry, per-poll cap), multi-subscriber fan-out with a contained dead feed, and the full endpoint matrix incl. ownership-scoped delete and export/erasure. **Full suite: 356 passed.**

## What's next

Frontend PR (next up): Worker proxy `/api/v1/subscriptions` + a "Channels" pane on /me to add/remove feeds. Once both are deployed and a subscription produces its first drop, the monitoring "soon" tags on /about can come off (filter.fyi#51).

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)