### PR TITLE
feat(stats): per-user value stats endpoint (filter.fyi#53)

### DIFF
--- a/bot/api.py
+++ b/bot/api.py
@@ -421,6 +421,18 @@ async def user_get(user_id: int, _: None = Depends(_require_try_secret)):
     }
 
 
+@router.get("/users/{user_id}/stats")
+async def user_stats(user_id: int, _: None = Depends(_require_try_secret)):
+    """Value stats for the /me ROI strip (#53): reads filtered, verdict split,
+    estimated minutes not spent on skips, suggestion outcomes — trailing 30
+    days plus all-time. Pure aggregation, no LLM calls."""
+    from bot.stats import build_user_stats
+
+    if not get_user(user_id):
+        raise HTTPException(status_code=404, detail={"error": "not-found"})
+    return build_user_stats(user_id)
+
+
 @router.get("/users/{user_id}/export")
 async def user_export(user_id: int, _: None = Depends(_require_try_secret)):
     """Full data export for a user (GDPR portability). Worker-gated.

--- a/bot/stats.py
+++ b/bot/stats.py
@@ -1,0 +1,89 @@
+"""Per-user value stats (#53): what filter.fyi actually did for this person.
+
+Powers the ROI strip on /me ("June: 14 reads filtered · 6 skips (~3.5 hrs not
+read) · 3 actions done") and the digest header. Pure aggregation over stored
+analyses and the Shortlist — no LLM calls.
+
+The "time you didn't spend" figure is an estimate by construction: it sums
+the analyzer's own `time_required` strings ("12 min read", "~1 hr") over
+skip-verdict items at full value and skim-verdict items at half (a skim still
+costs *some* time). The UI labels it as an estimate.
+"""
+from __future__ import annotations
+
+import re
+from datetime import datetime, timedelta, timezone
+
+from bot.analyzer import parse_stored
+
+# A skim isn't a full read avoided — count half.
+SKIM_FACTOR = 0.5
+MONTH_DAYS = 30
+
+_HOURS_RE = re.compile(r"(\d+(?:\.\d+)?)\s*(?:h\b|hrs?\b|hours?\b)", re.IGNORECASE)
+_MINUTES_RE = re.compile(r"(\d+)\s*(?:m\b|mins?\b|minutes?\b)", re.IGNORECASE)
+
+
+def parse_minutes(time_required: str) -> int:
+    """Best-effort minutes from an analyzer time_required string.
+
+    Handles "12 min read", "8 min watch", "~1 hr", "2 hrs", "1 h 30 min".
+    Unparseable strings count as 0 — the estimate stays honest by
+    under-counting, never inventing.
+    """
+    text = time_required or ""
+    minutes = 0.0
+    h = _HOURS_RE.search(text)
+    if h:
+        minutes += float(h.group(1)) * 60
+    m = _MINUTES_RE.search(text)
+    if m:
+        minutes += int(m.group(1))
+    return int(minutes)
+
+
+def _window_stats(items, suggestions, since_iso: str | None) -> dict:
+    out = {
+        "items": 0, "watch": 0, "skim": 0, "skip": 0,
+        "minutes_saved": 0,
+        "suggestions_saved": 0, "suggestions_tried": 0, "suggestions_done": 0,
+    }
+    saved_minutes = 0.0
+    for row in items:
+        if since_iso and row["created_at"] < since_iso:
+            continue
+        out["items"] += 1
+        analysis = parse_stored(row["analysis"]) or {}
+        verdict = (analysis.get("verdict") or "").lower()
+        if verdict in ("watch", "skim", "skip"):
+            out[verdict] += 1
+        minutes = parse_minutes(analysis.get("time_required") or "")
+        if verdict == "skip":
+            saved_minutes += minutes
+        elif verdict == "skim":
+            saved_minutes += minutes * SKIM_FACTOR
+    out["minutes_saved"] = int(saved_minutes)
+
+    for s in suggestions:
+        # Saves are dated by creation; outcomes by their last status change.
+        if s["status"] == "saved":
+            if not since_iso or s["created_at"] >= since_iso:
+                out["suggestions_saved"] += 1
+        elif s["status"] in ("tried", "done"):
+            if not since_iso or s["updated_at"] >= since_iso:
+                out[f"suggestions_{s['status']}"] += 1
+    return out
+
+
+def build_user_stats(user_id: int, *, now: datetime | None = None) -> dict:
+    """{"month": …, "all_time": …} for one user. Month = trailing 30 days."""
+    from bot.db import get_all_items, get_saved_suggestions
+
+    now = now or datetime.now(timezone.utc)
+    since_iso = (now - timedelta(days=MONTH_DAYS)).strftime("%Y-%m-%dT%H:%M:%S")
+    items = get_all_items(user_id)
+    suggestions = get_saved_suggestions(user_id)
+    return {
+        "month": _window_stats(items, suggestions, since_iso),
+        "all_time": _window_stats(items, suggestions, None),
+    }

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,0 +1,99 @@
+"""Per-user value stats (#53): time parsing, window math, and the endpoint.
+
+The honesty contract: minutes_saved only counts what the analyzer actually
+estimated (unparseable strings count 0), skips at full value, skims at half.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+NOW = datetime(2026, 6, 12, 12, 0, tzinfo=timezone.utc)
+
+
+class TestParseMinutes:
+    @pytest.mark.parametrize("text,minutes", [
+        ("12 min read", 12),
+        ("8 min watch", 8),
+        ("~1 hr", 60),
+        ("2 hrs", 120),
+        ("1 h 30 min", 90),
+        ("1.5 hours", 90),
+        ("a quick look", 0),
+        ("", 0),
+    ])
+    def test_variants(self, text, minutes):
+        from bot.stats import parse_minutes
+        assert parse_minutes(text) == minutes
+
+
+def _add(db, uid, *, verdict, time_required="10 min read", days_ago=0):
+    analysis = {"main_idea": "x", "why_it_matters": "", "grounded_in": "",
+                "category": "ai", "time_required": time_required,
+                "verdict": verdict, "suggestions": []}
+    item_id = db.save_item(uid, "article", "https://ex.com/a", "c", json.dumps(analysis))
+    if days_ago:
+        ts = (NOW - timedelta(days=days_ago)).strftime("%Y-%m-%dT%H:%M:%S")
+        with db._get_conn() as conn:
+            conn.execute("UPDATE items SET created_at = ? WHERE id = ?", (ts, item_id))
+    return item_id
+
+
+class TestBuildUserStats:
+    def test_verdict_split_and_minutes_saved(self, db):
+        from bot.stats import build_user_stats
+        uid = db.upsert_user_by_email("u@example.com")
+        _add(db, uid, verdict="watch", time_required="30 min watch")
+        _add(db, uid, verdict="skip", time_required="20 min read")   # +20
+        _add(db, uid, verdict="skim", time_required="10 min read")   # +5 (half)
+        s = build_user_stats(uid, now=NOW)["month"]
+        assert (s["items"], s["watch"], s["skim"], s["skip"]) == (3, 1, 1, 1)
+        assert s["minutes_saved"] == 25  # watch items never count
+
+    def test_month_window_vs_all_time(self, db):
+        from bot.stats import build_user_stats
+        uid = db.upsert_user_by_email("u@example.com")
+        _add(db, uid, verdict="skip", time_required="60 min read", days_ago=40)
+        _add(db, uid, verdict="skip", time_required="20 min read", days_ago=1)
+        s = build_user_stats(uid, now=NOW)
+        assert s["month"]["items"] == 1 and s["month"]["minutes_saved"] == 20
+        assert s["all_time"]["items"] == 2 and s["all_time"]["minutes_saved"] == 80
+
+    def test_suggestion_outcomes_counted_by_status(self, db):
+        from bot.stats import build_user_stats
+        uid = db.upsert_user_by_email("u@example.com")
+        item = _add(db, uid, verdict="watch")
+        for i, status in enumerate(["saved", "tried", "done"]):
+            sid = db.save_suggestion(user_id=uid, item_id=item, suggestion_index=i,
+                                     title=f"s{i}", detail="d", effort="",
+                                     first_step="", grounded_in="")
+            if status != "saved":
+                db.update_saved_suggestion_status(sid, uid, status)
+        s = build_user_stats(uid, now=NOW)["month"]
+        assert (s["suggestions_saved"], s["suggestions_tried"], s["suggestions_done"]) == (1, 1, 1)
+
+    def test_empty_user_is_all_zeroes(self, db):
+        from bot.stats import build_user_stats
+        uid = db.upsert_user_by_email("u@example.com")
+        s = build_user_stats(uid, now=NOW)
+        assert s["month"]["items"] == 0 and s["all_time"]["minutes_saved"] == 0
+
+
+class TestStatsEndpoint:
+    def test_returns_both_windows(self, client, auth_headers, db):
+        uid = db.upsert_user_by_email("u@example.com")
+        _add(db, uid, verdict="skip", time_required="15 min read")
+        r = client.get(f"/api/users/{uid}/stats", headers=auth_headers)
+        assert r.status_code == 200
+        body = r.json()
+        assert body["month"]["minutes_saved"] == 15
+        assert set(body) == {"month", "all_time"}
+
+    def test_unknown_user_404(self, client, auth_headers):
+        assert client.get("/api/users/99999/stats", headers=auth_headers).status_code == 404
+
+    def test_requires_secret(self, client, db):
+        uid = db.upsert_user_by_email("u@example.com")
+        assert client.get(f"/api/users/{uid}/stats").status_code == 401


### PR DESCRIPTION
## What

Backend half of filter.fyi#53 (the /me ROI strip — "June: 14 reads filtered · 6 skips (~3.5 hrs not read) · 3 actions done").

`GET /api/users/{user_id}/stats` (try-secret gated, 404 on unknown user) returns `{month, all_time}`, each with: items analyzed, watch/skim/skip split, `minutes_saved`, and suggestions saved/tried/done.

**The honesty rules** (`bot/stats.py`):
- `minutes_saved` sums the analyzer's own `time_required` estimates — skip-verdict items at full value, skim at half (a skim still costs some time), watch never counts.
- Unparseable time strings count **0**: the estimate under-counts rather than inventing. Parser handles "12 min read", "~1 hr", "2 hrs", "1 h 30 min", "1.5 hours".
- Saves are windowed by `created_at`; tried/done outcomes by `updated_at` (when the status actually changed).

Pure aggregation over existing tables — no LLM calls, no schema changes.

## Tests

15 new in `tests/test_stats.py`: the time-parser matrix, verdict/minutes math, month-vs-all-time windowing, outcome counting, empty user, and the endpoint (200 shape / 404 / 401). **Full suite: 371 passed.**

Frontend PR (worker proxy + the strip on /me) follows separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)