### PR TITLE
fix(admin): attribute retrigger to the original submitter, not admin

### DIFF
--- a/bot/admin.py
+++ b/bot/admin.py
@@ -32,7 +32,7 @@ from datetime import datetime, timedelta, timezone
 from fastapi import APIRouter, Depends, Header, HTTPException, Query
 from pydantic import BaseModel
 
-from bot.analyzer import UsageContext
+from bot.analyzer import UsageContext, to_json_str
 from bot.pipeline import PipelineError, analyze_url
 
 # llm_calls lives on the same Fly SQLite as everything else; bot.db's private
@@ -566,6 +566,13 @@ def _is_http_url(s: str) -> bool:
 
 class RetriggerRequest(BaseModel):
     url: str
+    # Who originally submitted this URL — the Usage row the admin is acting
+    # on already carries these (see `usage_overview`'s `rows`), so the caller
+    # (the admin dashboard) passes them straight through rather than us
+    # re-deriving "most recent processed_urls row for this URL", which could
+    # pick the wrong submitter if several people hit the same URL.
+    user_id: int | None = None
+    anon_id: str | None = None
 
 
 @router.post("/retrigger")
@@ -577,10 +584,24 @@ async def retrigger_endpoint(
     llm_cache (both get overwritten with the fresh result on the way out, so
     normal traffic benefits from the corrected cache entry too).
 
-    Runs unattributed to any user (anon_id="admin-retrigger", not saved to
-    any library) and still writes the usual `processed_urls` audit row, so
-    the fresh attempt shows up in the Usage pillar's row list right after
-    this call returns.
+    Attribution follows the original submitter, not the admin:
+      - `user_id` set: the analysis runs under that user's profile/model tier
+        (`UsageContext(user_id=...)`), and their existing library item for
+        this URL is updated in place via `upsert_item_by_source` — so a
+        signed-in user whose saved item was corrupted by a since-fixed bug
+        sees the corrected version without a duplicate entry or the fix
+        landing on some anonymous admin identity instead.
+      - `user_id` absent but `anon_id` present: usage/cost rows attribute to
+        that anon_id, but there's nothing to update in place — anonymous
+        results live in the Worker's D1 store, not this backend, so we can't
+        reach in and refresh what they see. `item_updated` is False.
+      - Neither set (e.g. a very old audit row, or an ad-hoc URL an operator
+        is just spot-checking): falls back to the synthetic
+        anon_id="admin-retrigger" used before this endpoint knew about
+        submitters.
+
+    Still writes the usual `processed_urls` audit row, so the fresh attempt
+    shows up in the Usage pillar's row list right after this call returns.
 
     Always 200 on a completed run — a `PipelineError` (fetch failed, no
     text, analyse crashed) is reported in the body as `status: "error"`
@@ -592,7 +613,13 @@ async def retrigger_endpoint(
     if not _is_http_url(url):
         raise HTTPException(status_code=400, detail={"error": "invalid-url"})
 
-    ctx = UsageContext(anon_id="admin-retrigger")
+    if req.user_id is not None:
+        ctx = UsageContext(user_id=req.user_id)
+    elif req.anon_id:
+        ctx = UsageContext(anon_id=req.anon_id)
+    else:
+        ctx = UsageContext(anon_id="admin-retrigger")
+
     try:
         result = await analyze_url(url, ctx=ctx, skip_cache=True)
     except PipelineError as e:
@@ -605,6 +632,17 @@ async def retrigger_endpoint(
             "source_type": e.fetched.get("source_type") or "",
         }
 
+    item_id: int | None = None
+    if req.user_id is not None:
+        from bot.db import upsert_item_by_source
+        item_id = upsert_item_by_source(
+            user_id=req.user_id,
+            source_type=result.source_type,
+            source=url,
+            content=result.summary,
+            analysis=to_json_str(result.analysis),
+        )
+
     return {
         "status": "ok",
         "url": url,
@@ -612,4 +650,6 @@ async def retrigger_endpoint(
         "source_type": result.source_type,
         "verdict": result.analysis.get("verdict"),
         "summary_preview": result.summary[:500],
+        "item_updated": item_id is not None,
+        "item_id": item_id,
     }

--- a/bot/db.py
+++ b/bot/db.py
@@ -693,6 +693,38 @@ def save_item(
         return cur.lastrowid
 
 
+def upsert_item_by_source(
+    user_id: int, source_type: str, source: str, content: str, analysis: str,
+) -> int:
+    """Refresh a user's existing saved item for `source` in place, or create
+    one if they don't have one yet. Unlike `save_item` (always inserts, so
+    resubmitting a URL piles up duplicate library entries), this updates the
+    most recent matching row — `user_note` and `created_at` are left alone.
+
+    Used by the admin retrigger endpoint: when a fetcher bug is fixed and an
+    operator reruns a URL past the cache, the user who originally saved it
+    should see the corrected version in place, not a stale copy plus a new
+    duplicate.
+    """
+    with _get_conn() as conn:
+        row = conn.execute(
+            "SELECT id FROM items WHERE user_id = ? AND source = ? ORDER BY id DESC LIMIT 1",
+            (user_id, source),
+        ).fetchone()
+        if row is not None:
+            conn.execute(
+                "UPDATE items SET source_type = ?, content = ?, analysis = ? WHERE id = ?",
+                (source_type, content, analysis, row["id"]),
+            )
+            return row["id"]
+        cur = conn.execute(
+            "INSERT INTO items (user_id, source_type, source, content, analysis) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (user_id, source_type, source, content, analysis),
+        )
+        return cur.lastrowid
+
+
 _ITEM_COLS = (
     "id, user_id, source_type, source, content, analysis, user_note, file_path, created_at"
 )

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -585,3 +585,96 @@ class TestRetrigger:
         body = r.json()
         assert body["status"] == "error"
         assert body["error_code"] == "extraction-failed"
+
+    def test_user_id_attributes_to_the_original_submitter_not_admin(
+        self, db, retrigger_client, admin_headers,
+    ):
+        """The whole point: a signed-in user's retrigger must NOT land under
+        the synthetic admin-retrigger identity — it must run (and be billed/
+        attributed) as that user."""
+        uid = db.get_or_create_user_by_telegram(1)
+        retrigger_client.post(
+            "/api/admin/retrigger",
+            json={"url": "https://x.com/a/status/1", "user_id": uid},
+            headers=admin_headers,
+        )
+        with db._get_conn() as conn:
+            row = conn.execute(
+                "SELECT user_id, anon_id FROM processed_urls"
+            ).fetchone()
+        assert row["user_id"] == uid
+        assert row["anon_id"] is None
+
+    def test_user_id_creates_item_when_none_exists(self, db, retrigger_client, admin_headers):
+        uid = db.get_or_create_user_by_telegram(2)
+        r = retrigger_client.post(
+            "/api/admin/retrigger",
+            json={"url": "https://x.com/a/status/1", "user_id": uid},
+            headers=admin_headers,
+        )
+        body = r.json()
+        assert body["item_updated"] is True
+        assert body["item_id"] is not None
+        item = db.get_item(body["item_id"], user_id=uid)
+        assert item is not None
+        assert item["source"] == "https://x.com/a/status/1"
+        assert item["source_type"] == "social"
+
+    def test_user_id_updates_existing_item_in_place_not_a_duplicate(
+        self, db, retrigger_client, admin_headers,
+    ):
+        """The scenario that motivated this: a user's saved item was corrupted
+        by a since-fixed fetcher bug (#103). Retrigger must refresh that same
+        item, not leave the stale one sitting alongside a new duplicate."""
+        uid = db.get_or_create_user_by_telegram(3)
+        stale_id = db.save_item(
+            uid, "social", "https://x.com/a/status/1",
+            "STALE title-only content", '{"main_idea": "stale"}', "my note",
+        )
+        r = retrigger_client.post(
+            "/api/admin/retrigger",
+            json={"url": "https://x.com/a/status/1", "user_id": uid},
+            headers=admin_headers,
+        )
+        body = r.json()
+        assert body["item_id"] == stale_id, "must update the existing item, not create a new one"
+        assert len(db.get_all_items(user_id=uid)) == 1, "no duplicate left behind"
+        refreshed = db.get_item(stale_id, user_id=uid)
+        assert refreshed["content"] == "Neutral summary of the content."
+        assert refreshed["content"] != "STALE title-only content"
+        assert refreshed["user_note"] == "my note", "unrelated fields must survive the refresh"
+
+    def test_anon_id_attributes_but_does_not_persist_an_item(
+        self, db, retrigger_client, admin_headers,
+    ):
+        """Anonymous results live in the Worker's D1 store, not this backend
+        — there's nothing here to update in place, so item_updated must be
+        False even though the retrigger itself succeeds."""
+        r = retrigger_client.post(
+            "/api/admin/retrigger",
+            json={"url": "https://x.com/a/status/1", "anon_id": "visitor-abc"},
+            headers=admin_headers,
+        )
+        body = r.json()
+        assert body["status"] == "ok"
+        assert body["item_updated"] is False
+        assert body["item_id"] is None
+        with db._get_conn() as conn:
+            row = conn.execute(
+                "SELECT user_id, anon_id FROM processed_urls"
+            ).fetchone()
+        assert row["anon_id"] == "visitor-abc"
+        assert row["user_id"] is None
+
+    def test_no_submitter_falls_back_to_admin_retrigger_identity(
+        self, db, retrigger_client, admin_headers,
+    ):
+        """Ad-hoc spot-checks (no known submitter) keep the old behaviour."""
+        retrigger_client.post(
+            "/api/admin/retrigger",
+            json={"url": "https://x.com/a/status/1"},
+            headers=admin_headers,
+        )
+        with db._get_conn() as conn:
+            row = conn.execute("SELECT anon_id FROM processed_urls").fetchone()
+        assert row["anon_id"] == "admin-retrigger"

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -173,6 +173,50 @@ class TestUserHelpers:
 
 
 # ---------------------------------------------------------------------------
+# upsert_item_by_source — refresh-in-place for the admin retrigger endpoint
+# ---------------------------------------------------------------------------
+
+class TestUpsertItemBySource:
+    def test_creates_when_no_existing_item(self, db):
+        uid = db.get_or_create_user_by_telegram(1)
+        item_id = db.upsert_item_by_source(
+            uid, "article", "https://ex.com/a", "content", '{"main_idea": "x"}',
+        )
+        item = db.get_item(item_id, user_id=uid)
+        assert item["source"] == "https://ex.com/a"
+        assert item["content"] == "content"
+
+    def test_updates_the_most_recent_match_in_place(self, db):
+        uid = db.get_or_create_user_by_telegram(1)
+        first_id = db.save_item(
+            uid, "article", "https://ex.com/a", "stale content", '{"main_idea": "stale"}', "a note",
+        )
+        returned_id = db.upsert_item_by_source(
+            uid, "article", "https://ex.com/a", "fresh content", '{"main_idea": "fresh"}',
+        )
+        assert returned_id == first_id
+        assert len(db.get_all_items(user_id=uid)) == 1
+        item = db.get_item(first_id, user_id=uid)
+        assert item["content"] == "fresh content"
+        assert item["analysis"] == '{"main_idea": "fresh"}'
+        assert item["user_note"] == "a note", "unrelated fields untouched"
+
+    def test_scoped_to_user_and_source(self, db):
+        u1 = db.get_or_create_user_by_telegram(1)
+        u2 = db.get_or_create_user_by_telegram(2)
+        db.save_item(u1, "article", "https://ex.com/a", "u1 content", "{}")
+        # Different user, same URL: must not touch u1's item.
+        db.upsert_item_by_source(u2, "article", "https://ex.com/a", "u2 content", "{}")
+        # Same user, different URL: must not touch the /a item.
+        db.upsert_item_by_source(u1, "article", "https://ex.com/b", "u1 other content", "{}")
+
+        assert len(db.get_all_items(user_id=u1)) == 2
+        assert len(db.get_all_items(user_id=u2)) == 1
+        u1_a = next(i for i in db.get_all_items(user_id=u1) if i["source"] == "https://ex.com/a")
+        assert u1_a["content"] == "u1 content"
+
+
+# ---------------------------------------------------------------------------
 # Link codes
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- `POST /api/admin/retrigger` always ran under a synthetic `anon_id="admin-retrigger"` identity, unattributed to whoever actually submitted the URL — for a signed-in user this meant confirming a fetcher fix worked, but never touching *their* saved item, so they'd keep seeing the stale, broken version in their library.
- `RetriggerRequest` now accepts optional `user_id`/`anon_id`. The admin Usage row being acted on already carries these (see `usage_overview`'s `rows`), so the caller forwards them rather than the endpoint re-deriving "most recent `processed_urls` row for this URL" — which could pick the wrong submitter if multiple people hit the same URL.
- `user_id` present: the analysis runs under that user's profile/model tier (`UsageContext(user_id=...)`), and their existing library item for the URL is refreshed **in place** via the new `db.upsert_item_by_source` (update, not insert — resubmitting doesn't pile up duplicate library entries; `user_note`/`created_at` are left alone).
- `anon_id` only: usage/cost rows attribute correctly, but there's nothing to update — anonymous results live in the Worker's D1 store, not this backend. Response reports `item_updated: false`.
- Neither set: falls back to the old `admin-retrigger` identity (ad-hoc spot-checks).

## Test plan
- [x] New `TestUpsertItemBySource` in `tests/test_db.py` — create-when-missing, update-in-place (no duplicate, unrelated fields untouched), scoped correctly to (user, source).
- [x] New tests in `tests/test_admin.py::TestRetrigger` — `user_id` attributes correctly (not `admin-retrigger`) and upserts an item; existing item is updated in place, not duplicated; `anon_id`-only attributes but doesn't persist; no-submitter fallback still works.
- [x] `python3 -m pytest` — 473 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)