### PR TITLE
fix(fetch): route Reddit to old.reddit; never verdict a blocked page (#67)

### DIFF
--- a/bot/fetch_errors.py
+++ b/bot/fetch_errors.py
@@ -87,8 +87,20 @@ _USER_MESSAGES: dict[str, str] = {
 }
 
 
+# Reddit Cloudflare-gates datacenter fetches and serves a JS-only shell on www,
+# so a generic "couldn't extract" message is misleading (#67). When the failure
+# is on a Reddit URL, say what's actually going on.
+_REDDIT_CONTENT_REASONS = frozenset({NO_TEXT_EXTRACTED, JS_REQUIRED, FETCH_FAILED, RATE_LIMITED})
+_REDDIT_MESSAGE = (
+    "Reddit blocks automated fetches from servers, so we often can't read a "
+    "post's content. Paste the post text directly and I'll analyse it."
+)
+
+
 def user_message(reason: str | None, url: str = "") -> str:
     """Friendly explanation for a fetch failure, with a sensible fallback."""
+    if "reddit.com" in (url or "").lower() and reason in _REDDIT_CONTENT_REASONS:
+        return _REDDIT_MESSAGE
     if reason and reason in _USER_MESSAGES:
         return _USER_MESSAGES[reason]
     if url:

--- a/bot/fetcher.py
+++ b/bot/fetcher.py
@@ -597,6 +597,19 @@ _PAYWALL_SIGNATURES = (
     "you've reached your",
     "you have reached your",
 )
+# Block / removed / not-found boilerplate that extracts longer than the JS-wall
+# heuristics but is still not real content — most often Reddit pages served to
+# datacenter IPs, which would otherwise be analysed into a meaningless verdict
+# (#67). Matched anywhere in the (short) extracted text.
+_NO_CONTENT_SIGNATURES = (
+    "you've been blocked by network security",
+    "the page you requested does not exist",
+    "this post has been removed",
+    "sorry, this post has been removed",
+    "this community has been banned",
+    "this account has been suspended",
+    "page not found",
+)
 
 
 def _wall_reason(text: str | None) -> str | None:
@@ -613,6 +626,8 @@ def _wall_reason(text: str | None) -> str | None:
             return fetch_errors.JS_REQUIRED
         if any(s in low for s in _PAYWALL_SIGNATURES):
             return fetch_errors.PAYWALLED
+        if any(s in low for s in _NO_CONTENT_SIGNATURES):
+            return fetch_errors.NO_TEXT_EXTRACTED
     if len(clean) < _MIN_ARTICLE_CHARS:
         return fetch_errors.NO_TEXT_EXTRACTED
     return None
@@ -677,6 +692,21 @@ async def _generic_fetch(url: str) -> dict:
 def _domain_matches(domain: str, *targets: str) -> bool:
     """Check if domain equals or is a subdomain of any target."""
     return any(domain == t or domain.endswith(f".{t}") for t in targets)
+
+
+# Reddit's modern www/app pages are a client-rendered JS shell — a plain fetch
+# extracts nothing, so a Reddit link used to either error or (worse) get a
+# meaningless verdict off page chrome (#67). old.reddit.com still serves the
+# real server-rendered post, so we rewrite the host. (Media subdomains
+# i.redd.it / v.redd.it are left alone — they aren't articles.) Reddit also
+# Cloudflare-gates datacenter IPs, so this is best-effort; when it's blocked
+# the fetch surfaces a clean Reddit-specific error rather than a bogus verdict.
+def _to_old_reddit(url: str) -> str:
+    parts = urlparse(url)
+    host = parts.hostname or ""
+    if host in ("www.reddit.com", "reddit.com", "np.reddit.com", "m.reddit.com"):
+        return parts._replace(netloc="old.reddit.com").geturl()
+    return url
 
 
 # Direct audio (podcast) URLs end up here instead of the HTML article path:
@@ -941,6 +971,11 @@ async def _fetch_url_uncached(
         return await loop.run_in_executor(
             None, _transcribe_audio_url, url, max_whisper_duration
         )
+
+    if _domain_matches(domain, "reddit.com"):
+        # Server-rendered old.reddit instead of the www JS shell; same generic
+        # extraction + wall/no-content detection handles the rest.
+        return await _generic_fetch(_to_old_reddit(url))
 
     if urlparse(url).path.lower().endswith(".pdf"):
         return await _pdf_fetch(url)

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -632,3 +632,53 @@ class TestDirectAudioUrls:
                                                    max_whisper_duration=1800)
         transcribe.assert_called_once_with("https://cdn.example/ep.mp3")
         assert result["source_type"] == "audio"  # corrected from transcribe's "video"
+
+
+class TestRedditFetch:
+    """Reddit www/app pages are a JS shell; route to old.reddit and never let a
+    blocked/removed page become a verdict (#67)."""
+
+    def test_rewrites_www_to_old_reddit(self):
+        from bot.fetcher import _to_old_reddit
+        assert _to_old_reddit(
+            "https://www.reddit.com/r/x/comments/abc/title/"
+        ) == "https://old.reddit.com/r/x/comments/abc/title/"
+        assert _to_old_reddit("https://reddit.com/r/x/comments/abc/t/") \
+            == "https://old.reddit.com/r/x/comments/abc/t/"
+        # media + already-old hosts are left untouched
+        assert _to_old_reddit("https://i.redd.it/abc.png") == "https://i.redd.it/abc.png"
+        assert _to_old_reddit("https://old.reddit.com/r/x/") == "https://old.reddit.com/r/x/"
+
+    def test_fetch_url_routes_reddit_through_old_host(self, monkeypatch):
+        from bot import fetcher
+        monkeypatch.setattr(fetcher, "assert_public_url", lambda u: None)
+        seen = {}
+
+        async def fake_generic(u):
+            seen["url"] = u
+            return {"text": "real post body " * 30, "title": "Post", "source_type": "article"}
+
+        monkeypatch.setattr(fetcher, "_generic_fetch", fake_generic)
+        result = asyncio.run(
+            fetcher._fetch_url_uncached("https://www.reddit.com/r/x/comments/abc/title/")
+        )
+        assert seen["url"].startswith("https://old.reddit.com/")
+        assert result["text"].startswith("real post body")
+
+    def test_blocked_reddit_page_is_no_content_not_a_verdict(self):
+        # The "blocked / does not exist" boilerplate must read as no-content so
+        # the pipeline errors instead of analysing chrome into a verdict.
+        from bot import fetcher, fetch_errors
+        blocked = "You've been blocked by network security. File a ticket below."
+        removed = "the page you requested does not exist. " + "x " * 100  # > min chars
+        assert fetcher._wall_reason(blocked) == fetch_errors.NO_TEXT_EXTRACTED
+        assert fetcher._wall_reason(removed) == fetch_errors.NO_TEXT_EXTRACTED
+        # a genuine long post is still real content
+        assert fetcher._wall_reason("A substantive discussion. " * 50) is None
+
+    def test_reddit_failure_message_is_specific(self):
+        from bot.fetch_errors import user_message, NO_TEXT_EXTRACTED, JS_REQUIRED
+        msg = user_message(NO_TEXT_EXTRACTED, "https://www.reddit.com/r/x/comments/abc/t/")
+        assert "Reddit" in msg and "paste" in msg.lower()
+        # non-reddit keeps the generic message
+        assert "Reddit" not in user_message(JS_REQUIRED, "https://example.com/a")


### PR DESCRIPTION
## The bug (filter.fyi#67)

A Reddit link produced a **"skip-able" verdict despite no content being retrieved.** Root cause, reproduced live: `www.reddit.com` serves a client-rendered **JS shell** (~8 KB, extracts to 0–few chars), not the post. So either we errored, or page chrome got analysed into a meaningless verdict.

Findings from poking at it:
- `www.reddit.com` → JS shell, no real content.
- `old.reddit.com` → full server-rendered post (a real post extracts ~2 KB of title+body via trafilatura).
- `.json` API → 403 (OAuth-gated now).
- Reddit also **Cloudflare-gates datacenter IPs**, so even old.reddit can be blocked from a server.

## The fix

1. **Route `reddit.com` → `old.reddit.com`** (www/np/m/bare hosts). Media subdomains (`i`/`v.redd.it`) and already-old hosts are left untouched. Same generic extraction + wall detection handles the rest.
2. **Never let a blocked/removed page become a verdict.** Added block/removed/not-found boilerplate ("you've been blocked by network security", "the page you requested does not exist", "this post has been removed", …) to `_wall_reason`, so those read as **no-content** → clean `extraction-failed` error instead of being analysed. This is the part that definitively kills the "verdict despite no content" complaint, regardless of Reddit's blocking.
3. **Reddit-aware error message**: "Reddit blocks automated fetches from servers … paste the post text directly" instead of the generic JS/paywall line.

## Honesty about limits

This is **best-effort**: because Reddit Cloudflare-gates datacenter IPs, `old.reddit` may still be blocked from Fly — in which case the user now gets an honest Reddit-specific error rather than a bogus verdict, but the post still won't fetch. **Reliable** Reddit fetching needs the official **OAuth API**, which I've filed as a follow-up (needs an app registration + 2 Fly secrets, and I can't verify it without credentials). Link in the issue.

## Tests

4 new in `tests/test_fetcher.py`: host rewrite (incl. media/old left alone), `fetch_url` routing through the old host, blocked/removed boilerplate → no-content (not a verdict), and the Reddit-specific message. **Full suite: 408 passed.**

Part of filter.fyi#67 (backend half; the URL-in-title overflow is a separate frontend PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)