### PR TITLE
feat(admin): add retrigger endpoint to bypass url_cache/llm_cache

### DIFF
--- a/bot/admin.py
+++ b/bot/admin.py
@@ -1,4 +1,5 @@
-"""Admin observability endpoints — read-only aggregations over operational data.
+"""Admin observability endpoints — mostly read-only aggregations over
+operational data, plus one mutating action (retrigger).
 
 Auth is intentionally separate from the try-secret used by /api/try and /api/job:
 admin endpoints take their own `FILTER_FYI_ADMIN_SECRET` so the two can rotate
@@ -14,6 +15,12 @@ Currently exposes:
   GET /api/admin/cost-overview?days=N
     All cost/usage aggregations for the last N days (default 30, max 365),
     drawn from llm_calls. See `cost_overview()` for the response shape.
+  GET /api/admin/usage-overview?days=N&limit=&offset=
+    Activity rollup + paginated row list from processed_urls. See
+    `usage_overview()` for the response shape.
+  POST /api/admin/retrigger
+    Re-run the URL pipeline for one URL, bypassing url_cache and llm_cache.
+    See `retrigger_endpoint()`.
 """
 from __future__ import annotations
 
@@ -23,6 +30,10 @@ import secrets
 from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query
+from pydantic import BaseModel
+
+from bot.analyzer import UsageContext
+from bot.pipeline import PipelineError, analyze_url
 
 # llm_calls lives on the same Fly SQLite as everything else; bot.db's private
 # connection helper is the canonical entry point. We don't re-implement it.
@@ -528,3 +539,77 @@ async def usage_overview_endpoint(
     Whisper path. See `usage_overview()` for the full response shape.
     """
     return usage_overview(days, limit, offset)
+
+
+# ---------------------------------------------------------------------------
+# Retrigger — the one mutating admin action
+# ---------------------------------------------------------------------------
+#
+# Usage-overview rows only ever show 'ok' or 'error' based on whether the
+# pipeline raised — a fetch that "succeeds" but returns degraded content
+# (e.g. #103: X Articles coming back as title + attribution only) reads as
+# 'ok' with nothing to flag it. Once such a bug is fixed, the bad result is
+# still sitting in url_cache/llm_cache, so simply resubmitting the same URL
+# keeps serving the stale cached output until its TTL expires. Retrigger
+# forces a clean re-fetch + re-analyse past both caches for one URL, so an
+# operator can confirm a fix actually took effect on a known-bad example.
+
+
+def _is_http_url(s: str) -> bool:
+    from urllib.parse import urlparse
+    try:
+        u = urlparse(s)
+        return u.scheme in ("http", "https") and bool(u.netloc)
+    except Exception:
+        return False
+
+
+class RetriggerRequest(BaseModel):
+    url: str
+
+
+@router.post("/retrigger")
+async def retrigger_endpoint(
+    req: RetriggerRequest,
+    _: None = Depends(_require_admin_secret),
+) -> dict:
+    """Re-run the URL pipeline for `req.url`, bypassing url_cache and
+    llm_cache (both get overwritten with the fresh result on the way out, so
+    normal traffic benefits from the corrected cache entry too).
+
+    Runs unattributed to any user (anon_id="admin-retrigger", not saved to
+    any library) and still writes the usual `processed_urls` audit row, so
+    the fresh attempt shows up in the Usage pillar's row list right after
+    this call returns.
+
+    Always 200 on a completed run — a `PipelineError` (fetch failed, no
+    text, analyse crashed) is reported in the body as `status: "error"`
+    rather than raised, since "the retrigger ran and confirmed it's still
+    broken" is a valid, useful outcome for this endpoint, not a failure of
+    the endpoint itself.
+    """
+    url = (req.url or "").strip()
+    if not _is_http_url(url):
+        raise HTTPException(status_code=400, detail={"error": "invalid-url"})
+
+    ctx = UsageContext(anon_id="admin-retrigger")
+    try:
+        result = await analyze_url(url, ctx=ctx, skip_cache=True)
+    except PipelineError as e:
+        return {
+            "status": "error",
+            "url": url,
+            "error_code": e.code,
+            "message": str(e),
+            "title": e.fetched.get("title") or "",
+            "source_type": e.fetched.get("source_type") or "",
+        }
+
+    return {
+        "status": "ok",
+        "url": url,
+        "title": result.title,
+        "source_type": result.source_type,
+        "verdict": result.analysis.get("verdict"),
+        "summary_preview": result.summary[:500],
+    }

--- a/bot/analyzer.py
+++ b/bot/analyzer.py
@@ -476,7 +476,13 @@ def _record_cache_hit(*, purpose: str, ctx: UsageContext | None) -> None:
         logger.exception("record_cache_hit failed; hit not logged")
 
 
-def analyze(text: str, user_id: int | None = None, *, ctx: UsageContext | None = None) -> dict:
+def analyze(
+    text: str,
+    user_id: int | None = None,
+    *,
+    ctx: UsageContext | None = None,
+    skip_cache: bool = False,
+) -> dict:
     """Returns a dict with keys: main_idea, why_it_matters, category, quick_win, bigger_play, time_required, verdict."""
     # Back-compat: callers that still pass `user_id` positionally get it merged
     # into the context so usage rows still attribute to a user.
@@ -492,9 +498,11 @@ def analyze(text: str, user_id: int | None = None, *, ctx: UsageContext | None =
     # Content-addressed cache lookup. Key spans every input that affects the
     # output, so a prompt/model/schema change auto-invalidates. Skips the
     # upstream LLM call entirely on hit — no llm_calls row written because
-    # nothing was actually called.
+    # nothing was actually called. `skip_cache` bypasses the read (but the
+    # result below still overwrites the entry, refreshing it) — used by the
+    # admin retrigger endpoint to force a fresh read past a stale cache key.
     cache_key = _cache_key_analyze(text, profile, model, signals)
-    cached = _try_cache_get(cache_key)
+    cached = None if skip_cache else _try_cache_get(cache_key)
     if cached is not None:
         try:
             result = json.loads(cached)
@@ -629,6 +637,7 @@ def summarize_content(
     *,
     ctx: UsageContext | None = None,
     published_at: str | None = None,
+    skip_cache: bool = False,
 ) -> str:
     """Distil source content into a faithful, length-scaled structured brief.
 
@@ -643,6 +652,9 @@ def summarize_content(
     in tagged as a best-estimate fallback — still better than letting the
     model default to its training year, which is what produced the date
     hallucinations seen on non-English transcripts.
+
+    `skip_cache=True` bypasses the cache read and forces a fresh LLM call,
+    overwriting the entry — see `analyze()`'s `skip_cache` for why.
     """
     text = (text or "").strip()
     if not text:
@@ -657,7 +669,7 @@ def summarize_content(
     # NOT part of the key — a per-day fallback would otherwise blow the cache
     # daily for any source without a real publication date.
     cache_key = _cache_key_summary(text, model)
-    cached = _try_cache_get(cache_key)
+    cached = None if skip_cache else _try_cache_get(cache_key)
     if cached is not None:
         logger.info("summary cache hit (key=%s...)", cache_key[:12])
         _record_cache_hit(purpose="summary", ctx=ctx)

--- a/bot/fetcher.py
+++ b/bot/fetcher.py
@@ -890,7 +890,10 @@ def _transcribe_audio_url(url: str, max_whisper_duration: int) -> dict:
 
 
 async def fetch_url(
-    url: str, *, max_whisper_duration: int = WHISPER_MAX_DURATION_ANON_S
+    url: str,
+    *,
+    max_whisper_duration: int = WHISPER_MAX_DURATION_ANON_S,
+    skip_cache: bool = False,
 ) -> dict:
     """Public entry point. Wraps `_fetch_url_uncached` with a per-URL cache so
     repeat submissions, retries, and concurrent fetches of the same URL don't
@@ -902,10 +905,15 @@ async def fetch_url(
     transcribe, never the transcript itself, so the cache stays keyed by URL —
     except the one tier-dependent degraded outcome (`video_too_long_for_whisper`)
     which we never cache, so a stricter tier can't poison a more generous one.
+
+    `skip_cache=True` bypasses the cache read (a stale/bad entry stays stale
+    forever otherwise — e.g. a fetcher bug cached a degraded result before the
+    fix shipped) but still overwrites the entry with the fresh result, so the
+    next normal request benefits too. Used by the admin retrigger endpoint.
     """
     from bot.db import get_cached_fetch, set_cached_fetch
 
-    cached = get_cached_fetch(url)
+    cached = None if skip_cache else get_cached_fetch(url)
     if cached is not None:
         logger.info(f"url_cache hit for {url}")
         return cached

--- a/bot/pipeline.py
+++ b/bot/pipeline.py
@@ -121,6 +121,7 @@ async def analyze_url(
     max_whisper_duration: int | None = None,
     on_step: Optional[Callable[[str], None]] = None,
     capacity_timeout: float | None = None,
+    skip_cache: bool = False,
 ) -> PipelineResult:
     """Run the full URL → analysis chain.
 
@@ -146,6 +147,11 @@ async def analyze_url(
     shedding with `PipelineError(ERR_BUSY)`. None → the limiter default (short;
     synchronous web callers shed fast so they don't blow the Worker's ~25s
     budget); the polling job runner passes a larger value to queue instead.
+
+    `skip_cache=True` bypasses `url_cache` and `llm_cache` reads for this run
+    (both still get overwritten with the fresh result). For normal traffic
+    this is always False; the admin retrigger endpoint sets it to force a
+    clean re-fetch + re-analyse of a URL whose cached result is known bad.
     """
     def _step(label: str) -> None:
         if on_step is not None:
@@ -179,7 +185,9 @@ async def analyze_url(
     try:
         _step("fetching")
         try:
-            fetched = await fetch_url(url, max_whisper_duration=max_whisper_duration)
+            fetched = await fetch_url(
+                url, max_whisper_duration=max_whisper_duration, skip_cache=skip_cache
+            )
         except Exception as e:
             logger.exception("pipeline: fetch_url crashed for %s", url)
             raise PipelineError(ERR_FETCH_FAILED, message=str(e))
@@ -224,12 +232,16 @@ async def analyze_url(
         loop = asyncio.get_running_loop()
         summary = await loop.run_in_executor(
             None,
-            lambda: summarize_content(text, ctx=ctx, published_at=published_at),
+            lambda: summarize_content(
+                text, ctx=ctx, published_at=published_at, skip_cache=skip_cache
+            ),
         )
 
         _step("analyzing")
         try:
-            analysis = await loop.run_in_executor(None, lambda: analyze(summary, ctx=ctx))
+            analysis = await loop.run_in_executor(
+                None, lambda: analyze(summary, ctx=ctx, skip_cache=skip_cache)
+            )
         except Exception as e:
             logger.exception("pipeline: analyze crashed for %s", url)
             raise PipelineError(ERR_ANALYZE_FAILED, fetched=fetched, message=str(e))

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -471,3 +471,117 @@ class TestRangeFiltering:
         assert admin_client.get(
             "/api/admin/cost-overview?days=10000", headers=admin_headers
         ).status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Retrigger
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def retrigger_client(monkeypatch):
+    """Same as `admin_client`, but with the pipeline's external dependencies
+    (fetch/summarize/analyze) stubbed the way tests/conftest.py's `client`
+    fixture does for bot.api — retrigger runs the same bot.pipeline chain."""
+    monkeypatch.setenv("FILTER_FYI_ADMIN_SECRET", "test-admin-secret")
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    import bot.admin
+    import bot.pipeline
+
+    async def fake_fetch_url(url, **kwargs):
+        return {
+            "text": "Fresh full body, not just a title.",
+            "title": "A Title",
+            "source_type": "social",
+            "image_urls": [],
+        }
+
+    def fake_analyze(text, user_id=None, **_kwargs):
+        return {
+            "main_idea": "x", "why_it_matters": "y", "category": "c",
+            "suggestions": [], "time_required": "5m", "verdict": "watch",
+        }
+
+    def fake_summarize_content(text, **_kwargs):
+        return "Neutral summary of the content."
+
+    monkeypatch.setattr(bot.pipeline, "fetch_url", fake_fetch_url)
+    monkeypatch.setattr(bot.pipeline, "analyze", fake_analyze)
+    monkeypatch.setattr(bot.pipeline, "summarize_content", fake_summarize_content)
+
+    app = FastAPI()
+    app.include_router(bot.admin.router)
+    return TestClient(app)
+
+
+class TestRetrigger:
+    def test_missing_secret_rejected(self, retrigger_client):
+        r = retrigger_client.post(
+            "/api/admin/retrigger", json={"url": "https://x.com/a/status/1"}
+        )
+        assert r.status_code == 401
+
+    def test_invalid_url_rejected(self, retrigger_client, admin_headers):
+        r = retrigger_client.post(
+            "/api/admin/retrigger", json={"url": "not-a-url"}, headers=admin_headers,
+        )
+        assert r.status_code == 400
+
+    def test_success_returns_fresh_result(self, retrigger_client, admin_headers):
+        r = retrigger_client.post(
+            "/api/admin/retrigger",
+            json={"url": "https://x.com/a/status/1"},
+            headers=admin_headers,
+        )
+        assert r.status_code == 200
+        body = r.json()
+        assert body["status"] == "ok"
+        assert body["title"] == "A Title"
+        assert body["source_type"] == "social"
+        assert body["verdict"] == "watch"
+
+    def test_writes_a_fresh_processed_urls_row(self, db, retrigger_client, admin_headers):
+        retrigger_client.post(
+            "/api/admin/retrigger",
+            json={"url": "https://x.com/a/status/1"},
+            headers=admin_headers,
+        )
+        with db._get_conn() as conn:
+            rows = conn.execute(
+                "SELECT url, status, anon_id FROM processed_urls"
+            ).fetchall()
+        assert len(rows) == 1
+        assert rows[0]["url"] == "https://x.com/a/status/1"
+        assert rows[0]["status"] == "ok"
+        assert rows[0]["anon_id"] == "admin-retrigger"
+
+    def test_bypasses_url_cache(self, db, retrigger_client, admin_headers):
+        """A stale url_cache entry (the exact scenario #103's fix needs to
+        repair post-deploy) must not shadow the retriggered fetch."""
+        db.set_cached_fetch(
+            "https://x.com/a/status/1",
+            {"text": "STALE title-only stub", "title": "Stale", "source_type": "social"},
+        )
+        r = retrigger_client.post(
+            "/api/admin/retrigger",
+            json={"url": "https://x.com/a/status/1"},
+            headers=admin_headers,
+        )
+        assert r.json()["title"] == "A Title", "must fetch fresh, not the stale cache entry"
+
+    def test_pipeline_error_reported_not_raised(self, retrigger_client, admin_headers, monkeypatch):
+        import bot.pipeline
+
+        async def empty_fetch(url, **kwargs):
+            return {"text": "", "title": "", "source_type": "article"}
+        monkeypatch.setattr(bot.pipeline, "fetch_url", empty_fetch)
+
+        r = retrigger_client.post(
+            "/api/admin/retrigger",
+            json={"url": "https://example.com/empty"},
+            headers=admin_headers,
+        )
+        assert r.status_code == 200, "a still-broken URL is a valid retrigger outcome, not an HTTP error"
+        body = r.json()
+        assert body["status"] == "error"
+        assert body["error_code"] == "extraction-failed"

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -555,6 +555,27 @@ class TestUrlCacheLayer:
         assert "https://example.com/a" in r_a2["text"]
         assert "https://example.com/b" in r_b2["text"]
 
+    def test_skip_cache_bypasses_read_but_refreshes_entry(self):
+        """A stale cached fetch (e.g. from a since-fixed extraction bug) must
+        stay bypassable on demand — see issue #103's retrigger endpoint."""
+        from bot import fetcher
+
+        with patch.object(fetcher, "_fetch_url_uncached", new_callable=AsyncMock) as inner:
+            inner.side_effect = [
+                {"text": "stale body", "title": "Hi", "source_type": "article"},
+                {"text": "fresh body", "title": "Hi", "source_type": "article"},
+            ]
+
+            r1 = asyncio.run(fetcher.fetch_url("https://example.com/a"))
+            r2 = asyncio.run(fetcher.fetch_url("https://example.com/a", skip_cache=True))
+            # A subsequent normal (cached) read now sees the refreshed entry.
+            r3 = asyncio.run(fetcher.fetch_url("https://example.com/a"))
+
+        assert inner.call_count == 2, "skip_cache must hit upstream, not the stale entry"
+        assert r1["text"] == "stale body"
+        assert r2["text"] == "fresh body"
+        assert r3["text"] == "fresh body", "skip_cache run must refresh the cache entry"
+
 
 class TestRobots:
     """robots.txt is deliberately NOT consulted: a generic fetch is a single

--- a/tests/test_llm_usage.py
+++ b/tests/test_llm_usage.py
@@ -271,6 +271,65 @@ class TestResultCache:
         assert result2 == "proper summary"
 
 
+class TestSkipCache:
+    """`skip_cache=True` must force a fresh upstream call past an existing
+    cache entry, and refresh that entry — the retrigger endpoint (#103)
+    depends on this to repair a stale cached result post-fix."""
+
+    def test_analyze_skip_cache_forces_upstream_call_and_refreshes(self, db, monkeypatch):
+        from bot import analyzer
+        monkeypatch.setattr(analyzer, "_PROVIDER", "anthropic")
+        monkeypatch.setattr(analyzer, "_MODEL", "claude-haiku-4-5-20251001")
+        monkeypatch.setattr(analyzer, "_PREMIUM_MODEL", "claude-haiku-4-5-20251001")
+
+        stale = _FakeAnthropic(input_tokens=100, output_tokens=50, tool_input={
+            "main_idea": "stale", "why_it_matters": "y", "category": "c",
+            "quick_win": "qw", "bigger_play": "bp", "time_required": "5m",
+            "verdict": "watch",
+        })
+        monkeypatch.setattr(analyzer, "_get_client", lambda: stale)
+        first = analyzer.analyze("the same text", ctx=analyzer.UsageContext(user_id=1))
+        assert first["main_idea"] == "stale"
+
+        fresh = _FakeAnthropic(input_tokens=100, output_tokens=50, tool_input={
+            "main_idea": "fresh", "why_it_matters": "y", "category": "c",
+            "quick_win": "qw", "bigger_play": "bp", "time_required": "5m",
+            "verdict": "watch",
+        })
+        monkeypatch.setattr(analyzer, "_get_client", lambda: fresh)
+        second = analyzer.analyze(
+            "the same text", ctx=analyzer.UsageContext(user_id=1), skip_cache=True,
+        )
+        assert second["main_idea"] == "fresh", "skip_cache must bypass the stale entry"
+        assert len(_all_llm_calls(db)) == 2, "skip_cache must hit upstream, not the cache"
+
+        # A subsequent normal (cached) call now sees the refreshed entry.
+        third = analyzer.analyze("the same text", ctx=analyzer.UsageContext(user_id=1))
+        assert third["main_idea"] == "fresh"
+        assert len(_all_llm_calls(db)) == 2, "the refreshed entry should now be a cache hit"
+
+    def test_summarize_content_skip_cache_forces_upstream_call_and_refreshes(self, db, monkeypatch):
+        from bot import analyzer
+        monkeypatch.setattr(analyzer, "_PROVIDER", "anthropic")
+        monkeypatch.setattr(analyzer, "_MODEL", "claude-haiku-4-5-20251001")
+        monkeypatch.setattr(analyzer, "_PREMIUM_MODEL", "claude-haiku-4-5-20251001")
+
+        stale = _FakeAnthropic(input_tokens=500, output_tokens=200, text="stale summary")
+        monkeypatch.setattr(analyzer, "_get_client", lambda: stale)
+        first = analyzer.summarize_content("the source text")
+        assert first == "stale summary"
+
+        fresh = _FakeAnthropic(input_tokens=500, output_tokens=200, text="fresh summary")
+        monkeypatch.setattr(analyzer, "_get_client", lambda: fresh)
+        second = analyzer.summarize_content("the source text", skip_cache=True)
+        assert second == "fresh summary"
+        assert len(_all_llm_calls(db)) == 2
+
+        third = analyzer.summarize_content("the source text")
+        assert third == "fresh summary"
+        assert len(_all_llm_calls(db)) == 2
+
+
 class TestImageCache:
     """analyze_image must cache too — its non-determinism is what breaks the
     *analyze* cache on the Telegram URL path, which appends image


### PR DESCRIPTION
## Summary
- The Usage pillar can't distinguish "fetch succeeded" from "fetch succeeded but returned degraded content" — both read as `status: 'ok'` (surfaced by #103: X Articles were silently truncated to title + attribution).
- Once a fetcher bug like that is fixed, the bad result is still sitting in `url_cache`/`llm_cache`, so resubmitting the same URL keeps serving the stale cached output until its TTL expires.
- Adds `skip_cache` to `fetch_url`, `analyze`, `summarize_content`, and `analyze_url` (threading it through the pipeline), plus `POST /api/admin/retrigger`, which re-runs the pipeline for one URL past both caches — overwriting the stale entries with the fresh result so normal traffic benefits too.
- Runs unattributed (`anon_id="admin-retrigger"`, not saved to any library) and always returns 200 — a `PipelineError` is reported as `status: "error"` in the body rather than raised, since "still broken" is a valid, useful retrigger outcome, not a failure of the endpoint itself.

Split out from #104 for clean separation — this is a general admin capability, independent of the X-article fetch fix that motivated it.

## Test plan
- [x] New `TestSkipCache` in `tests/test_llm_usage.py` — `analyze`/`summarize_content` bypass a stale cache entry with `skip_cache=True` and refresh it.
- [x] New `test_skip_cache_bypasses_read_but_refreshes_entry` in `tests/test_fetcher.py`.
- [x] New `TestRetrigger` in `tests/test_admin.py` — auth, invalid URL, success shape, writes a fresh `processed_urls` row, bypasses a stale `url_cache` entry, reports (not raises) a `PipelineError`.
- [x] `python3 -m pytest` — 462 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)