### PR TITLE
feat(memory): memory-infused handoff briefs (#71)

### DIFF
--- a/bot/agent_brief.py
+++ b/bot/agent_brief.py
@@ -53,11 +53,17 @@ def build_agent_brief(
     source_url: str = "",
     summary_excerpt: str = "",
     extra_sources: list[dict] | None = None,
+    history: str = "",
     variant: str = "full",
 ) -> str:
     """Render one handoff brief as a clean prompt. ``variant`` is "full" or "link".
 
     Empty ``action`` yields an empty string (nothing to hand off).
+
+    ``history`` is a pre-rendered, user-voice block of the reader's own library
+    history relevant to this action (bot/memory.py, #71). It sits in the
+    instruction region — it's the user speaking about their own past, NOT
+    untrusted source material, so it stays outside the fenced SOURCE block.
     """
     action = (action or "").strip()
     if not action:
@@ -74,6 +80,8 @@ def build_agent_brief(
         out += ["", f"A concrete first move: {first_step.strip()}"]
     if profile and profile.strip():
         out += ["", "About me — tailor everything to this:", _clip_sentence(profile, PROFILE_CHARS)]
+    if history and history.strip():
+        out += ["", history.strip()]
 
     # Source block — fenced + flagged as reference (prompt-injection guard).
     src: list[str] = []
@@ -128,6 +136,7 @@ def build_actions(
     source_title: str = "",
     source_url: str = "",
     summary_excerpt: str = "",
+    history_for=None,
 ) -> list[dict]:
     """Build the `actions` list — one entry per suggestion (0–5).
 
@@ -135,6 +144,11 @@ def build_actions(
     full copy-paste version; `brief_link` is the concise version for "open in …"
     deep links. Pure templating — no extra LLM calls. Returns [] when the
     analysis has no suggestions (content with no follow-up worth the time).
+
+    ``history_for`` is an optional ``(title, detail) -> str`` callable supplying
+    a per-suggestion library-history block (#71). Kept as a callback so this
+    function stays DB-free and testable; the caller (bot.api._actions_for)
+    wires it to bot.memory for signed-in users only.
     """
     grounded_in = (analysis.get("grounded_in") or "").strip()
     actions: list[dict] = []
@@ -153,6 +167,7 @@ def build_actions(
             source_title=source_title,
             source_url=source_url,
             summary_excerpt=summary_excerpt,
+            history=history_for(title, detail) if history_for else "",
         )
         actions.append({
             "index": i,

--- a/bot/api.py
+++ b/bot/api.py
@@ -122,16 +122,32 @@ def _actions_for(
     """Build the agent-handoff `actions` list for a response.
 
     Personalizes the brief with the signed-in user's profile (anon gets none),
-    and grounds it in a bounded excerpt of the content. Pure templating — no
-    extra LLM calls.
+    grounds it in a bounded excerpt of the content, and — for signed-in users —
+    folds in each suggestion's relevant library history (#71). Pure templating,
+    no extra LLM calls.
     """
     profile = get_user_profile(user_id) if user_id is not None else ""
+
+    history_for = None
+    if user_id is not None:
+        from bot.memory import build_history_block
+
+        def history_for(title: str, detail: str) -> str:
+            # Best-effort: memory is an enhancement, never a hard dependency of
+            # the handoff. A DB hiccup yields a brief without history.
+            try:
+                return build_history_block(user_id, title=title, detail=detail)
+            except Exception:
+                logger.exception("history block failed; brief without memory")
+                return ""
+
     return build_actions(
         analysis,
         profile=profile or "",
         source_title=source_title,
         source_url=source_url,
         summary_excerpt=source_text or "",
+        history_for=history_for,
     )
 
 

--- a/bot/memory.py
+++ b/bot/memory.py
@@ -1,0 +1,109 @@
+"""Memory-infused handoff briefs (#71): give the user's assistant the library
+history it can't know.
+
+A handoff brief on its own (bot/agent_brief.py) is recreatable with a single
+custom instruction. What makes it irreplaceable is the user's own accumulated
+context — what they've already completed, tried, or explicitly decided against
+on *related* topics. That lives in their filter.fyi library and nowhere their
+assistant can reach. Folding it into the brief means the user can't reproduce
+the same prompt elsewhere without re-typing their history.
+
+Relatedness is scoped per-suggestion (a databases brief shouldn't drag in
+trading-bot history) using the cheap deterministic token overlap from
+bot.consolidate — no embeddings, no LLM calls.
+
+Signed-in only: anon users have no history and their briefs are byte-identical
+to before. Distinct consumer from bot.signals — that digest feeds the
+*analyzer* to shape which suggestions get generated (global, day-coarsened for
+cache stability); this feeds the *brief* to inform the user's own agent
+(per-suggestion, real-time). They draw on the same tables for different ends.
+"""
+from __future__ import annotations
+
+from bot.consolidate import similarity, suggestion_text
+
+# Looser than consolidation's merge threshold — we want "same topic area", not
+# "the same step", so cross-references surface ("you're working on the RAG
+# pipeline; here's what you've already done on it").
+RELATED_THRESHOLD = 0.18
+HISTORY_CHARS = 600
+# Per-category caps so one long history doesn't swamp the brief.
+MAX_PER_CATEGORY = 4
+_DISMISS_LOOKBACK = 40
+
+
+def _quote(text: str, limit: int = 80) -> str:
+    text = " ".join((text or "").split())
+    return text[:limit] + ("…" if len(text) > limit else "")
+
+
+def _dedup(items: list[str]) -> list[str]:
+    seen, out = set(), []
+    for it in items:
+        key = it.lower()
+        if key not in seen:
+            seen.add(key)
+            out.append(it)
+    return out
+
+
+def build_history_block(user_id: int | None, *, title: str, detail: str) -> str:
+    """Render the user's library history relevant to one suggestion as a
+    compact, user-voice block. Returns "" for anon users or when nothing
+    related is found — callers drop the block and the brief is unchanged."""
+    if user_id is None:
+        return ""
+    from bot.db import get_saved_suggestions, get_suggestion_signals
+
+    target = suggestion_text(title, detail)
+    if not target:
+        return ""
+
+    done: list[str] = []
+    tried: list[str] = []
+    against: list[str] = []
+
+    for s in get_saved_suggestions(user_id):
+        cand = suggestion_text(s["title"], s["detail"])
+        # Skip the suggestion being handed off itself (near-identical), so we
+        # don't tell the agent "you already did this" about this very action.
+        sim = similarity(target, cand)
+        if sim < RELATED_THRESHOLD or sim >= 0.95:
+            continue
+        if s["status"] == "done" and len(done) < MAX_PER_CATEGORY:
+            done.append(_quote(s["title"] or s["detail"]))
+        elif s["status"] == "tried" and len(tried) < MAX_PER_CATEGORY:
+            tried.append(_quote(s["title"] or s["detail"]))
+
+    for d in get_suggestion_signals(user_id, events=("dismiss",), limit=_DISMISS_LOOKBACK):
+        cand = d["suggestion_text"] or ""
+        if similarity(target, cand) < RELATED_THRESHOLD:
+            continue
+        if len(against) >= MAX_PER_CATEGORY:
+            break
+        reason = (d["reason"] or "").strip()
+        label = _quote(cand)
+        against.append(label + (f" — {_quote(reason, 60)}" if reason else ""))
+
+    done, tried, against = _dedup(done), _dedup(tried), _dedup(against)
+    if not (done or tried or against):
+        return ""
+
+    lines = [
+        "From my own library — relevant things I've already acted on (factor "
+        "this in: don't repeat what I've finished or re-pitch what I dropped):"
+    ]
+    if done:
+        lines.append("- Already done: " + ", ".join(f'"{x}"' for x in done))
+    if tried:
+        lines.append("- Tried: " + ", ".join(f'"{x}"' for x in tried))
+    if against:
+        lines.append("- Decided against: " + "; ".join(f'"{x}"' for x in against))
+
+    block = "\n".join(lines)
+    if len(block) <= HISTORY_CHARS:
+        return block
+    # Trim from the end on a line boundary so we never cut mid-item.
+    while len(block) > HISTORY_CHARS and "\n" in block:
+        block = block.rsplit("\n", 1)[0]
+    return block

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,0 +1,158 @@
+"""Memory-infused handoff briefs (#71): the per-suggestion library-history
+block and its wiring into build_actions / the handoff brief.
+
+Contracts:
+  1. Anon users (user_id=None) get an empty block — briefs unchanged.
+  2. History is scoped to *related* suggestions only (topic overlap), so
+     unrelated library items never leak into a brief.
+  3. The block sits in the instruction region, NOT inside the fenced SOURCE
+     block (it's the user's own memory, not untrusted source material).
+  4. A history-lookup failure degrades to no-history, never breaks the brief.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+def _save(db, uid, item_id, *, index, title, detail, status="saved"):
+    sid = db.save_suggestion(user_id=uid, item_id=item_id, suggestion_index=index,
+                             title=title, detail=detail, effort="", first_step="",
+                             grounded_in="")
+    if status != "saved":
+        db.update_saved_suggestion_status(sid, uid, status)
+    return sid
+
+
+class TestBuildHistoryBlock:
+    def test_anon_gets_nothing(self, db):
+        from bot.memory import build_history_block
+        assert build_history_block(None, title="Add a reranker", detail="to the RAG pipeline") == ""
+
+    def test_empty_library_gets_nothing(self, db):
+        from bot.memory import build_history_block
+        uid = db.upsert_user_by_email("u@example.com")
+        assert build_history_block(uid, title="Add a reranker", detail="to the RAG pipeline") == ""
+
+    def test_related_outcomes_and_dismissals_appear(self, db):
+        from bot.memory import build_history_block
+        uid = db.upsert_user_by_email("u@example.com")
+        item = db.save_item(uid, "article", "https://ex.com/a", "c", "{}")
+        _save(db, uid, item, index=0, title="Set up an eval harness",
+              detail="eval harness for the RAG pipeline", status="done")
+        _save(db, uid, item, index=1, title="Add a reranker",
+              detail="reranker on the RAG pipeline retrieval", status="tried")
+        db.record_suggestion_signal(uid, "dismiss",
+                                    suggestion_text="Build a RAG pipeline demo app",
+                                    reason="too generic")
+        block = build_history_block(uid, title="Improve RAG pipeline",
+                                    detail="make the RAG pipeline retrieval better")
+        assert "Already done:" in block and "eval harness" in block.lower()
+        assert "Tried:" in block and "reranker" in block.lower()
+        assert "Decided against:" in block and "too generic" in block
+
+    def test_unrelated_history_is_excluded(self, db):
+        from bot.memory import build_history_block
+        uid = db.upsert_user_by_email("u@example.com")
+        item = db.save_item(uid, "article", "https://ex.com/a", "c", "{}")
+        _save(db, uid, item, index=0, title="Migrate trading bot",
+              detail="move the trading bot to async websockets", status="done")
+        assert build_history_block(uid, title="Add a reranker",
+                                   detail="reranker for the RAG pipeline") == ""
+
+    def test_the_action_itself_is_not_echoed_as_history(self, db):
+        from bot.memory import build_history_block
+        uid = db.upsert_user_by_email("u@example.com")
+        item = db.save_item(uid, "article", "https://ex.com/a", "c", "{}")
+        # An identical prior save shouldn't be reported back as "already done".
+        _save(db, uid, item, index=0, title="Add a reranker",
+              detail="add a reranker to the RAG pipeline", status="done")
+        block = build_history_block(uid, title="Add a reranker",
+                                    detail="add a reranker to the RAG pipeline")
+        assert block == ""
+
+    def test_block_is_bounded(self, db):
+        from bot.memory import HISTORY_CHARS, build_history_block
+        uid = db.upsert_user_by_email("u@example.com")
+        item = db.save_item(uid, "article", "https://ex.com/a", "c", "{}")
+        for i in range(20):
+            _save(db, uid, item, index=i,
+                  title=f"RAG pipeline improvement {i} " + "x" * 80,
+                  detail="work on the RAG pipeline retrieval " + "y" * 80, status="done")
+        assert len(build_history_block(uid, title="RAG pipeline",
+                                       detail="improve the RAG pipeline retrieval")) <= HISTORY_CHARS
+
+
+class TestBriefIntegration:
+    def test_history_is_outside_the_source_fence(self, db):
+        from bot.agent_brief import build_agent_brief
+        brief = build_agent_brief(
+            action="Improve the RAG pipeline",
+            source_title="A", source_url="https://ex.com/a",
+            history='From my own library — relevant things I\'ve already acted on:\n- Already done: "Eval harness"',
+        )
+        before_fence = brief.split("--- SOURCE")[0]
+        assert "Already done" in before_fence  # in the instruction region
+        fenced = brief.split("--- SOURCE")[1].split("--- END SOURCE")[0]
+        assert "Already done" not in fenced
+
+    def test_build_actions_threads_history_per_suggestion(self, db):
+        from bot.agent_brief import build_actions
+        analysis = {"grounded_in": "g", "suggestions": [
+            {"title": "Add a reranker", "detail": "to the pipeline", "effort": "", "first_step": ""},
+            {"title": "Write a blog post", "detail": "about it", "effort": "", "first_step": ""},
+        ]}
+        seen = []
+
+        def history_for(title, detail):
+            seen.append(title)
+            return "HIST::" + title if title == "Add a reranker" else ""
+
+        actions = build_actions(analysis, history_for=history_for)
+        assert seen == ["Add a reranker", "Write a blog post"]
+        assert "HIST::Add a reranker" in actions[0]["brief"]
+        assert "HIST::" not in actions[1]["brief"]
+
+    def test_no_history_callable_leaves_brief_unchanged(self, db):
+        from bot.agent_brief import build_actions
+        analysis = {"grounded_in": "", "suggestions": [
+            {"title": "Do X", "detail": "detail", "effort": "", "first_step": ""}]}
+        actions = build_actions(analysis)
+        assert "From my own library" not in actions[0]["brief"]
+
+
+class TestActionsForWiring:
+    def test_signed_in_brief_carries_history(self, db, monkeypatch):
+        from bot import api
+        uid = db.upsert_user_by_email("u@example.com")
+        item = db.save_item(uid, "article", "https://ex.com/a", "c", "{}")
+        db.save_suggestion(user_id=uid, item_id=item, suggestion_index=0,
+                           title="Set up an eval harness",
+                           detail="eval harness for the RAG pipeline",
+                           effort="", first_step="", grounded_in="")
+        db.update_saved_suggestion_status(
+            db.get_saved_suggestions(uid)[0]["id"], uid, "done")
+        analysis = {"grounded_in": "g", "suggestions": [
+            {"title": "Improve RAG retrieval", "detail": "tune the RAG pipeline retrieval",
+             "effort": "", "first_step": ""}]}
+        actions = api._actions_for(analysis, user_id=uid, source_text="x",
+                                   source_title="T", source_url="https://ex.com/b")
+        assert "From my own library" in actions[0]["brief"]
+
+    def test_anon_brief_has_no_history(self, db):
+        from bot import api
+        analysis = {"grounded_in": "g", "suggestions": [
+            {"title": "Improve RAG retrieval", "detail": "tune retrieval",
+             "effort": "", "first_step": ""}]}
+        actions = api._actions_for(analysis, user_id=None, source_text="x")
+        assert "From my own library" not in actions[0]["brief"]
+
+    def test_history_failure_does_not_break_actions(self, db, monkeypatch):
+        from bot import api
+        import bot.memory
+        uid = db.upsert_user_by_email("u@example.com")
+        monkeypatch.setattr(bot.memory, "build_history_block",
+                            lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom")))
+        analysis = {"grounded_in": "g", "suggestions": [
+            {"title": "Do X", "detail": "d", "effort": "", "first_step": ""}]}
+        actions = api._actions_for(analysis, user_id=uid, source_text="x")
+        assert actions and "From my own library" not in actions[0]["brief"]


### PR DESCRIPTION
## What

Closes #71 — the last audit item. Turns the handoff brief from "recreatable with one custom instruction" into something the user can't reproduce elsewhere without re-typing their own history.

For signed-in users, each suggestion's brief now folds in the relevant slice of their library — what they've **completed**, **tried**, or explicitly **decided against** on related topics:

```
From my own library — relevant things I've already acted on (factor this in:
don't repeat what I've finished or re-pitch what I dropped):
- Already done: "Set up an eval harness"
- Tried: "Add a reranker"
- Decided against: "Build a RAG demo app" — too generic
```

## How

- **`bot/memory.py`** — `build_history_block(user_id, title, detail)` renders the block, scoped to suggestions *related* to the one being handed off via the cheap deterministic token-overlap similarity from `bot.consolidate` (looser threshold than the merge one — "same topic area", not "same step", so a databases brief never drags in trading-bot history). Bounded at 600 chars; the action being handed off is excluded from its own history.
- **Placement matters:** the block goes in the instruction region of the brief, **not** inside the fenced SOURCE block — it's the user speaking about their own past, not untrusted source material, so the prompt-injection guard is unaffected.
- **`build_actions`** gains an optional `history_for(title, detail)` callback, so it stays DB-free and unit-testable; `api._actions_for` wires it to `bot.memory` for **signed-in users only** and best-effort (a lookup failure degrades to a no-history brief, never breaks the handoff).
- **No extra LLM calls.** Anon briefs are byte-identical to before.

## Frontend: nothing needed

The landing page (signed-in job path), `/submit/*`, and Telegram all build briefs through `_actions_for`, and the frontend already prefers the server-built `action.brief` / `action.brief_link` over its client-side fallback composer. So history flows through with no UI change.

Relationship to #69: `bot.signals` feeds the **analyzer** to shape *which* suggestions are generated (global, day-coarsened for cache stability); this feeds the **brief** to inform the user's own agent (per-suggestion, real-time). Same tables, different ends.

## Tests

12 new in `tests/test_memory.py`: anon/empty → nothing, related outcomes + dismissals surface, unrelated history excluded, the action isn't echoed as its own history, char-bound, fence placement, the `history_for` threading through `build_actions`, the signed-in/anon `_actions_for` split, and failure isolation. **Full suite: 396 passed.**

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)