### PR TITLE
feat(mcp): MCP server — filter.fyi as a tool inside Claude/Cursor/any agent

### DIFF
--- a/bot/mcp_server.py
+++ b/bot/mcp_server.py
@@ -1,0 +1,255 @@
+"""MCP server — filter.fyi as a first-class tool for AI agents.
+
+Mounted at `/mcp` (Streamable HTTP, stateless). Lets Claude Code / Claude
+Desktop / Cursor / any MCP client analyse links, search the user's library,
+and read/tune their lens — so the product works where the user's agent
+already lives, not just in a browser tab.
+
+Auth: the same per-user Bearer token as the REST API (`users.api_token`,
+minted via Telegram `/token`). A tiny ASGI middleware validates the header
+and stashes the canonical users.id in a ContextVar the tools read; there is
+no anonymous MCP access.
+
+Client config (e.g. Claude Code):
+
+    claude mcp add --transport http filter-fyi https://<backend>/mcp \
+        --header "Authorization: Bearer <token>"
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from contextvars import ContextVar
+
+from mcp.server.fastmcp import FastMCP
+
+from bot.analyzer import UsageContext
+from bot.db import get_all_items, get_item, get_user_by_token, get_user_profile, search_items, set_user_field
+from bot.pipeline import PipelineError, analyze_text, analyze_url
+
+logger = logging.getLogger(__name__)
+
+# The authenticated caller for the current request. Set by the auth middleware
+# before the MCP app sees the request; tools must only read it via
+# `_require_user_id()`.
+_current_user_id: ContextVar[int | None] = ContextVar("mcp_user_id", default=None)
+
+
+def _require_user_id() -> int:
+    uid = _current_user_id.get()
+    if uid is None:  # middleware rejects unauthenticated requests; belt & braces
+        raise RuntimeError("MCP tool invoked without an authenticated user")
+    return uid
+
+
+mcp = FastMCP(
+    name="filter-fyi",
+    instructions=(
+        "filter.fyi turns anything the user reads/watches/listens to into a "
+        "verdict (worth the time / worth a skim / skip-able) plus concrete "
+        "next-step suggestions. Use `analyze` on URLs the user shares, "
+        "`search_library` / `get_library_item` to recall what they already "
+        "filtered, and `get_lens` / `set_lens` to read or tune the personal "
+        "perspective every analysis is judged against."
+    ),
+    # Mounted as a sub-app at /mcp by main.py, so serve at this app's root.
+    streamable_http_path="/",
+    stateless_http=True,
+    json_response=True,
+)
+
+
+def _split_analysis(analysis: dict) -> tuple[str, dict]:
+    """Split analyzer output into (verdict, rest) — same shape the REST API uses."""
+    analysis = dict(analysis or {})
+    verdict = analysis.pop("verdict", "skim")
+    return verdict, analysis
+
+
+def _actions_for_user(analysis: dict, *, user_id: int, result, source_url: str) -> list[dict]:
+    # Reuse the REST layer's action builder (profile + library-history aware)
+    # so MCP and web hand out identical briefs. Imported lazily to keep this
+    # module import-light for tests.
+    from bot.api import _actions_for
+
+    return _actions_for(
+        analysis,
+        user_id=user_id,
+        source_text=result.summary,
+        source_title=result.title,
+        source_url=source_url,
+    )
+
+
+@mcp.tool()
+async def analyze(url: str = "", text: str = "", note: str = "") -> dict:
+    """Analyse a URL (article, YouTube, PDF, tweet…) or pasted text through the
+    user's lens. Returns a verdict, why it matters, and 0–5 concrete next-step
+    suggestions, and saves the result to the user's filter.fyi library.
+
+    Provide exactly one of `url` or `text`. `note` is an optional remark from
+    the user stored alongside the item. Long sources can take up to a minute.
+    """
+    user_id = _require_user_id()
+    url = (url or "").strip()
+    text = (text or "").strip()
+    if bool(url) == bool(text):
+        return {"error": "bad-request", "message": "Provide exactly one of `url` or `text`."}
+
+    try:
+        if url:
+            result = await analyze_url(
+                url,
+                ctx=UsageContext(user_id=user_id, source_type="mcp"),
+                save_for_user_id=user_id,
+                user_note=note,
+            )
+        else:
+            result = await analyze_text(
+                text,
+                ctx=UsageContext(user_id=user_id, source_type="mcp"),
+                save_for_user_id=user_id,
+                user_note=note,
+            )
+    except PipelineError as e:
+        return {"error": e.code, "message": str(e) or "The analysis failed."}
+
+    verdict, analysis = _split_analysis(result.analysis)
+    return {
+        "item_id": result.saved_id,
+        "url": url or None,
+        "title": result.title or url,
+        "source_type": result.source_type,
+        "verdict": verdict,
+        "analysis": analysis,
+        "actions": _actions_for_user(analysis, user_id=user_id, result=result, source_url=url),
+    }
+
+
+@mcp.tool()
+async def search_library(query: str = "", limit: int = 20) -> list[dict]:
+    """Search the user's filter.fyi library (everything they've analysed).
+    Empty query returns the most recent items. Returns lean rows — use
+    `get_library_item` for the full analysis of one item.
+    """
+    user_id = _require_user_id()
+    limit = max(1, min(int(limit), 100))
+    rows = await asyncio.to_thread(
+        lambda: search_items(query, user_id) if query.strip() else get_all_items(user_id)
+    )
+    out = []
+    for r in rows[:limit]:
+        try:
+            analysis = json.loads(r["analysis"] or "{}")
+        except (TypeError, ValueError):
+            analysis = {}
+        out.append(
+            {
+                "item_id": r["id"],
+                "title": analysis.get("title") or r["source"],
+                "verdict": analysis.get("verdict", ""),
+                "source": r["source"],
+                "source_type": r["source_type"],
+                "created_at": r["created_at"],
+            }
+        )
+    return out
+
+
+@mcp.tool()
+async def get_library_item(item_id: int) -> dict:
+    """Fetch one library item in full: stored summary (`content`), the complete
+    analysis (main idea, why it matters, suggestions), and the user's note."""
+    user_id = _require_user_id()
+    row = await asyncio.to_thread(get_item, item_id, user_id)
+    if not row:
+        return {"error": "not-found", "message": f"No library item {item_id} for this user."}
+    try:
+        analysis = json.loads(row["analysis"] or "{}")
+    except (TypeError, ValueError):
+        analysis = {}
+    return {
+        "item_id": row["id"],
+        "source": row["source"],
+        "source_type": row["source_type"],
+        "created_at": row["created_at"],
+        "user_note": row["user_note"],
+        "analysis": analysis,
+        "content": row["content"],
+    }
+
+
+@mcp.tool()
+async def get_lens() -> dict:
+    """Read the user's lens — the personal perspective (role, goals, stack,
+    interests) every analysis is judged against."""
+    user_id = _require_user_id()
+    profile = await asyncio.to_thread(get_user_profile, user_id)
+    return {"lens": profile or "", "set": bool((profile or "").strip())}
+
+
+@mcp.tool()
+async def set_lens(lens: str) -> dict:
+    """Replace the user's lens. Keep it short and concrete (who they are, what
+    they're building, what they care about) — it steers every future verdict
+    and suggestion. Read it first with `get_lens`; don't drop details the user
+    still wants."""
+    user_id = _require_user_id()
+    lens = (lens or "").strip()
+    if len(lens) > 4000:
+        return {"error": "too-long", "message": "Keep the lens under 4000 characters."}
+    await asyncio.to_thread(set_user_field, user_id, profile=lens)
+    return {"ok": True, "lens": lens}
+
+
+class _BearerAuthMiddleware:
+    """Pure-ASGI bearer auth for the mounted MCP app.
+
+    Validates `Authorization: Bearer <users.api_token>` and seeds the
+    per-request ContextVar. Rejections are plain JSON 401s — cheap, and no MCP
+    session is ever created for an unauthenticated caller.
+    """
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+        headers = {k.decode("latin-1").lower(): v.decode("latin-1") for k, v in scope.get("headers") or []}
+        scheme, _, token = (headers.get("authorization") or "").partition(" ")
+        row = None
+        if scheme.lower() == "bearer" and token:
+            row = await asyncio.to_thread(get_user_by_token, token)
+        if not row:
+            body = json.dumps(
+                {"error": "unauthorized", "message": "Send Authorization: Bearer <api token> (Telegram /token)."}
+            ).encode()
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 401,
+                    "headers": [
+                        (b"content-type", b"application/json"),
+                        (b"www-authenticate", b"Bearer"),
+                    ],
+                }
+            )
+            await send({"type": "http.response.body", "body": body})
+            return
+        token_ctx = _current_user_id.set(row["id"])
+        try:
+            await self.app(scope, receive, send)
+        finally:
+            _current_user_id.reset(token_ctx)
+
+
+def build_mcp_asgi_app():
+    """The auth-wrapped Streamable-HTTP ASGI app, ready to mount at /mcp.
+
+    The caller must also run `mcp.session_manager.run()` for the app's
+    lifetime (main.py does this inside the FastAPI lifespan).
+    """
+    return _BearerAuthMiddleware(mcp.streamable_http_app())

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -1,0 +1,47 @@
+# MCP server — filter.fyi inside your agent
+
+The backend exposes an MCP (Model Context Protocol) server at `/mcp`
+(Streamable HTTP, stateless). It makes filter.fyi a first-class tool wherever
+the user's agent lives — Claude Code, Claude Desktop, Cursor, or any MCP
+client — instead of only in a browser tab or Telegram.
+
+## Auth
+
+Same per-user Bearer token as the REST API: `users.api_token`, minted with the
+Telegram `/token` command. Every request must send
+`Authorization: Bearer <token>`; there is no anonymous MCP access. Analyses
+run through the caller's lens and land in their library, exactly like the web
+and Telegram surfaces.
+
+## Client setup
+
+Claude Code:
+
+```bash
+claude mcp add --transport http filter-fyi https://<backend-host>/mcp \
+  --header "Authorization: Bearer <token>"
+```
+
+Any other Streamable-HTTP MCP client: point it at `https://<backend-host>/mcp`
+with the same header.
+
+## Tools
+
+| Tool | What it does |
+|---|---|
+| `analyze(url, text, note)` | Full pipeline on a URL **or** pasted text (exactly one); saves to the library; returns verdict + analysis + agent-handoff actions. Long sources can take up to a minute. |
+| `search_library(query, limit)` | Lean rows over everything the user has filtered; empty query = most recent. |
+| `get_library_item(item_id)` | One item in full: stored summary, complete analysis, user note. |
+| `get_lens()` | The user's perspective text. |
+| `set_lens(lens)` | Replace the perspective (≤ 4000 chars). |
+
+## Implementation notes
+
+- `bot/mcp_server.py` — FastMCP instance + a pure-ASGI Bearer middleware that
+  resolves the token to a canonical `users.id` and seeds a request-scoped
+  ContextVar the tools read. Mounted in `main.py`; the transport's session
+  manager runs inside the FastAPI lifespan.
+- Tool responses reuse the REST layer's action builder (`bot.api._actions_for`),
+  so MCP and web hand out identical briefs (profile + library-history aware).
+- Errors surface as structured `{error, message}` payloads (pipeline error
+  codes like `fetch-failed`, `no-transcript`, `busy`), not exceptions.

--- a/main.py
+++ b/main.py
@@ -218,7 +218,10 @@ async def lifespan(app: FastAPI):
         maintenance_tasks.append(asyncio.create_task(_monitor_loop()))
         logger.info("Channel monitor enabled (interval=%ds)", _MONITOR_INTERVAL_S)
 
-    yield
+    # The MCP transport's session manager must run for the app's lifetime —
+    # entering it here ties its task group to FastAPI's lifespan.
+    async with mcp.session_manager.run():
+        yield
 
     for task in maintenance_tasks:
         task.cancel()
@@ -238,9 +241,14 @@ app = FastAPI(lifespan=lifespan)
 
 from bot.api import router as api_router  # noqa: E402
 from bot.admin import router as admin_router  # noqa: E402
+from bot.mcp_server import build_mcp_asgi_app, mcp  # noqa: E402
 
 app.include_router(api_router)
 app.include_router(admin_router)
+
+# MCP (Streamable HTTP) — filter.fyi as a tool inside Claude/Cursor/any agent.
+# Bearer-authenticated per user; see bot/mcp_server.py.
+app.mount("/mcp", build_mcp_asgi_app())
 
 _STATIC_DIR = Path(__file__).parent / "bot" / "static"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,5 +25,7 @@ feedparser>=6.0.0
 pyjwt[crypto]>=2.8.0
 # web UI file uploads
 python-multipart>=0.0.9
+# MCP server (/mcp, Streamable HTTP) — filter.fyi as a tool for AI agents
+mcp>=1.13.0
 # tests
 pytest>=8.0.0

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,211 @@
+"""Tests for the MCP server (bot/mcp_server.py).
+
+Two layers:
+- tool functions called directly (with the auth ContextVar seeded), pipeline
+  mocked — verifies shapes, ownership scoping, and error mapping;
+- the ASGI auth middleware exercised end-to-end over httpx's ASGITransport —
+  verifies the 401 path and that a valid token reaches the wrapped app.
+
+House style: sync tests driving coroutines with `asyncio.run` (same as
+tests/test_pipeline.py).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+
+import httpx
+import pytest
+
+
+@pytest.fixture
+def mcp_mod(monkeypatch):
+    """bot.mcp_server bound to the isolated test DB, with the pipeline mocked."""
+    import bot.mcp_server as m
+    import bot.pipeline
+
+    async def fake_analyze_url(url, *, ctx, save_for_user_id=None, user_note="", **kw):
+        from bot.db import save_item
+
+        analysis = {
+            "verdict": "watch",
+            "title": "Hello RAG",
+            "main_idea": "RAG is useful.",
+            "why_it_matters": "Because context.",
+            "suggestions": [
+                {"title": "Try it", "detail": "Build a tiny RAG.", "effort": "an evening", "first_step": "pip install"}
+            ],
+        }
+        saved_id = None
+        if save_for_user_id is not None:
+            saved_id = save_item(
+                save_for_user_id,
+                "article",
+                url,
+                "summary text",
+                json.dumps(analysis),
+                user_note,
+            )
+        return bot.pipeline.PipelineResult(
+            fetched={"title": "Hello RAG", "source_type": "article"},
+            summary="summary text",
+            analysis=dict(analysis),
+            saved_id=saved_id,
+        )
+
+    monkeypatch.setattr(m, "analyze_url", fake_analyze_url)
+    return m
+
+
+def _make_user(db, token="tok-1", email="a@b.c"):
+    uid = db.upsert_user_by_email(email)
+    db.set_user_field(uid, api_token=token)
+    return uid
+
+
+def _as_user(mcp_mod, uid, coro):
+    """Run one tool coroutine with the auth ContextVar seeded, then reset."""
+    tok = mcp_mod._current_user_id.set(uid)
+    try:
+        return asyncio.run(coro)
+    finally:
+        mcp_mod._current_user_id.reset(tok)
+
+
+def test_tools_require_an_authenticated_user(mcp_mod):
+    with pytest.raises(RuntimeError):
+        mcp_mod._require_user_id()
+
+
+def test_analyze_saves_to_library_and_returns_actions(db, mcp_mod):
+    uid = _make_user(db)
+    out = _as_user(mcp_mod, uid, mcp_mod.analyze(url="https://example.com/rag"))
+
+    assert out["verdict"] == "watch"
+    assert out["item_id"] is not None
+    assert out["analysis"]["main_idea"] == "RAG is useful."
+    assert len(out["actions"]) == 1
+    assert "brief" in out["actions"][0]
+
+    # and it landed in the caller's library
+    rows = db.get_all_items(uid)
+    assert len(rows) == 1
+    assert rows[0]["source"] == "https://example.com/rag"
+
+
+def test_analyze_requires_exactly_one_input(db, mcp_mod):
+    uid = _make_user(db)
+    neither = _as_user(mcp_mod, uid, mcp_mod.analyze())
+    both = _as_user(mcp_mod, uid, mcp_mod.analyze(url="https://x.y", text="some pasted text"))
+    assert neither["error"] == "bad-request"
+    assert both["error"] == "bad-request"
+
+
+def test_analyze_maps_pipeline_errors(db, mcp_mod, monkeypatch):
+    import bot.pipeline
+
+    async def boom(url, **kw):
+        raise bot.pipeline.PipelineError(bot.pipeline.ERR_FETCH_FAILED, message="could not fetch")
+
+    monkeypatch.setattr(mcp_mod, "analyze_url", boom)
+    uid = _make_user(db)
+    out = _as_user(mcp_mod, uid, mcp_mod.analyze(url="https://example.com/dead"))
+    assert out == {"error": "fetch-failed", "message": "could not fetch"}
+
+
+def test_library_tools_are_ownership_scoped(db, mcp_mod):
+    uid = _make_user(db, token="tok-1", email="a@b.c")
+    other = _make_user(db, token="tok-2", email="d@e.f")
+
+    created = _as_user(mcp_mod, uid, mcp_mod.analyze(url="https://example.com/rag"))
+    mine = _as_user(mcp_mod, uid, mcp_mod.search_library())
+    item = _as_user(mcp_mod, uid, mcp_mod.get_library_item(created["item_id"]))
+
+    assert [r["item_id"] for r in mine] == [created["item_id"]]
+    assert item["analysis"]["verdict"] == "watch"
+    assert item["content"] == "summary text"
+
+    # the other user sees nothing
+    theirs = _as_user(mcp_mod, other, mcp_mod.search_library())
+    stolen = _as_user(mcp_mod, other, mcp_mod.get_library_item(created["item_id"]))
+    assert theirs == []
+    assert stolen["error"] == "not-found"
+
+
+def test_search_library_matches_query(db, mcp_mod):
+    uid = _make_user(db)
+    _as_user(mcp_mod, uid, mcp_mod.analyze(url="https://example.com/rag"))
+    hit = _as_user(mcp_mod, uid, mcp_mod.search_library(query="rag"))
+    miss = _as_user(mcp_mod, uid, mcp_mod.search_library(query="quantum-basket-weaving"))
+    assert len(hit) == 1
+    assert miss == []
+
+
+def test_lens_roundtrip(db, mcp_mod):
+    uid = _make_user(db)
+    assert _as_user(mcp_mod, uid, mcp_mod.get_lens()) == {"lens": "", "set": False}
+    set_out = _as_user(mcp_mod, uid, mcp_mod.set_lens("Solo founder building trading bots."))
+    assert set_out["ok"] is True
+    assert _as_user(mcp_mod, uid, mcp_mod.get_lens()) == {
+        "lens": "Solo founder building trading bots.",
+        "set": True,
+    }
+    too_long = _as_user(mcp_mod, uid, mcp_mod.set_lens("x" * 4001))
+    assert too_long["error"] == "too-long"
+
+
+# --- auth middleware ---------------------------------------------------------
+
+def _echo_app():
+    """Minimal ASGI app that reports the ContextVar the middleware seeded."""
+
+    async def app(scope, receive, send):
+        import bot.mcp_server as m
+
+        body = json.dumps({"user_id": m._current_user_id.get()}).encode()
+        await send({"type": "http.response.start", "status": 200,
+                    "headers": [(b"content-type", b"application/json")]})
+        await send({"type": "http.response.body", "body": body})
+
+    return app
+
+
+def test_middleware_rejects_missing_or_bad_tokens(db, mcp_mod):
+    async def run():
+        wrapped = mcp_mod._BearerAuthMiddleware(_echo_app())
+        transport = httpx.ASGITransport(app=wrapped)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+            no_header = await c.post("/")
+            bad = await c.post("/", headers={"authorization": "Bearer nope"})
+            wrong_scheme = await c.post("/", headers={"authorization": "Basic abc"})
+        return no_header, bad, wrong_scheme
+
+    no_header, bad, wrong_scheme = asyncio.run(run())
+    assert no_header.status_code == 401
+    assert bad.status_code == 401
+    assert wrong_scheme.status_code == 401
+    assert no_header.headers["www-authenticate"] == "Bearer"
+
+
+def test_middleware_seeds_user_and_resets_after(db, mcp_mod):
+    uid = _make_user(db, token="sekrit")
+
+    async def run():
+        wrapped = mcp_mod._BearerAuthMiddleware(_echo_app())
+        transport = httpx.ASGITransport(app=wrapped)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+            return await c.post("/", headers={"authorization": "Bearer sekrit"})
+
+    ok = asyncio.run(run())
+    assert ok.status_code == 200
+    assert ok.json() == {"user_id": uid}
+    # the request-scoped identity never leaks past the request
+    assert mcp_mod._current_user_id.get() is None
+
+
+def test_main_app_mounts_mcp():
+    """The FastAPI app exposes /mcp (auth-wrapped) without disturbing REST routes."""
+    import main
+
+    mounted = [r for r in main.app.routes if getattr(r, "path", "") == "/mcp"]
+    assert mounted, "expected /mcp to be mounted on the app"


### PR DESCRIPTION
## What

Mounts an MCP server (Streamable HTTP, stateless) at `/mcp` on the existing FastAPI backend, making filter.fyi a first-class tool wherever the user's agent already lives — Claude Code, Claude Desktop, Cursor, or any MCP client.

**Tools**
- `analyze(url | text, note)` — full pipeline through the caller's lens, saved to their library, returns verdict + analysis + the same agent-handoff actions the web UI builds
- `search_library(query, limit)` / `get_library_item(item_id)` — recall over everything they've filtered
- `get_lens()` / `set_lens(lens)` — read/tune the perspective every verdict is judged against

**Auth:** same per-user Bearer token as the REST API (`users.api_token`, Telegram `/token`). A pure-ASGI middleware validates the header and seeds a request-scoped ContextVar; no anonymous access, all tools ownership-scoped.

## Why

Agent-first distribution: "add filter.fyi to Claude Code in one command" is a differentiator none of the summarizer competitors have, it deepens the moat around the lens + library (agents can *use* your reading history), and it's a concrete plank of the $20/mo Pro story.

## Notes for review

- `mcp>=1.13` added to requirements (installs cleanly next to fastapi 0.136 / starlette 1.0).
- Session manager runs inside the existing FastAPI lifespan (`main.py`).
- Docs: `docs/MCP.md` (client setup + tool table).
- Tests: `tests/test_mcp_server.py` — 10 new, full suite 439 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)