### PR TITLE
fix(fetcher): reconstruct X Article body from content.blocks

### DIFF
--- a/bot/fetcher.py
+++ b/bot/fetcher.py
@@ -339,6 +339,13 @@ def _syndication_fetch(tweet_id: str) -> dict | None:
         return None
 
 
+def _article_body_from_blocks(article: dict) -> str:
+    """fxtwitter puts X Article bodies in a Draft.js-style block list, not a
+    flat `text` field — reconstruct it by joining each block's text."""
+    blocks = (article.get("content") or {}).get("blocks") or []
+    return "\n\n".join(b["text"] for b in blocks if b.get("text"))
+
+
 def _format_fxtwitter(tweet: dict, url: str) -> dict:
     handle = tweet.get("author", {}).get("screen_name", "")
     author = tweet.get("author", {}).get("name", "")
@@ -351,7 +358,11 @@ def _format_fxtwitter(tweet: dict, url: str) -> dict:
     article = tweet.get("article")
     if article:
         title = article.get("title", "")
-        body = article.get("text") or tweet.get("text", "")
+        body = (
+            _article_body_from_blocks(article)
+            or article.get("preview_text")
+            or tweet.get("text", "")
+        )
         text = f"X Article by @{handle}: {title}\n\n{body}"
         return {"text": text[:MAX_CONTENT_CHARS], "title": title or f"Article by @{handle}", "source_type": "social", "image_urls": image_urls}
 

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -867,3 +867,48 @@ class TestRedditFetch:
         assert "Reddit" in msg and "paste" in msg.lower()
         # non-reddit keeps the generic message
         assert "Reddit" not in user_message(JS_REQUIRED, "https://example.com/a")
+
+
+class TestXArticleExtraction:
+    # fxtwitter puts the X Article body in article.content.blocks (Draft.js
+    # style), not article.text — that key doesn't exist in current responses.
+    # See issue #103: articles were coming through as title + attribution only.
+
+    def _article_tweet(self, blocks=None, preview_text="preview only"):
+        return {
+            "author": {"screen_name": "gregisenberg", "name": "GREG ISENBERG"},
+            "text": "",
+            "article": {
+                "title": "How I'd make $10 million with AI agents",
+                "preview_text": preview_text,
+                "content": {"blocks": blocks} if blocks is not None else {},
+            },
+        }
+
+    def test_article_body_is_reconstructed_from_blocks(self):
+        from bot import fetcher
+        tweet = self._article_tweet(blocks=[
+            {"text": "First paragraph.", "type": "unstyled"},
+            {"text": "", "type": "unstyled"},  # empty blocks are dropped
+            {"text": "Second paragraph.", "type": "header-two"},
+        ])
+        result = fetcher._format_fxtwitter(tweet, "https://x.com/i/status/1")
+        assert "First paragraph." in result["text"]
+        assert "Second paragraph." in result["text"]
+        assert result["title"] == "How I'd make $10 million with AI agents"
+
+    def test_falls_back_to_preview_text_when_no_blocks(self):
+        from bot import fetcher
+        tweet = self._article_tweet(blocks=[], preview_text="just the preview")
+        result = fetcher._format_fxtwitter(tweet, "https://x.com/i/status/1")
+        assert "just the preview" in result["text"]
+
+    def test_regular_tweet_without_article_is_unaffected(self):
+        from bot import fetcher
+        tweet = {
+            "author": {"screen_name": "someone", "name": "Someone"},
+            "text": "just a normal tweet",
+        }
+        result = fetcher._format_fxtwitter(tweet, "https://x.com/i/status/1")
+        assert "just a normal tweet" in result["text"]
+        assert result["title"] == "Post by @someone"


### PR DESCRIPTION
## Summary
- fxtwitter's API no longer puts the X Article body under `article.text` — that key doesn't exist in current responses. The body now lives in `article.content.blocks` (a Draft.js-style block list).
- We were falling back to the tweet's own `text`, which is empty for article tweets (it's just the `t.co` link), so articles came through as title + attribution only, with no actual content for the LLM to analyse.
- Added `_article_body_from_blocks` to reconstruct the body by joining block text, with a fallback to `preview_text` if blocks are ever missing.

Fixes #103

## Test plan
- [x] Verified against both URLs from the issue (Greg Isenberg's "$10 million with AI agents" article, Leon Lin's "How To Actually Design With AI" article) — both now return full body text (8,534 and 6,514 chars respectively) instead of empty bodies.
- [x] Added `TestXArticleExtraction` covering block reconstruction, fallback to `preview_text`, and that regular (non-article) tweets are unaffected.
- [x] `python3 -m pytest` — 456 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)