### PR TITLE
fix(monitor): bypass YouTube consent wall so channel subs resolve (#65)

### DIFF
--- a/bot/monitor.py
+++ b/bot/monitor.py
@@ -47,7 +47,20 @@ _UA = "filter.fyi feed monitor (+https://filter.fyi)"
 
 _YT_HOSTS = {"youtube.com", "www.youtube.com", "m.youtube.com"}
 _YT_FEED = "https://www.youtube.com/feeds/videos.xml?channel_id={cid}"
-_YT_CHANNEL_ID_RE = re.compile(r'"channelId"\s*:\s*"(UC[0-9A-Za-z_-]{22})"')
+# A YouTube channel page exposes its UC… id in several spots. We try the most
+# stable ones (canonical link / og:url always point at the /channel/UC… form
+# even from a handle page), so a markup tweak to any single field can't break
+# resolution.
+_YT_CHANNEL_ID_RES = [
+    re.compile(r'"channelId"\s*:\s*"(UC[0-9A-Za-z_-]{22})"'),
+    re.compile(r'"externalId"\s*:\s*"(UC[0-9A-Za-z_-]{22})"'),
+    re.compile(r'<link[^>]+rel="canonical"[^>]+href="https://www\.youtube\.com/channel/(UC[0-9A-Za-z_-]{22})"'),
+    re.compile(r'<meta[^>]+property="og:url"[^>]+content="https://www\.youtube\.com/channel/(UC[0-9A-Za-z_-]{22})"'),
+]
+# YouTube serves an EU "consent" interstitial to datacenter IPs (e.g. Fly),
+# which carries none of the channel markup. This cookie records the consent
+# and is what every YouTube-feed tool sends to get the real page.
+_YT_CONSENT_COOKIE = "SOCS=CAI"
 _FEED_LINK_RE = re.compile(
     r'<link[^>]+rel=["\']alternate["\'][^>]*>', re.IGNORECASE
 )
@@ -59,13 +72,24 @@ class FeedError(Exception):
     """A user-facing problem with a feed URL (unreachable, no feed found…)."""
 
 
+def _is_youtube(url: str) -> bool:
+    try:
+        return urlparse(url).hostname in _YT_HOSTS
+    except ValueError:
+        return False
+
+
 def _get(url: str) -> httpx.Response:
     """SSRF-guarded GET with a size cap. Re-checks the final URL after
-    redirects (per bot/ssrf.py's documented limitation)."""
+    redirects (per bot/ssrf.py's documented limitation). Sends the YouTube
+    consent cookie so datacenter IPs get the real channel page, not the EU
+    consent wall."""
     assert_public_url(url)
+    headers = {"User-Agent": _UA}
+    if _is_youtube(url):
+        headers["Cookie"] = _YT_CONSENT_COOKIE
     resp = httpx.get(
-        url, timeout=_FETCH_TIMEOUT_S, follow_redirects=True,
-        headers={"User-Agent": _UA},
+        url, timeout=_FETCH_TIMEOUT_S, follow_redirects=True, headers=headers,
     )
     assert_public_url(str(resp.url))
     resp.raise_for_status()
@@ -101,9 +125,10 @@ def _youtube_feed_url(url: str, body: str | None) -> str | None:
     # Handle/legacy forms (/@name, /c/name, /user/name) carry the channelId
     # only inside the page markup.
     if body:
-        m = _YT_CHANNEL_ID_RE.search(body)
-        if m:
-            return _YT_FEED.format(cid=m.group(1))
+        for pat in _YT_CHANNEL_ID_RES:
+            m = pat.search(body)
+            if m:
+                return _YT_FEED.format(cid=m.group(1))
     return None
 
 

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -87,11 +87,51 @@ class TestResolveFeed:
         assert r["feed_url"] == feed
         assert r["source_kind"] == "youtube"
 
+    def test_youtube_channel_id_via_canonical_link_fallback(self, fake_get):
+        # Markup without "channelId" but with the canonical /channel/ link —
+        # the resolver must still find the id (#65 robustness).
+        from bot.monitor import resolve_feed
+        feed = "https://www.youtube.com/feeds/videos.xml?channel_id=UCabcdefghijklmnopqrstuv"
+        page = ('<html><head><link rel="canonical" '
+                'href="https://www.youtube.com/channel/UCabcdefghijklmnopqrstuv">'
+                '</head></html>')
+        fake_get["https://www.youtube.com/@handleonly"] = page
+        fake_get[feed] = FEED_XML
+        assert resolve_feed("https://www.youtube.com/@handleonly")["feed_url"] == feed
+
     def test_page_without_feed_raises_user_facing_error(self, fake_get):
         from bot.monitor import FeedError, resolve_feed
         fake_get["https://ex.com/nothing"] = HTML_NO_FEED
         with pytest.raises(FeedError, match="No feed found"):
             resolve_feed("https://ex.com/nothing")
+
+
+class TestYouTubeConsentCookie:
+    def test_get_sends_consent_cookie_to_youtube_only(self, monkeypatch):
+        # #65: datacenter IPs hit YouTube's EU consent wall without this cookie,
+        # so the channel page (and its channelId) never loads.
+        from bot import monitor
+        seen = {}
+
+        class _Resp:
+            def __init__(self, url):
+                self.url = url
+                self.content = b"<rss></rss>"
+                self.text = "<rss></rss>"
+            def raise_for_status(self):
+                pass
+
+        def fake_httpx_get(url, **kw):
+            seen[url] = kw.get("headers", {})
+            return _Resp(url)
+
+        monkeypatch.setattr(monitor.httpx, "get", fake_httpx_get)
+        monkeypatch.setattr(monitor, "assert_public_url", lambda u: None)
+
+        monitor._get("https://www.youtube.com/@x")
+        monitor._get("https://blog.example/feed.xml")
+        assert "SOCS" in seen["https://www.youtube.com/@x"].get("Cookie", "")
+        assert "Cookie" not in seen["https://blog.example/feed.xml"]
 
     def test_non_public_target_is_blocked(self):
         # Real SSRF guard, no stub: localhost is rejected before any DNS.


### PR DESCRIPTION
## The bug

Subscribing to a YouTube channel failed with "No feed found at that URL". Root cause: YouTube serves datacenter IPs (Fly) the EU **consent interstitial** at `consent.youtube.com` instead of the channel page, and that page carries none of the channel markup — so `_youtube_feed_url` never found the `channelId`.

Reproduced live from this environment: `GET https://www.youtube.com/@mkbhd` → 200 but final URL `https://consent.youtube.com/ml?...`, no `channelId` anywhere.

## The fix (`bot/monitor.py`)

1. **Send the `SOCS=CAI` consent cookie** on `youtube.com` requests (only) — the same cookie every YouTube-feed tool uses to get the real page. With it, the channel page loads normally.
2. **Broaden channelId extraction** from just `"channelId"` to also `"externalId"`, the canonical `<link rel="canonical">`, and `og:url` — all of which point at the `/channel/UC…` form even on a handle page. So a tweak to any single field can't break resolution.

Verified live after the fix: `@mkbhd`, `@veritasium`, and `/c/3blue1brown` all resolve to their `UC…` id (all four patterns match), and the resulting `feeds/videos.xml` parses with entries.

## Tests

2 new in `tests/test_monitor.py`: channelId via the canonical-link fallback, and that `_get` sends the consent cookie to YouTube **only** (not other feeds). 23/23 pass.

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)