### PR TITLE
feat(personas): anon-selectable lens — 3 pre-defined AI personas (#72)

### DIFF
--- a/bot/analyzer.py
+++ b/bot/analyzer.py
@@ -24,6 +24,10 @@ class UsageContext:
     anon_id: str | None = None
     job_id: str | None = None
     source_type: str = ""
+    # Anon-only: a pre-defined persona key (bot.personas) the visitor picked, so
+    # their first analysis uses that lens instead of DEFAULT_PROFILE. Ignored
+    # for signed-in users — their saved lens always wins (#72).
+    persona: str = ""
 
 
 def _record_usage(
@@ -290,11 +294,18 @@ _OPENAI_JSON_SUFFIX = (
 )
 
 
-def _load_profile(user_id: int | None) -> str:
-    if user_id is None:
-        return DEFAULT_PROFILE
-    from bot.db import get_user_profile
-    return get_user_profile(user_id) or DEFAULT_PROFILE
+def _load_profile(user_id: int | None, persona: str = "") -> str:
+    """Resolve the profile fed to the analyzer.
+
+    Signed-in users always get their own saved lens (persona ignored). Anon
+    users get the persona they picked, if any (#72); otherwise everyone falls
+    back to DEFAULT_PROFILE.
+    """
+    if user_id is not None:
+        from bot.db import get_user_profile
+        return get_user_profile(user_id) or DEFAULT_PROFILE
+    from bot.personas import resolve_anon_profile
+    return resolve_anon_profile(persona) or DEFAULT_PROFILE
 
 
 def _load_signals(user_id: int | None) -> str:
@@ -474,7 +485,7 @@ def analyze(text: str, user_id: int | None = None, *, ctx: UsageContext | None =
     elif ctx.user_id is None and user_id is not None:
         ctx = UsageContext(user_id=user_id, anon_id=ctx.anon_id, job_id=ctx.job_id, source_type=ctx.source_type)
 
-    profile = _load_profile(ctx.user_id)
+    profile = _load_profile(ctx.user_id, ctx.persona)
     signals = _load_signals(ctx.user_id)
     model = _resolve_model("analyze", ctx)
 

--- a/bot/api.py
+++ b/bot/api.py
@@ -930,6 +930,9 @@ class _JobRequest(BaseModel):
     # Optional anon UUID from the Worker (anon /api/job traffic). Same purpose
     # as TryRequest.anon_id: per-visitor usage attribution only.
     anon_id: str | None = None
+    # Optional anon persona key (#72) — the lens an anonymous visitor picked.
+    # Ignored for signed-in users (their saved lens wins).
+    persona: str = ""
 
 
 @router.post("/job", status_code=202)
@@ -952,7 +955,8 @@ async def start_job(req: _JobRequest, _: None = Depends(_require_try_secret)):
     create_job(job_id)
 
     task = asyncio.create_task(
-        _run_job(job_id, url, req.user_id, req.user_note, req.anon_id, text=text)
+        _run_job(job_id, url, req.user_id, req.user_note, req.anon_id,
+                 text=text, persona=req.persona)
     )
     _background_tasks.add(task)
     task.add_done_callback(_background_tasks.discard)
@@ -968,6 +972,7 @@ async def _run_job(
     anon_id: str | None = None,
     *,
     text: str = "",
+    persona: str = "",
 ) -> None:
     """Background task: routes through the unified URL pipeline and stamps
     progress steps for the polling UI. The pipeline does its own progression
@@ -975,7 +980,7 @@ async def _run_job(
     the browser has something to show — finer per-step progress would need
     a callback API on the pipeline, parked as a follow-up."""
     try:
-        ctx = UsageContext(user_id=user_id, anon_id=anon_id, job_id=job_id)
+        ctx = UsageContext(user_id=user_id, anon_id=anon_id, job_id=job_id, persona=persona)
 
         def _on_step(label: str) -> None:
             _job_steps[job_id] = label

--- a/bot/personas.py
+++ b/bot/personas.py
@@ -1,0 +1,55 @@
+"""Pre-defined anon personas (filter.fyi#72).
+
+Anonymous visitors have no saved lens, so every analysis runs against the
+generic DEFAULT_PROFILE and the first result reads as one-size-fits-all. These
+three personas let an anon pick the lens that fits them before their first try
+— sharpening the audition-moment result and showcasing, before any signup,
+that filter.fyi adapts to *who you are*.
+
+The frontend owns the display copy (punchy labels); the only contract across
+surfaces is the persona KEY. Unknown/empty keys resolve to None so callers
+fall back to DEFAULT_PROFILE — adding/renaming a persona never breaks the API.
+"""
+from __future__ import annotations
+
+# key -> the profile text fed to the analyzer as "about the person".
+ANON_PERSONAS: dict[str, str] = {
+    "leader": (
+        "The reader is a non-technical leader or decision-maker — a founder, "
+        "executive, or manager weighing AI for their organisation. They do NOT "
+        "write code and will not run hands-on engineering tasks. Tailor every "
+        "suggestion to decisions and strategy: build-vs-buy calls, which "
+        "workflows to pilot first, risks and governance, the questions to ask "
+        "vendors and teams, and simple decision frameworks for AI adoption. "
+        "Avoid code, libraries, and implementation detail. They value clear "
+        "trade-offs, business impact, and an honest read on hype vs. substance."
+    ),
+    "explorer": (
+        "The reader is curious but not technical and not a decision-maker. They "
+        "feel some anxiety about keeping up with AI and want to build confidence "
+        "gradually. Tailor every suggestion to small, low-pressure, concrete "
+        "first steps that need no coding: a 10-minute experiment with a popular "
+        "tool, one thing to try in their existing work, a gentle way to get "
+        "hands-on. Keep it reassuring and jargon-light. They value quick wins, "
+        "feeling less behind, and momentum without overwhelm."
+    ),
+    "builder": (
+        "The reader is a hands-on technical practitioner — a developer, ML "
+        "engineer, or builder who writes code and ships. Tailor every suggestion "
+        "to concrete, code-level next steps: architectures to try, libraries and "
+        "tools to wire in, benchmarks to run, experiments to prototype. Be "
+        "specific and technical; assume they can read code and run commands. "
+        "They're skeptical of hype and value practical patterns, real benchmarks, "
+        "and implementation detail."
+    ),
+}
+
+ANON_PERSONA_KEYS = frozenset(ANON_PERSONAS)
+
+
+def resolve_anon_profile(key: str | None) -> str | None:
+    """The profile text for a persona key, or None for unknown/empty keys
+    (caller falls back to DEFAULT_PROFILE)."""
+    if not key:
+        return None
+    return ANON_PERSONAS.get(key.strip().lower())

--- a/tests/test_personas.py
+++ b/tests/test_personas.py
@@ -1,0 +1,111 @@
+"""Anon persona selection (#72): the lens an anonymous visitor picks flows
+into the analyzer's profile, partitions the cache, and never overrides a
+signed-in user's saved lens."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+
+class TestResolve:
+    def test_known_keys_return_their_profile(self):
+        from bot.personas import ANON_PERSONA_KEYS, resolve_anon_profile
+        assert ANON_PERSONA_KEYS == {"leader", "explorer", "builder"}
+        assert "decision-maker" in resolve_anon_profile("leader").lower()
+        assert "not technical" in resolve_anon_profile("explorer").lower()
+        assert "code" in resolve_anon_profile("builder").lower()
+
+    def test_unknown_or_empty_is_none(self):
+        from bot.personas import resolve_anon_profile
+        assert resolve_anon_profile("") is None
+        assert resolve_anon_profile(None) is None
+        assert resolve_anon_profile("ceo") is None
+
+    def test_key_is_case_insensitive(self):
+        from bot.personas import resolve_anon_profile
+        assert resolve_anon_profile("BUILDER") == resolve_anon_profile("builder")
+
+
+class TestLoadProfile:
+    def test_anon_persona_selects_that_lens(self):
+        from bot.analyzer import _load_profile
+        from bot.personas import ANON_PERSONAS
+        assert _load_profile(None, "leader") == ANON_PERSONAS["leader"]
+
+    def test_anon_without_persona_falls_back_to_default(self):
+        from bot.analyzer import DEFAULT_PROFILE, _load_profile
+        assert _load_profile(None, "") == DEFAULT_PROFILE
+        assert _load_profile(None, "bogus") == DEFAULT_PROFILE
+
+    def test_signed_in_lens_ignores_persona(self, db):
+        from bot.analyzer import _load_profile
+        uid = db.upsert_user_by_email("u@example.com")
+        db.set_user_profile(uid, "My own saved lens.")
+        # Even with a persona passed, the saved lens wins for signed-in users.
+        assert _load_profile(uid, "leader") == "My own saved lens."
+
+
+class TestAnalyzerIntegration:
+    """The persona text actually reaches the prompt, and changes the cache key."""
+
+    def _fake(self, monkeypatch):
+        from bot import analyzer
+        prompts = []
+
+        def create(**kw):
+            prompts.append(kw["messages"][0]["content"])
+            return SimpleNamespace(
+                content=[SimpleNamespace(type="tool_use", name="record_analysis",
+                                         input={"main_idea": "x", "why_it_matters": "y",
+                                                "grounded_in": "g", "category": "c",
+                                                "time_required": "5m", "verdict": "watch",
+                                                "suggestions": []})],
+                usage=SimpleNamespace(input_tokens=1, output_tokens=1),
+            )
+        monkeypatch.setattr(analyzer, "_PROVIDER", "anthropic")
+        monkeypatch.setattr(analyzer, "_MODEL", "claude-haiku-4-5-20251001")
+        monkeypatch.setattr(analyzer, "_PREMIUM_MODEL", "claude-haiku-4-5-20251001")
+        monkeypatch.setattr(analyzer, "_get_client",
+                            lambda: SimpleNamespace(messages=SimpleNamespace(create=create)))
+        return analyzer, prompts
+
+    def test_persona_text_reaches_the_prompt(self, db, monkeypatch):
+        analyzer, prompts = self._fake(monkeypatch)
+        analyzer.analyze("content", ctx=analyzer.UsageContext(persona="leader"))
+        assert "decision-maker" in prompts[0].lower()
+        assert "do not write code" in prompts[0].lower()
+
+    def test_cache_key_differs_by_persona(self, db):
+        from bot import analyzer
+        from bot.personas import ANON_PERSONAS
+        k_leader = analyzer._cache_key_analyze("t", ANON_PERSONAS["leader"], "m")
+        k_builder = analyzer._cache_key_analyze("t", ANON_PERSONAS["builder"], "m")
+        assert k_leader != k_builder
+
+
+class TestJobEndpoint:
+    def test_start_job_accepts_persona(self, client, auth_headers):
+        r = client.post("/api/job",
+                        json={"url": "https://example.com/x", "persona": "leader"},
+                        headers=auth_headers)
+        assert r.status_code == 202
+
+    def test_run_job_threads_persona_into_analysis(self, client, db, monkeypatch):
+        import asyncio
+        import bot.api
+        from bot.personas import ANON_PERSONAS
+        seen = {}
+
+        def fake_analyze(text, user_id=None, *, ctx=None, **kw):
+            from bot.analyzer import _load_profile
+            seen["profile"] = _load_profile(ctx.user_id, ctx.persona)
+            return {"main_idea": "x", "why_it_matters": "", "grounded_in": "",
+                    "category": "", "time_required": "", "verdict": "watch",
+                    "suggestions": []}
+
+        monkeypatch.setattr(bot.pipeline, "analyze", fake_analyze)
+        db.create_job("job-persona")
+        asyncio.run(bot.api._run_job("job-persona", "https://example.com/x", None, "",
+                                     anon_id="a1", persona="explorer"))
+        assert seen["profile"] == ANON_PERSONAS["explorer"]


### PR DESCRIPTION
## Why

Anonymous visitors all run on the generic `DEFAULT_PROFILE`, so their **first** result — the audition moment — reads one-size-fits-all. This lets an anon pick the lens that fits them before their first try: sharper results, and a showcase (before any signup) that filter.fyi adapts to *who you are*. Backend half of filter.fyi#72.

## What

- **`bot/personas.py`** — three personas, keyed `leader` / `explorer` / `builder`:
  - **leader** — non-technical decision-maker (founder/exec): strategy, build-vs-buy, which workflows to pilot, decision frameworks — *no code*.
  - **explorer** — curious, non-technical, a bit AI-anxious: small low-pressure no-code first steps, reassuring, jargon-light.
  - **builder** — hands-on dev/ML engineer: code-level next steps, architectures, benchmarks, experiments (≈ today's `DEFAULT_PROFILE` ethos, sharpened).
  - `resolve_anon_profile(key)` → the profile text, or `None` for unknown/empty keys so callers fall back to `DEFAULT_PROFILE`. Adding/renaming a persona never breaks the API.
- **`UsageContext.persona`** + `_load_profile(user_id, persona)`: anon users get the picked persona; **signed-in users' saved lens always wins** (persona ignored). The persona feeds the analyze prompt and is part of the **cache key**, so personas partition the cache naturally (no cross-contamination, no extra invalidation of existing anon traffic — no-selection still hits `DEFAULT_PROFILE`).
- **`/api/job` accepts `{persona}`**; `_run_job` threads it onto the ctx.

The frontend owns the display copy (punchy labels); the persona **key** is the only cross-surface contract.

## Tests

10 new in `tests/test_personas.py`: resolve (known/unknown/case), `_load_profile` (anon picks lens / falls back / signed-in ignores persona), analyzer integration (persona text reaches the prompt; cache key differs by persona), and the job path (`start_job` accepts persona; `_run_job` threads it into the analysis). **Full suite: 428 passed.**

Pairs with the frontend PR (Worker passthrough + the 3-card picker above the URL field). Inert until that ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)