### PR TITLE
feat(consolidate): cross-source suggestion consolidation (#70)

### DIFF
--- a/bot/agent_brief.py
+++ b/bot/agent_brief.py
@@ -52,6 +52,7 @@ def build_agent_brief(
     source_title: str = "",
     source_url: str = "",
     summary_excerpt: str = "",
+    extra_sources: list[dict] | None = None,
     variant: str = "full",
 ) -> str:
     """Render one handoff brief as a clean prompt. ``variant`` is "full" or "link".
@@ -82,6 +83,15 @@ def build_agent_brief(
         src.append((source_title or source_url).strip())
     if grounded_in and grounded_in.strip():
         src.append(f"Key point it hinges on: {grounded_in.strip()}")
+    # Consolidated entries (#70): every source that converged on this action,
+    # so the assistant can cross-reference instead of trusting one take.
+    for s in extra_sources or []:
+        title = (s.get("title") or "").strip()
+        url = (s.get("url") or "").strip()
+        if title and url:
+            src.append(f"Also recommended by: {title} — {url}")
+        elif title or url:
+            src.append(f"Also recommended by: {title or url}")
     if variant == "full" and summary_excerpt and summary_excerpt.strip():
         src += ["", "What it says:", _clip_sentence(summary_excerpt, SUMMARY_EXCERPT_CHARS)]
     if src:

--- a/bot/api.py
+++ b/bot/api.py
@@ -35,6 +35,7 @@ from bot.db import (
     LINK_CODE_TTL_SECONDS,
     SAVED_SUGGESTION_STATUSES,
     SUGGESTION_SIGNAL_EVENTS,
+    add_saved_suggestion_source,
     add_subscription,
     create_job,
     create_link_code,
@@ -45,6 +46,7 @@ from bot.db import (
     get_all_items,
     get_item,
     get_job_record,
+    get_saved_suggestion_sources,
     get_saved_suggestions,
     get_subscriptions,
     get_suggestion_signals,
@@ -686,9 +688,35 @@ async def saved_suggestion_create(
 ):
     """Park ("later") a suggestion on the user's Shortlist. Idempotent on
     (user, item, suggestion_index). Ownership-scoped: the item must belong to
-    the user (404 otherwise), so you can't pin against someone else's read."""
+    the user (404 otherwise), so you can't pin against someone else's read.
+
+    Consolidation (#70): a save that closely matches an existing Shortlist
+    entry from a *different* item merges into it — the existing entry gains
+    this item as a source instead of the list gaining a near-duplicate. The
+    response carries `merged: true` + the surviving entry so the client can
+    point at it. Exact re-saves of the same (item, index) keep the original
+    idempotent-refresh path.
+    """
+    from bot.consolidate import find_similar
+
     if not get_item(req.item_id, req.user_id):
         raise HTTPException(status_code=404, detail={"error": "not-found"})
+
+    existing = get_saved_suggestions(req.user_id)
+    own = next(
+        (r for r in existing
+         if r["item_id"] == req.item_id and r["suggestion_index"] == req.suggestion_index),
+        None,
+    )
+    if own is None:
+        match = find_similar(
+            req.title, req.detail,
+            [r for r in existing if r["item_id"] != req.item_id],
+        )
+        if match is not None:
+            add_saved_suggestion_source(match["id"], req.user_id, req.item_id)
+            return {"id": match["id"], "status": match["status"], "merged": True}
+
     saved_id = save_suggestion(
         req.user_id,
         req.item_id,
@@ -705,10 +733,20 @@ async def saved_suggestion_create(
 @router.get("/saved-suggestions")
 async def saved_suggestions_list(user_id: int, _: None = Depends(_require_try_secret)):
     """The user's Shortlist, newest first. Each row carries its source URL and
-    the source item's title (for the back-link) alongside the snapshot."""
+    the source item's title (for the back-link) alongside the snapshot, plus
+    any extra sources a consolidated entry has absorbed (#70)."""
+    extra_sources = get_saved_suggestion_sources(user_id)
     out = []
     for r in get_saved_suggestions(user_id):
         _, item_title = _extract_verdict_and_title(r["item_analysis"])
+        sources = []
+        for s in extra_sources.get(r["id"], []):
+            _, s_title = _extract_verdict_and_title(s["item_analysis"])
+            sources.append({
+                "item_id": s["item_id"],
+                "source": s["source"],
+                "item_title": s_title,
+            })
         out.append({
             "id": r["id"],
             "item_id": r["item_id"],
@@ -723,6 +761,7 @@ async def saved_suggestions_list(user_id: int, _: None = Depends(_require_try_se
             "updated_at": r["updated_at"],
             "source": r["source"],
             "item_title": item_title,
+            "sources": sources,
         })
     return out
 

--- a/bot/consolidate.py
+++ b/bot/consolidate.py
@@ -1,0 +1,87 @@
+"""Cross-source suggestion consolidation (#70): N reads → 1 action.
+
+Different sources frequently converge on the same next step ("set up an eval
+harness", "try the new model on your pipeline"). Without consolidation each
+read appends its own copy, and the Shortlist becomes the inbox-overflow it
+was meant to cure. Two consumers use this module:
+
+- the Shortlist save path: a new save that closely matches an existing entry
+  *merges into it* (the existing entry gains a source) instead of appending;
+- the weekly digest: convergent suggestions from the week's items collapse
+  into one action backed by all of its sources.
+
+Similarity is deliberately cheap and deterministic — token overlap (Jaccard)
+over the normalized title+detail. No embeddings, no LLM calls, fully
+testable. It only needs to catch *obvious* convergence; a missed merge is a
+minor annoyance, a wrong merge would be confusing, so the threshold errs
+conservative.
+"""
+from __future__ import annotations
+
+import re
+
+# Jaccard similarity at/above this counts as "the same next step". Tuned
+# conservative: distinct-but-related suggestions should NOT merge.
+SIMILARITY_THRESHOLD = 0.5
+
+# Words too common in suggestion copy to carry signal.
+_STOPWORDS = frozenset(
+    "a an the and or of to in on for with your you it its this that try use "
+    "set up out new build add make start get".split()
+)
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+
+def tokens(text: str) -> frozenset[str]:
+    """Normalized signal tokens of a suggestion text."""
+    return frozenset(
+        t for t in _TOKEN_RE.findall((text or "").lower())
+        if len(t) > 2 and t not in _STOPWORDS
+    )
+
+
+def similarity(a: str, b: str) -> float:
+    """Jaccard overlap of the two texts' token sets. 0.0 when either is empty."""
+    ta, tb = tokens(a), tokens(b)
+    if not ta or not tb:
+        return 0.0
+    return len(ta & tb) / len(ta | tb)
+
+
+def suggestion_text(title: str, detail: str) -> str:
+    return f"{title or ''} {detail or ''}".strip()
+
+
+def find_similar(title: str, detail: str, candidates: list[dict]) -> dict | None:
+    """Best candidate at/above the threshold, else None.
+
+    ``candidates`` are dicts (or Rows) with at least title/detail. Ties go to
+    the highest score; equal scores keep the first (oldest-listed) candidate
+    so merging is stable.
+    """
+    text = suggestion_text(title, detail)
+    best, best_score = None, 0.0
+    for c in candidates:
+        score = similarity(text, suggestion_text(c["title"], c["detail"]))
+        if score >= SIMILARITY_THRESHOLD and score > best_score:
+            best, best_score = c, score
+    return best
+
+
+def cluster(items: list[dict]) -> list[list[dict]]:
+    """Greedy single-link clustering for the digest: each item joins the first
+    cluster whose representative it matches, else starts its own. Order is
+    preserved (first occurrence leads the cluster), so an input ranked
+    best-first yields clusters ranked best-first."""
+    clusters: list[list[dict]] = []
+    for item in items:
+        text = suggestion_text(item.get("title", ""), item.get("detail", ""))
+        for c in clusters:
+            rep = c[0]
+            if similarity(text, suggestion_text(rep.get("title", ""), rep.get("detail", ""))) >= SIMILARITY_THRESHOLD:
+                c.append(item)
+                break
+        else:
+            clusters.append([item])
+    return clusters

--- a/bot/db.py
+++ b/bot/db.py
@@ -123,6 +123,23 @@ CREATE TABLE IF NOT EXISTS saved_suggestions (
 # FEEDBACK_SIGNALS taps so the follow-up reads consistently across surfaces.
 SAVED_SUGGESTION_STATUSES = frozenset({"saved", "tried", "done"})
 
+# Extra sources backing a consolidated Shortlist entry (#70). The entry's own
+# item_id is its primary source; each row here is one *additional* item whose
+# similar suggestion merged into it instead of appending a duplicate entry.
+# `user_id` is denormalized for cheap GDPR erasure. Entries predating
+# consolidation simply have no rows here.
+_CREATE_SAVED_SUGGESTION_SOURCES_SQL = """\
+CREATE TABLE IF NOT EXISTS saved_suggestion_sources (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    saved_id   INTEGER NOT NULL,
+    user_id    INTEGER NOT NULL,
+    item_id    INTEGER NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%S', 'now')),
+    UNIQUE(saved_id, item_id),
+    FOREIGN KEY (saved_id) REFERENCES saved_suggestions(id),
+    FOREIGN KEY (item_id) REFERENCES items(id)
+)"""
+
 _CREATE_INDEXES_SQL = [
     "CREATE INDEX IF NOT EXISTS idx_items_user ON items(user_id, created_at DESC)",
     "CREATE INDEX IF NOT EXISTS idx_link_codes_expires ON link_codes(expires_at)",
@@ -133,6 +150,7 @@ _CREATE_INDEXES_SQL = [
     "CREATE INDEX IF NOT EXISTS idx_feedback_item ON feedback(item_id)",
     "CREATE INDEX IF NOT EXISTS idx_saved_suggestions_user ON saved_suggestions(user_id, created_at DESC)",
     "CREATE INDEX IF NOT EXISTS idx_saved_suggestions_item ON saved_suggestions(item_id)",
+    "CREATE INDEX IF NOT EXISTS idx_saved_suggestion_sources_saved ON saved_suggestion_sources(saved_id)",
     "CREATE INDEX IF NOT EXISTS idx_suggestion_signals_user ON suggestion_signals(user_id, created_at DESC)",
     "CREATE INDEX IF NOT EXISTS idx_subscriptions_user ON subscriptions(user_id, created_at DESC)",
     "CREATE INDEX IF NOT EXISTS idx_subscription_items_sub ON subscription_items(subscription_id, status)",
@@ -482,6 +500,7 @@ def _init() -> None:
         conn.execute(_CREATE_ERROR_LOG_SQL)
         conn.execute(_CREATE_FEEDBACK_SQL)
         conn.execute(_CREATE_SAVED_SUGGESTIONS_SQL)
+        conn.execute(_CREATE_SAVED_SUGGESTION_SOURCES_SQL)
         conn.execute(_CREATE_JOBS_SQL)
         # Added after jobs shipped: carries the user-facing failure message so
         # the Worker can show *why* a job failed instead of a generic string.
@@ -637,6 +656,7 @@ def delete_user(user_id: int) -> dict:
         conn.execute("DELETE FROM link_codes WHERE user_id = ?", (user_id,))
         conn.execute("DELETE FROM feedback WHERE user_id = ?", (user_id,))
         conn.execute("DELETE FROM saved_suggestions WHERE user_id = ?", (user_id,))
+        conn.execute("DELETE FROM saved_suggestion_sources WHERE user_id = ?", (user_id,))
         conn.execute("DELETE FROM suggestion_signals WHERE user_id = ?", (user_id,))
         conn.execute("DELETE FROM subscription_items WHERE user_id = ?", (user_id,))
         conn.execute("DELETE FROM subscriptions WHERE user_id = ?", (user_id,))
@@ -843,14 +863,56 @@ def update_saved_suggestion_status(saved_id: int, user_id: int, status: str) -> 
 
 
 def delete_saved_suggestion(saved_id: int, user_id: int) -> bool:
-    """Remove one shortlisted suggestion. Ownership-scoped — returns False if
-    the row doesn't exist or belongs to another user."""
+    """Remove one shortlisted suggestion (and its extra sources).
+    Ownership-scoped — returns False if the row doesn't exist or belongs to
+    another user."""
     with _get_conn() as conn:
         cur = conn.execute(
             "DELETE FROM saved_suggestions WHERE id = ? AND user_id = ?",
             (saved_id, user_id),
         )
+        if not cur.rowcount:
+            return False
+        conn.execute(
+            "DELETE FROM saved_suggestion_sources WHERE saved_id = ?", (saved_id,)
+        )
+        return True
+
+
+def add_saved_suggestion_source(saved_id: int, user_id: int, item_id: int) -> bool:
+    """Attach one extra source item to a consolidated entry (#70). Idempotent;
+    a no-op when the item is already attached or is the entry's own primary
+    item. Ownership-scoped via the entry."""
+    with _get_conn() as conn:
+        entry = conn.execute(
+            "SELECT item_id FROM saved_suggestions WHERE id = ? AND user_id = ?",
+            (saved_id, user_id),
+        ).fetchone()
+        if not entry or entry["item_id"] == item_id:
+            return False
+        cur = conn.execute(
+            "INSERT OR IGNORE INTO saved_suggestion_sources (saved_id, user_id, item_id) "
+            "VALUES (?, ?, ?)",
+            (saved_id, user_id, item_id),
+        )
         return cur.rowcount > 0
+
+
+def get_saved_suggestion_sources(user_id: int) -> dict[int, list[sqlite3.Row]]:
+    """All extra sources for a user's Shortlist, keyed by saved_id. Each row
+    joins the item for its URL + stored analysis (the title lives inside)."""
+    with _get_conn() as conn:
+        rows = conn.execute(
+            "SELECT s.saved_id, s.item_id, i.source AS source, "
+            "       i.analysis AS item_analysis "
+            "FROM saved_suggestion_sources s JOIN items i ON i.id = s.item_id "
+            "WHERE s.user_id = ? ORDER BY s.id",
+            (user_id,),
+        ).fetchall()
+    out: dict[int, list[sqlite3.Row]] = {}
+    for r in rows:
+        out.setdefault(r["saved_id"], []).append(r)
+    return out
 
 
 # ---------------------------------------------------------------------------

--- a/bot/digest.py
+++ b/bot/digest.py
@@ -133,29 +133,51 @@ def build_digest(user_id: int, *, now: datetime | None = None) -> dict | None:
     # Top actions: the best suggestion of each watch/skim item, best-first
     # (suggestions[] is already ordered best-first by the analyzer), one per
     # source so a single dense read doesn't crowd out the rest of the week.
-    actions = []
+    # Convergent suggestions across items collapse into one action backed by
+    # all of its sources (#70) — N reads → 1 thing to do.
+    from bot.consolidate import cluster
+
+    candidates = []
     for rank, row, analysis in parsed:
-        if rank >= _VERDICT_RANK["skip"] or len(actions) >= MAX_ACTIONS:
+        if rank >= _VERDICT_RANK["skip"]:
             continue
         suggestions = analysis.get("suggestions") or []
         if not suggestions:
             continue
         s = suggestions[0]
-        label = _item_label(analysis, row["source"])
-        actions.append({
+        candidates.append({
             "title": (s.get("title") or "Try this").strip(),
             "detail": (s.get("detail") or "").strip(),
             "effort": (s.get("effort") or "").strip(),
             "first_step": (s.get("first_step") or "").strip(),
+            "grounded_in": (analysis.get("grounded_in") or "").strip(),
             "source": row["source"],
-            "source_label": label,
+            "source_label": _item_label(analysis, row["source"]),
+        })
+
+    actions = []
+    for group in cluster(candidates)[:MAX_ACTIONS]:
+        lead = group[0]  # candidates are rank-ordered, so the lead is the best take
+        extra = [
+            {"title": m["source_label"], "url": m["source"]}
+            for m in group[1:]
+        ]
+        actions.append({
+            "title": lead["title"],
+            "detail": lead["detail"],
+            "effort": lead["effort"],
+            "first_step": lead["first_step"],
+            "source": lead["source"],
+            "source_label": lead["source_label"],
+            "also_from": extra,
             "brief": build_agent_brief(
-                action=(s.get("detail") or s.get("title") or "").strip(),
-                first_step=(s.get("first_step") or "").strip(),
-                grounded_in=(analysis.get("grounded_in") or "").strip(),
+                action=lead["detail"] or lead["title"],
+                first_step=lead["first_step"],
+                grounded_in=lead["grounded_in"],
                 profile=profile,
-                source_title=label,
-                source_url=row["source"],
+                source_title=lead["source_label"],
+                source_url=lead["source"],
+                extra_sources=extra,
                 variant="link",
             ),
         })
@@ -205,6 +227,8 @@ def render_digest_text(d: dict) -> str:
             if a["first_step"]:
                 out.append(f"   First move: {a['first_step']}")
             out.append(f"   From: {a['source_label']} — {a['source']}")
+            for extra in a.get("also_from") or []:
+                out.append(f"   Also recommended by: {extra['title']} — {extra['url']}")
             if a["brief"]:
                 out += ["", "   Hand this to your AI (ChatGPT, Claude, Cursor …):", ""]
                 out += ["   | " + line for line in a["brief"].splitlines()]
@@ -247,6 +271,11 @@ def render_digest_html(d: dict) -> str:
                 + (f"<p style=\"margin:0 0 6px;\">First move: {esc(a['first_step'])}</p>" if a["first_step"] else "")
                 + f"<p style=\"margin:0 0 6px;font-size:12px;color:#5e5e58;\">From: "
                   f"<a href=\"{esc(a['source'], quote=True)}\">{esc(a['source_label'])}</a></p>"
+                + "".join(
+                    f"<p style=\"margin:0 0 6px;font-size:12px;color:#5e5e58;\">Also recommended by: "
+                    f"<a href=\"{esc(x['url'], quote=True)}\">{esc(x['title'])}</a></p>"
+                    for x in (a.get("also_from") or [])
+                )
                 + (
                     "<p style=\"margin:8px 0 4px;font-size:12px;color:#5e5e58;\">"
                     "Hand this to your AI (ChatGPT, Claude, Cursor …):</p>"

--- a/tests/test_consolidate.py
+++ b/tests/test_consolidate.py
@@ -1,0 +1,179 @@
+"""Cross-source consolidation (#70): similarity, merge-on-save, multi-source
+briefs, and digest clustering.
+
+The product contract: when several sources converge on the same next step,
+the user sees ONE action backed by all of them — on the Shortlist (merge at
+save time) and in the weekly digest (cluster at assembly time). Similarity is
+deliberately conservative: distinct-but-related suggestions must NOT merge.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+import pytest
+
+NOW = datetime(2026, 6, 12, 6, 0, tzinfo=timezone.utc)
+
+
+class TestSimilarity:
+    def test_rewordings_of_the_same_step_match(self):
+        from bot.consolidate import SIMILARITY_THRESHOLD, similarity
+        a = "Set up an eval harness for your RAG pipeline"
+        b = "Build an eval harness covering the RAG pipeline"
+        assert similarity(a, b) >= SIMILARITY_THRESHOLD
+
+    def test_distinct_steps_do_not_match(self):
+        from bot.consolidate import SIMILARITY_THRESHOLD, similarity
+        a = "Set up an eval harness for your RAG pipeline"
+        b = "Migrate the trading bot to async websockets"
+        assert similarity(a, b) < SIMILARITY_THRESHOLD
+
+    def test_empty_text_never_matches(self):
+        from bot.consolidate import similarity
+        assert similarity("", "anything at all") == 0.0
+
+    def test_find_similar_returns_best_match_or_none(self):
+        from bot.consolidate import find_similar
+        candidates = [
+            {"title": "Migrate to websockets", "detail": "async trading bot rewrite"},
+            {"title": "Eval harness", "detail": "set up an eval harness for the RAG pipeline"},
+        ]
+        hit = find_similar("Build eval harness", "an eval harness for your RAG pipeline", candidates)
+        assert hit is candidates[1]
+        assert find_similar("Write a novel", "fiction in your spare time", candidates) is None
+
+    def test_cluster_groups_convergent_and_preserves_order(self):
+        from bot.consolidate import cluster
+        items = [
+            {"title": "Eval harness", "detail": "set up an eval harness for the RAG pipeline"},
+            {"title": "Websockets", "detail": "migrate the trading bot to async websockets"},
+            {"title": "Build eval harness", "detail": "an eval harness for your RAG pipeline"},
+        ]
+        groups = cluster(items)
+        assert [len(g) for g in groups] == [2, 1]
+        assert groups[0][0]["title"] == "Eval harness"  # first occurrence leads
+
+
+def _save(client, auth_headers, uid, item_id, *, index=0, title, detail):
+    return client.post("/api/saved-suggestions", headers=auth_headers, json={
+        "user_id": uid, "item_id": item_id, "suggestion_index": index,
+        "title": title, "detail": detail, "effort": "", "first_step": "", "grounded_in": "",
+    })
+
+
+class TestMergeOnSave:
+    @pytest.fixture
+    def user_with_items(self, db):
+        uid = db.upsert_user_by_email("u@example.com")
+        a = db.save_item(uid, "article", "https://ex.com/a", "c", json.dumps({"main_idea": "Read A", "verdict": "watch"}))
+        b = db.save_item(uid, "article", "https://ex.com/b", "c", json.dumps({"main_idea": "Read B", "verdict": "watch"}))
+        return uid, a, b
+
+    def test_similar_save_from_another_item_merges(self, client, auth_headers, db, user_with_items):
+        uid, a, b = user_with_items
+        r1 = _save(client, auth_headers, uid, a,
+                   title="Eval harness", detail="set up an eval harness for the RAG pipeline")
+        assert r1.status_code == 201 and "merged" not in r1.json()
+        r2 = _save(client, auth_headers, uid, b,
+                   title="Build eval harness", detail="an eval harness for your RAG pipeline")
+        assert r2.json() == {"id": r1.json()["id"], "status": "saved", "merged": True}
+
+        rows = client.get(f"/api/saved-suggestions?user_id={uid}", headers=auth_headers).json()
+        assert len(rows) == 1
+        assert [s["source"] for s in rows[0]["sources"]] == ["https://ex.com/b"]
+        assert rows[0]["sources"][0]["item_title"] == "Read B"
+
+    def test_dissimilar_save_appends_normally(self, client, auth_headers, db, user_with_items):
+        uid, a, b = user_with_items
+        _save(client, auth_headers, uid, a,
+              title="Eval harness", detail="set up an eval harness for the RAG pipeline")
+        r = _save(client, auth_headers, uid, b,
+                  title="Websockets", detail="migrate the trading bot to async websockets")
+        assert "merged" not in r.json()
+        rows = client.get(f"/api/saved-suggestions?user_id={uid}", headers=auth_headers).json()
+        assert len(rows) == 2
+
+    def test_resave_of_same_suggestion_stays_idempotent_not_merged(self, client, auth_headers, db, user_with_items):
+        uid, a, _ = user_with_items
+        r1 = _save(client, auth_headers, uid, a, title="Eval harness",
+                   detail="set up an eval harness for the RAG pipeline")
+        r2 = _save(client, auth_headers, uid, a, title="Eval harness",
+                   detail="set up an eval harness for the RAG pipeline")
+        assert r2.json()["id"] == r1.json()["id"]
+        assert "merged" not in r2.json()
+
+    def test_merge_is_idempotent_across_repeat_saves(self, client, auth_headers, db, user_with_items):
+        uid, a, b = user_with_items
+        _save(client, auth_headers, uid, a, title="Eval harness",
+              detail="set up an eval harness for the RAG pipeline")
+        for _ in range(2):
+            _save(client, auth_headers, uid, b, title="Build eval harness",
+                  detail="an eval harness for your RAG pipeline")
+        rows = client.get(f"/api/saved-suggestions?user_id={uid}", headers=auth_headers).json()
+        assert len(rows) == 1 and len(rows[0]["sources"]) == 1
+
+    def test_deleting_the_entry_drops_its_sources(self, client, auth_headers, db, user_with_items):
+        uid, a, b = user_with_items
+        r = _save(client, auth_headers, uid, a, title="Eval harness",
+                  detail="set up an eval harness for the RAG pipeline")
+        _save(client, auth_headers, uid, b, title="Build eval harness",
+              detail="an eval harness for your RAG pipeline")
+        client.delete(f"/api/saved-suggestions/{r.json()['id']}?user_id={uid}", headers=auth_headers)
+        with db._get_conn() as conn:
+            assert conn.execute("SELECT COUNT(*) FROM saved_suggestion_sources").fetchone()[0] == 0
+
+    def test_erasure_covers_sources(self, client, auth_headers, db, user_with_items):
+        uid, a, b = user_with_items
+        _save(client, auth_headers, uid, a, title="Eval harness",
+              detail="set up an eval harness for the RAG pipeline")
+        _save(client, auth_headers, uid, b, title="Build eval harness",
+              detail="an eval harness for your RAG pipeline")
+        db.delete_user(uid)
+        with db._get_conn() as conn:
+            assert conn.execute("SELECT COUNT(*) FROM saved_suggestion_sources").fetchone()[0] == 0
+
+
+class TestMultiSourceBrief:
+    def test_extra_sources_land_inside_the_fenced_block(self):
+        from bot.agent_brief import build_agent_brief
+        brief = build_agent_brief(
+            action="Set up an eval harness",
+            source_title="Read A", source_url="https://ex.com/a",
+            extra_sources=[{"title": "Read B", "url": "https://ex.com/b"}],
+        )
+        body = brief.split("--- SOURCE")[1].split("--- END SOURCE")[0]
+        assert "Read A — https://ex.com/a" in body
+        assert "Also recommended by: Read B — https://ex.com/b" in body
+
+
+class TestDigestClustering:
+    @pytest.fixture
+    def digest_env(self, monkeypatch):
+        monkeypatch.setenv("RESEND_API_KEY", "re_test")
+        monkeypatch.setenv("DIGEST_FROM_EMAIL", "digest@filter.fyi")
+        monkeypatch.setenv("DIGEST_UNSUBSCRIBE_SECRET", "s")
+        monkeypatch.setenv("WEBHOOK_URL", "https://backend.test")
+
+    def _item(self, db, uid, *, main_idea, source, title, detail):
+        analysis = {"main_idea": main_idea, "why_it_matters": "", "grounded_in": "g",
+                    "category": "ai", "time_required": "5 min", "verdict": "watch",
+                    "suggestions": [{"title": title, "detail": detail, "effort": "", "first_step": ""}]}
+        db.save_item(uid, "article", source, "c", json.dumps(analysis))
+
+    def test_convergent_week_collapses_to_one_backed_action(self, db, digest_env):
+        from bot.digest import build_digest, render_digest_text
+        uid = db.upsert_user_by_email("u@example.com")
+        self._item(db, uid, main_idea="Read A", source="https://ex.com/a",
+                   title="Eval harness", detail="set up an eval harness for the RAG pipeline")
+        self._item(db, uid, main_idea="Read B", source="https://ex.com/b",
+                   title="Build eval harness", detail="an eval harness for your RAG pipeline")
+        self._item(db, uid, main_idea="Read C", source="https://ex.com/c",
+                   title="Websockets", detail="migrate the trading bot to async websockets")
+        d = build_digest(uid, now=NOW)
+        assert len(d["actions"]) == 2
+        merged = next(a for a in d["actions"] if a["also_from"])
+        assert {x["url"] for x in merged["also_from"]} == {"https://ex.com/a"} or \
+               {x["url"] for x in merged["also_from"]} == {"https://ex.com/b"}
+        assert "Also recommended by:" in merged["brief"]
+        assert "Also recommended by:" in render_digest_text(d)

--- a/tests/test_digest.py
+++ b/tests/test_digest.py
@@ -64,10 +64,20 @@ class TestBuildDigest:
     def test_actions_lead_watch_first_and_cap_at_three(self, db, digest_env):
         from bot.digest import MAX_ACTIONS, build_digest
         uid = db.upsert_user_by_email("u@example.com")
-        _add_item(db, uid, verdict="skim", suggestions=[_suggestion(title="Skim move")],
+        # Distinct details per suggestion — convergent ones would (rightly)
+        # consolidate into a single action since #70.
+        details = [
+            "rewrite the ingestion job in rust",
+            "benchmark quantized models on the laptop",
+            "publish the trading bot postmortem",
+            "interview three users about the digest",
+        ]
+        _add_item(db, uid, verdict="skim",
+                  suggestions=[_suggestion(title="Skim move", detail=details[3])],
                   main_idea="Skim read", source="https://ex.com/skim")
         for i in range(3):
-            _add_item(db, uid, verdict="watch", suggestions=[_suggestion(title=f"Watch move {i}")],
+            _add_item(db, uid, verdict="watch",
+                      suggestions=[_suggestion(title=f"Watch move {i}", detail=details[i])],
                       main_idea=f"Watch read {i}", source=f"https://ex.com/w{i}")
         d = build_digest(uid, now=NOW)
         assert len(d["actions"]) == MAX_ACTIONS


### PR DESCRIPTION
## What

Implements #70 — the literal fulfillment of "curated action, not more reading": when several sources converge on the same next step, the user sees **one** action backed by all of them, instead of a pile of near-duplicates.

**Merge-on-save (Shortlist).** Saving a suggestion that closely matches an existing entry from a *different* item no longer appends — the existing entry gains that item as a source (`saved_suggestion_sources`), and the API returns `{merged: true, id, status}` pointing at the survivor. Exact re-saves of the same (item, index) keep the existing idempotent-refresh behavior. The list endpoint now returns `sources[]` per entry (item_id, URL, title) so the UI can show "backed by N sources".

**Digest clustering.** The week's candidate actions are clustered *before* the top-3 cap, so three reads pushing the same move produce one digest action listing all three sources — in the rendered email and inside the handoff brief's fenced SOURCE block ("Also recommended by: …", via a new `extra_sources` param on `build_agent_brief`).

**Similarity** (`bot/consolidate.py`): Jaccard token overlap over normalized title+detail, conservative threshold (0.5). Deliberately cheap and deterministic — no embeddings, no LLM calls, fully unit-testable. Design bias: a missed merge is a minor annoyance, a wrong merge is confusing, so it only catches obvious convergence.

**Lifecycle:** sources are deleted with their entry, erased with the user; no migration needed (pre-existing entries just have no extra sources).

## Tests

13 new in `tests/test_consolidate.py`: similarity matrix (rewording matches, distinct doesn't, empty never), find/cluster behavior, the full merge-on-save matrix (merge, append, idempotent re-save, repeat-merge idempotency, delete/erasure of sources), multi-source brief fencing, and end-to-end digest clustering. One existing digest test updated to use distinct suggestion details (identical ones now rightly consolidate). **Full suite: 369 passed.**

## Pairing

A small frontend PR follows: "backed by N sources" marker on Shortlist entries + extra sources in the client-built brief. Independent — this PR is fully functional without it (digest + API already consolidated).

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)