### PR TITLE
fix(summary): stream the Anthropic summary call

### DIFF
--- a/bot/analyzer.py
+++ b/bot/analyzer.py
@@ -669,11 +669,20 @@ def summarize_content(
     try:
         client = _get_client()
         if _PROVIDER == "anthropic":
-            resp = client.messages.create(
+            # Stream the summary rather than blocking on one response. The SDK
+            # rejects a *non-streaming* request whose `max_tokens` implies a
+            # >10-minute worst case — which long-transcript briefs routinely
+            # trip, since `_summary_output_tokens` scales the budget up to 32k
+            # (fails instantly, latency 0, before any network call → the brief
+            # silently degraded to the truncated-transcript fallback). Streaming
+            # keeps the socket open incrementally; the model still stops at
+            # end_turn when the brief is done, so real latency is unchanged.
+            with client.messages.stream(
                 model=model,
                 max_tokens=max_tokens,
                 messages=[{"role": "user", "content": prompt}],
-            )
+            ) as stream:
+                resp = stream.get_final_message()
             in_tok, out_tok = _anthropic_tokens(resp)
             stop_reason = getattr(resp, "stop_reason", None)
             out = "".join(

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -23,6 +23,49 @@ class TestSummarizeContent:
         out = analyzer.summarize_content("x" * (analyzer.SUMMARY_MAX_CHARS + 5000))
         assert out == "x" * analyzer.SUMMARY_MAX_CHARS
 
+    def test_uses_streaming_on_anthropic(self, monkeypatch):
+        """Long-transcript briefs request a large max_tokens, which the Anthropic
+        SDK refuses on a *non-streaming* call ("Streaming is required for
+        operations that may take longer than 10 minutes"). Summaries must go
+        through `messages.stream()` so that guard never fires and silently
+        drops us to the truncated-transcript fallback."""
+        from bot import analyzer
+
+        class _Block:
+            type = "text"
+            text = "CURATED BRIEF"
+
+        class _FinalMessage:
+            content = [_Block()]
+            stop_reason = "end_turn"
+            usage = type("U", (), {"input_tokens": 12, "output_tokens": 3})()
+
+        class _StreamCtx:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
+            def get_final_message(self):
+                return _FinalMessage()
+
+        class _Messages:
+            def stream(self, **kwargs):
+                return _StreamCtx()
+
+            def create(self, **kwargs):  # pragma: no cover - must not be hit
+                raise AssertionError("summarize_content must stream, not create")
+
+        class _Client:
+            messages = _Messages()
+
+        monkeypatch.setattr(analyzer, "_PROVIDER", "anthropic")
+        monkeypatch.setattr(analyzer, "_get_client", lambda: _Client())
+
+        out = analyzer.summarize_content("some long transcript text")
+        assert out == "CURATED BRIEF"
+
     def test_output_tokens_scale_with_input(self):
         from bot import analyzer
 

--- a/tests/test_llm_usage.py
+++ b/tests/test_llm_usage.py
@@ -256,8 +256,9 @@ class TestResultCache:
         monkeypatch.setattr(analyzer, "_PREMIUM_MODEL", "claude-haiku-4-5-20251001")
 
         # First call: model raises → fallback returns truncated text.
+        # summarize_content streams, so the failure must come from stream().
         class Boom:
-            messages = SimpleNamespace(create=lambda **kw: (_ for _ in ()).throw(RuntimeError("rate-limited")))
+            messages = SimpleNamespace(stream=lambda **kw: (_ for _ in ()).throw(RuntimeError("rate-limited")))
         monkeypatch.setattr(analyzer, "_get_client", lambda: Boom())
         result1 = analyzer.summarize_content("x" * 200)
         assert result1.startswith("x")  # fallback truncation
@@ -377,9 +378,25 @@ class _FakeAnthropic:
             content = [SimpleNamespace(type="text", text=text or "")]
         resp = SimpleNamespace(
             content=content,
+            stop_reason="end_turn",
             usage=SimpleNamespace(input_tokens=input_tokens, output_tokens=output_tokens),
         )
-        self.messages = SimpleNamespace(create=lambda **kw: resp)
+
+        # `summarize_content` streams (see analyzer.py); expose a context-manager
+        # `stream()` whose get_final_message() returns the same resp. `analyze`
+        # still uses the non-streaming `create()`.
+        class _Stream:
+            def __enter__(self_inner):
+                return self_inner
+            def __exit__(self_inner, *exc):
+                return False
+            def get_final_message(self_inner):
+                return resp
+
+        self.messages = SimpleNamespace(
+            create=lambda **kw: resp,
+            stream=lambda **kw: _Stream(),
+        )
 
 
 class _FakeOpenAI:


### PR DESCRIPTION
## Problem

`item/126` (and 116, 77) stored a **raw truncated transcript** in place of the curated brief, and processing was suspiciously fast. Verified on the live DB:

- `items.content` for all three is **exactly 100000 chars** = `SUMMARY_MAX_CHARS` (the truncation-fallback cap). Head of 126 is literally `Title\n\nTranscript:\n<raw captions>`.
- `llm_calls` shows the `summary` call (`claude-sonnet-4-6`) in **`error` with latency 0ms**: *"Streaming is required for operations that may take longer than 10 minutes"*.

## Root cause

`_summary_output_tokens` scales `max_tokens` 1:1 with the source, up to `_SUMMARY_MAX_OUTPUT_TOKENS = 32_000`. The Anthropic SDK rejects a **non-streaming** request whose `max_tokens` implies a >10-min worst case — before any network call. On the signed-in premium path, long transcripts trip this every time, so `summarize_content` hit its except branch and stored `text[:SUMMARY_MAX_CHARS]`. `analyze` then ran on the raw transcript (which is why a real analysis still exists on the item).

## Fix

Switch the summary call to `client.messages.stream()` + `get_final_message()`. The model still stops at `end_turn` when the brief is done, so **real latency is unchanged** — streaming only avoids the SDK's upfront guard. `analyze()` is unaffected (`max_tokens=2048`, nowhere near the threshold).

## Tests

- New: `summarize_content` must stream (asserts `create()` is never called).
- Updated the shared `_FakeAnthropic` and the fallback-path fake to expose `stream()`.
- Full suite: 429 passing.

## Follow-up (not in this PR)

Re-process items 77 / 116 / 126 to replace the raw-transcript content with proper briefs once this is deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)