### PR TITLE
fix(personas): make anon lens prompts topic-agnostic posture

### DIFF
--- a/bot/personas.py
+++ b/bot/personas.py
@@ -13,34 +13,40 @@ fall back to DEFAULT_PROFILE — adding/renaming a persona never breaks the API.
 from __future__ import annotations
 
 # key -> the profile text fed to the analyzer as "about the person".
+#
+# These describe the reader's *posture* (how they want next steps framed), not a
+# topic — so a lens works whatever they filter (AI, markets, a field they're
+# learning, a hobby). The frontend labels them "See the big picture" / "Keep up,
+# calmly" / "Get hands-on"; keep the prompts topic-agnostic to match.
 ANON_PERSONAS: dict[str, str] = {
     "leader": (
-        "The reader is a non-technical leader or decision-maker — a founder, "
-        "executive, or manager weighing AI for their organisation. They do NOT "
-        "write code and will not run hands-on engineering tasks. Tailor every "
-        "suggestion to decisions and strategy: build-vs-buy calls, which "
-        "workflows to pilot first, risks and governance, the questions to ask "
-        "vendors and teams, and simple decision frameworks for AI adoption. "
-        "Avoid code, libraries, and implementation detail. They value clear "
-        "trade-offs, business impact, and an honest read on hype vs. substance."
+        "The reader wants the big picture, not the how-to — a decision-maker or "
+        "strategic thinker who cares what something means and what to do about "
+        "it. Tailor every suggestion to decisions and direction, whatever the "
+        "topic: what this changes, the trade-offs and risks to weigh, which "
+        "option to pick, the questions to ask, and simple frameworks for "
+        "deciding. Skip step-by-step implementation and hands-on detail. They "
+        "value clear trade-offs, an honest read on signal vs. hype, and a "
+        "confident sense of what actually matters."
     ),
     "explorer": (
-        "The reader is curious but not technical and not a decision-maker. They "
-        "feel some anxiety about keeping up with AI and want to build confidence "
-        "gradually. Tailor every suggestion to small, low-pressure, concrete "
-        "first steps that need no coding: a 10-minute experiment with a popular "
-        "tool, one thing to try in their existing work, a gentle way to get "
-        "hands-on. Keep it reassuring and jargon-light. They value quick wins, "
-        "feeling less behind, and momentum without overwhelm."
+        "The reader is curious but not an expert here, and feels some pressure "
+        "to keep up. They want to build confidence gradually, without overwhelm. "
+        "Tailor every suggestion to small, low-pressure, concrete first steps: a "
+        "short experiment, one thing to try in what they already do, a gentle "
+        "way to get started — no technical background assumed. Keep it "
+        "reassuring and jargon-light. They value quick wins, feeling less "
+        "behind, and momentum without pressure."
     ),
     "builder": (
-        "The reader is a hands-on technical practitioner — a developer, ML "
-        "engineer, or builder who writes code and ships. Tailor every suggestion "
-        "to concrete, code-level next steps: architectures to try, libraries and "
-        "tools to wire in, benchmarks to run, experiments to prototype. Be "
-        "specific and technical; assume they can read code and run commands. "
-        "They're skeptical of hype and value practical patterns, real benchmarks, "
-        "and implementation detail."
+        "The reader wants to get hands-on and actually do something with what "
+        "they read. Tailor every suggestion to concrete, practical next steps "
+        "and experiments they can run: things to try, test, prototype, or put "
+        "into practice, specific enough to start today. When the topic is "
+        "technical, go code-level — libraries, commands, architectures, "
+        "benchmarks; when it isn't, give the equivalent hands-on move: a "
+        "backtest, a template, a drill, a small project. Be specific and "
+        "concrete. They're skeptical of hype and value real results over theory."
     ),
 }
 

--- a/tests/test_personas.py
+++ b/tests/test_personas.py
@@ -12,9 +12,32 @@ class TestResolve:
     def test_known_keys_return_their_profile(self):
         from bot.personas import ANON_PERSONA_KEYS, resolve_anon_profile
         assert ANON_PERSONA_KEYS == {"leader", "explorer", "builder"}
-        assert "decision-maker" in resolve_anon_profile("leader").lower()
-        assert "not technical" in resolve_anon_profile("explorer").lower()
-        assert "code" in resolve_anon_profile("builder").lower()
+        leader = resolve_anon_profile("leader").lower()
+        explorer = resolve_anon_profile("explorer").lower()
+        builder = resolve_anon_profile("builder").lower()
+        # Each captures a posture (decide / ease-in / do), not a topic.
+        assert "decision-maker" in leader
+        assert "low-pressure" in explorer
+        assert "hands-on" in builder
+
+    def test_personas_are_topic_agnostic(self):
+        """The lenses must work whatever the reader filters (markets, learning,
+        a hobby), not just AI — so the prompts describe posture, not subject."""
+        from bot.personas import ANON_PERSONAS
+        leader = ANON_PERSONAS["leader"].lower()
+        # leader tailors to decisions "whatever the topic", not AI adoption.
+        assert "whatever the topic" in leader
+        assert "ai adoption" not in leader
+
+    def test_builder_is_not_code_only(self):
+        """Regression for the "Get hands-on" relabel: the builder lens must
+        still land for non-coders (a trader's backtest, a learner's drill) and
+        not assume the reader writes code."""
+        from bot.personas import resolve_anon_profile
+        builder = resolve_anon_profile("builder").lower()
+        # Offers a non-technical hands-on path, not only code.
+        assert "when it isn't" in builder
+        assert "assume they can read code" not in builder
 
     def test_unknown_or_empty_is_none(self):
         from bot.personas import resolve_anon_profile
@@ -74,7 +97,7 @@ class TestAnalyzerIntegration:
         analyzer, prompts = self._fake(monkeypatch)
         analyzer.analyze("content", ctx=analyzer.UsageContext(persona="leader"))
         assert "decision-maker" in prompts[0].lower()
-        assert "do not write code" in prompts[0].lower()
+        assert "skip step-by-step implementation" in prompts[0].lower()
 
     def test_cache_key_differs_by_persona(self, db):
         from bot import analyzer


### PR DESCRIPTION
## Why

The reposition made the frontend neutral ("a filter for whatever you follow") and relabelled the anon persona cards from AI-specific to **topic-agnostic posture**: `See the big picture` / `Keep up, calmly` / `Get hands-on`. But `bot/personas.py` — the prompt text those cards actually drive — was still AI- and **code**-specific:

- `leader`: *"weighing AI for their organisation… AI adoption"*
- `builder`: *"a developer, ML engineer… assume they can read code and run commands"* → a non-coder who picks **Get hands-on** got code-level next steps for, say, a markets or parenting article.

This is the backend follow-up flagged when we relabelled the cards.

## Change

Rewrote all three lenses to describe **posture, not topic**, so they hold whatever the reader filters:

- **leader** → decisions & direction *"whatever the topic"*: what changes, trade-offs, which option, questions to ask; skip the how-to.
- **explorer** → ease in gradually, low-pressure first steps, no expertise assumed.
- **builder** → get hands-on: **code-level when the topic is technical**, otherwise the equivalent hands-on move — a backtest, a template, a drill, a small project.

## Safety

Persona **keys/contract unchanged** (`leader`/`explorer`/`builder`), so signed-in saved lenses (which ignore persona) and the `persona` API field are unaffected. This only changes the *text* fed to the analyzer for anon persona-picked results.

## Tests

Updated the word-assertions to the new posture wording, plus two guards:
- `test_personas_are_topic_agnostic` — leader tailors "whatever the topic", not "ai adoption".
- `test_builder_is_not_code_only` — builder offers a non-technical hands-on path and no longer assumes the reader codes.

`make test`: **441 passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)